### PR TITLE
Embed ListOptions in for issues && merge_requests

### DIFF
--- a/issues.go
+++ b/issues.go
@@ -80,6 +80,7 @@ func (i Issue) String() string {
 //
 // GitLab API docs: http://doc.gitlab.com/ce/api/issues.html#list-issues
 type ListIssuesOptions struct {
+	ListOptions
 	State   string   `url:"state,omitempty"`
 	Labels  []string `url:"labels,omitempty"`
 	OrderBy string   `url:"order_by,omitempty"`
@@ -109,6 +110,7 @@ func (s *IssuesService) ListIssues(opt *ListIssuesOptions) ([]*Issue, *Response,
 //
 // GitLab API docs: http://doc.gitlab.com/ce/api/issues.html#list-issues
 type ListProjectIssuesOptions struct {
+	ListOptions
 	IID       int      `url:"iid,omitempty"`
 	State     string   `url:"state,omitempty"`
 	Labels    []string `url:"labels,omitempty"`

--- a/merge_requests.go
+++ b/merge_requests.go
@@ -97,6 +97,7 @@ func (m MergeRequest) String() string {
 // GitLab API docs:
 // http://doc.gitlab.com/ce/api/merge_requests.html#list-merge-requests
 type ListMergeRequestsOptions struct {
+	ListOptions
 	IID     int    `url:"iid,omitempty"`
 	State   string `url:"state,omitempty"`
 	OrderBy string `url:"order_by,omitempty"`


### PR DESCRIPTION
This enables setting page/per_page options in ListIssuesOptions &&
ListProjectIssueOptions && ListMergeRequestOptions.

Paginating options can be set now.
eg)
```go
Client.Issues.ListProjectIssues(glProj.ID,                                                                                      
                 &gitlab.ListProjectIssuesOptions{                                                                                                           
                         ListOptions: gitlab.ListOptions{Page: 3, PerPage: 30},                                                                              
                         State:       "all",                                                                                                                 
                         OrderBy:     "created_at",                                                                                                          
                         Sort:        "desc",                                                                                                                
                 })
```