### PR TITLE
Fall back to passing raw query arguments with the request.

### DIFF
--- a/gitlab.go
+++ b/gitlab.go
@@ -17,7 +17,6 @@
 package gitlab
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -214,19 +213,6 @@ func (c *Client) NewRequest(method, path string, opt interface{}) (*http.Request
 		ProtoMinor: 1,
 		Header:     make(http.Header),
 		Host:       u.Host,
-	}
-
-	if method == "POST" || method == "PUT" {
-		bodyBytes, err := json.Marshal(opt)
-		if err != nil {
-			return nil, err
-		}
-		bodyReader := bytes.NewReader(bodyBytes)
-
-		u.RawQuery = ""
-		req.Body = ioutil.NopCloser(bodyReader)
-		req.ContentLength = int64(bodyReader.Len())
-		req.Header.Set("Content-Type", "application/json")
 	}
 
 	req.Header.Set("Accept", "application/json")


### PR DESCRIPTION
A bug was introduced by commmit 0e4fc277 in `gitlab.go`. Before that, request parameters were supplied as raw query arguments with `query.Values()`, like
```
description=This+is+a+body.&labels=aaa&title=My+issue
```
  
for all request methods (even POST/PUT), the same as documented in GitLab's official API doc.

But as of commit 0e4fc277 (2015-12-02), those arguments are now passed in the request body instead, which is fine but introduces a bug since labels are now sent as a `list` `{"labels":["aaa,bbb"]}` where GitLab still expects a comma-separated label names as a `string` parameter.

This produces an internal server error:
```
$ curl -XPOST https://server/api/v3/projects/:id/issues \
  -H "Private-Token: token" -H "Content-Type: application/json" \
  -d '{"title":"My issue","description":"This is a body.","labels":["aaa"]}'
```

The correct request should be instead:
```
  -d '{"title":"My issue","description":"This is a body.","labels":"aaa"}' 
```

So this block of code will marshal all options, rendering slices as JSON lists where GitLab expects a string of comma-separated values:
```
if method == "POST" || method == "PUT" {
...
}
```

Commenting this block of code makes everything work fine again, so I think this is safer to revert that change an continue passing raw query arguments, don't you think?