### PR TITLE
Fixes an internal server error when no label available

### DIFF
--- a/issues.go
+++ b/issues.go
@@ -194,7 +194,9 @@ func (s *IssuesService) CreateIssue(
 	u := fmt.Sprintf("projects/%s/issues", url.QueryEscape(project))
 
 	// This is needed to get a single, comma separated string
-	opt.Labels = []string{strings.Join(opt.Labels, ",")}
+	if len(opt.Labels) > 0 {
+		opt.Labels = []string{strings.Join(opt.Labels, ",")}
+	}
 
 	req, err := s.client.NewRequest("POST", u, opt)
 	if err != nil {


### PR DESCRIPTION
Error occurs when trying to create an issue with no labels at all. In
this case, the POST body parameter will be `"labels":[""]` instead of
the expected `"labels":[]"`.