### PR TITLE
Don't add the host into the url opaque param

### DIFF
--- a/gitlab.go
+++ b/gitlab.go
@@ -172,7 +172,7 @@ func (c *Client) SetBaseURL(urlStr string) error {
 	}
 
 	// Set the encoded opaque data
-	c.baseURL.Opaque = fmt.Sprintf("//%s%s", c.baseURL.Host, c.baseURL.Path)
+	c.baseURL.Opaque = c.baseURL.Path
 
 	return nil
 }


### PR DESCRIPTION
Adding the host into the URL.Opaque parameter creates an absolute
uri request like:

    GET https://gitlab.com/api/v3/... HTTP/1.1

instead of:

    GET /api/v3/... HTTP/1.1

Apache seems to have a problem with absolute uri requests when used
as a reversed proxy, double encoding %2F to %252F before passing the
request to GitLab, which breaks GitLab's api that accepts NAMESPACE/PROJECT.

The proxy config used is:

    ProxyPass / http://127.0.0.1:8080/ nocanon

'nocanon' parameter is the one that prevents double encoding, but it
seems to work only for relative uri requests.

An alternative is to use the mod_rewrite module directly instead of
the ProxyPass directive as:

    RewriteEngine On
    RewriteRule ^(.*) http://127.0.0.1:8080$1 [NE,P]

with the 'NE' flag (no escape) which works fine with absolute uri
requests. There are performance issues with this method as explained
here http://httpd.apache.org/docs/current/rewrite/flags.html#flag_p