### PR TITLE
Add projects to group

### DIFF
--- a/groups.go
+++ b/groups.go
@@ -33,10 +33,11 @@ type GroupsService struct {
 //
 // GitLab API docs: http://doc.gitlab.com/ce/api/groups.html
 type Group struct {
-	ID          int    `json:"id"`
-	Name        string `json:"name"`
-	Path        string `json:"path"`
-	Description string `json:"description"`
+	ID          int        `json:"id"`
+	Name        string     `json:"name"`
+	Path        string     `json:"path"`
+	Description string     `json:"description"`
+	Projects    *[]Project `json:"projects,omitempty"`
 }
 
 // ListGroups gets a list of groups. (As user: my groups, as admin: all groups)


### PR DESCRIPTION
This will add the ability to fetch projects for when calling ``GetGroup`` (projects will be returned in an array if there's any projects assigned to the group)