### PR TITLE
Support for user identities & fix for block/unblock

### DIFF
--- a/users.go
+++ b/users.go
@@ -18,6 +18,7 @@ package gitlab
 
 import (
 	"fmt"
+	"io/ioutil"
 	"time"
 )
 
@@ -396,39 +397,37 @@ func (s *UsersService) DeleteSSHKeyForUser(user int, kid int) (*Response, error)
 // BlockUser blocks the specified user. Available only for admin.
 //
 // GitLab API docs: http://doc.gitlab.com/ce/api/users.html#block-user
-func (s *UsersService) BlockUser(user int) (*User, *Response, error) {
+func (s *UsersService) BlockUser(user int) (*Response, error) {
 	u := fmt.Sprintf("users/%d/block", user)
 
 	req, err := s.client.NewRequest("PUT", u, nil)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	usr := new(User)
-	resp, err := s.client.Do(req, usr)
+	resp, err := s.client.Do(req, ioutil.Discard)
 	if err != nil {
-		return nil, resp, err
+		return resp, err
 	}
 
-	return usr, resp, err
+	return resp, err
 }
 
 // UnblockUser unblocks the specified user. Available only for admin.
 //
 // GitLab API docs: http://doc.gitlab.com/ce/api/users.html#unblock-user
-func (s *UsersService) UnblockUser(user int) (*User, *Response, error) {
+func (s *UsersService) UnblockUser(user int) (*Response, error) {
 	u := fmt.Sprintf("users/%d/unblock", user)
 
 	req, err := s.client.NewRequest("PUT", u, nil)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	usr := new(User)
-	resp, err := s.client.Do(req, usr)
+	resp, err := s.client.Do(req, ioutil.Discard)
 	if err != nil {
-		return nil, resp, err
+		return resp, err
 	}
 
-	return usr, resp, err
+	return resp, err
 }

--- a/users.go
+++ b/users.go
@@ -18,7 +18,6 @@ package gitlab
 
 import (
 	"fmt"
-	"io/ioutil"
 	"time"
 )
 
@@ -405,7 +404,7 @@ func (s *UsersService) BlockUser(user int) (*Response, error) {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(req, ioutil.Discard)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}
@@ -424,7 +423,7 @@ func (s *UsersService) UnblockUser(user int) (*Response, error) {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(req, ioutil.Discard)
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}

--- a/users.go
+++ b/users.go
@@ -33,28 +33,34 @@ type UsersService struct {
 //
 // GitLab API docs: http://doc.gitlab.com/ce/api/users.html
 type User struct {
-	ID               int        `json:"id"`
-	Username         string     `json:"username"`
-	Email            string     `json:"email"`
-	Name             string     `json:"name"`
-	State            string     `json:"state"`
-	CreatedAt        time.Time  `json:"created_at"`
-	Bio              string     `json:"bio"`
-	Skype            string     `json:"skype"`
-	Linkedin         string     `json:"linkedin"`
-	Twitter          string     `json:"twitter"`
-	WebsiteURL       string     `json:"website_url"`
-	ExternUID        string     `json:"extern_uid"`
-	Provider         string     `json:"provider"`
-	ThemeID          int        `json:"theme_id"`
-	ColorSchemeID    int        `json:"color_scheme_id"`
-	IsAdmin          bool       `json:"is_admin"`
-	AvatarURL        string     `json:"avatar_url"`
-	CanCreateGroup   bool       `json:"can_create_group"`
-	CanCreateProject bool       `json:"can_create_project"`
-	ProjectsLimit    int        `json:"projects_limit"`
-	CurrentSignInAt  *time.Time `json:"current_sign_in_at"`
-	TwoFactorEnabled bool       `json:"two_factor_enabled"`
+	ID               int             `json:"id"`
+	Username         string          `json:"username"`
+	Email            string          `json:"email"`
+	Name             string          `json:"name"`
+	State            string          `json:"state"`
+	CreatedAt        time.Time       `json:"created_at"`
+	Bio              string          `json:"bio"`
+	Skype            string          `json:"skype"`
+	Linkedin         string          `json:"linkedin"`
+	Twitter          string          `json:"twitter"`
+	WebsiteURL       string          `json:"website_url"`
+	ExternUID        string          `json:"extern_uid"`
+	Provider         string          `json:"provider"`
+	ThemeID          int             `json:"theme_id"`
+	ColorSchemeID    int             `json:"color_scheme_id"`
+	IsAdmin          bool            `json:"is_admin"`
+	AvatarURL        string          `json:"avatar_url"`
+	CanCreateGroup   bool            `json:"can_create_group"`
+	CanCreateProject bool            `json:"can_create_project"`
+	ProjectsLimit    int             `json:"projects_limit"`
+	CurrentSignInAt  *time.Time      `json:"current_sign_in_at"`
+	TwoFactorEnabled bool            `json:"two_factor_enabled"`
+	Identities       []*UserIdentity `json:"identities"`
+}
+
+type UserIdentity struct {
+	Provider  string `json:"provider"`
+	ExternUID string `json:"extern_uid"`
 }
 
 // ListUsersOptions represents the available ListUsers() options.


### PR DESCRIPTION
User identities were added in V8.3 although the API docs does not reflect this yet (tested on V8.4.4 with ldap users).

Fix for block/unblock user - the response does not contain User object, so the unmarshaling fails. The API docs does not define the response body, V8.4.4 seems to return simple boolean.