### PR TITLE
Fix documentation about ListProjectIssues method

### DIFF
--- a/issues.go
+++ b/issues.go
@@ -117,10 +117,10 @@ type ListProjectIssuesOptions struct {
 	Sort      string   `url:"sort,omitempty"`
 }
 
-// ListProjectIssues gets all issues created by authenticated user. This function
-// takes pagination parameters page and per_page to restrict the list of issues.
+// ListProjectIssues gets a list of project issues. This function accepts
+// pagination parameters page and per_page to return the list of project issues.
 //
-// GitLab API docs: http://doc.gitlab.com/ce/api/issues.html#list-issues
+// GitLab API docs: http://doc.gitlab.com/ce/api/issues.html#list-project-issues
 func (s *IssuesService) ListProjectIssues(
 	pid interface{},
 	opt *ListProjectIssuesOptions) ([]*Issue, *Response, error) {


### PR DESCRIPTION
Current master has wrong docs(ListIssues instead of ListProjectIssues)