### PR TITLE
Use pointers in the *Options structs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A GitLab API client enabling Go programs to interact with GitLab in a simple and uniform way
 
-**Documentation:** [![GoDoc](https://godoc.org/github.com/xanzy/go-gitlab?status.svg)](https://godoc.org/github.com/xanzy/go-gitlab)  
+**Documentation:** [![GoDoc](https://godoc.org/github.com/xanzy/go-gitlab?status.svg)](https://godoc.org/github.com/xanzy/go-gitlab)
 **Build Status:** [![Build Status](https://travis-ci.org/xanzy/go-gitlab.svg?branch=master)](https://travis-ci.org/xanzy/go-gitlab)
 
 ## Coverage
@@ -51,7 +51,7 @@ to list all projects for user "svanharmelen":
 
 ```go
 git := gitlab.NewClient(nil)
-opt := &ListProjectsOptions{Search: "svanharmelen"})
+opt := &ListProjectsOptions{Search: gitlab.String("svanharmelen")})
 projects, _, err := git.Projects.ListProjects(opt)
 ```
 
@@ -74,11 +74,11 @@ func main() {
 
 	// Create new project
 	p := &gitlab.CreateProjectOptions{
-		Name:                 "My Project",
-		Description:          "Just a test project to play with",
-		MergeRequestsEnabled: true,
-		SnippetsEnabled:      true,
-		VisibilityLevel:      gitlab.PublicVisibility,
+		Name:                 gitlab.String("My Project"),
+		Description:          gitlab.String("Just a test project to play with"),
+		MergeRequestsEnabled: gitlab.Bool(true),
+		SnippetsEnabled:      gitlab.Bool(true),
+		VisibilityLevel:      gitlab.VisibilityLevelPtr(gitlab.PublicVisibility),
 	}
 	project, _, err := git.Projects.CreateProject(p)
 	if err != nil {
@@ -87,10 +87,10 @@ func main() {
 
 	// Add a new snippet
 	s := &gitlab.CreateSnippetOptions{
-		Title:           "Dummy Snippet",
-		FileName:        "snippet.go",
-		Code:            "package main....",
-		VisibilityLevel: gitlab.PublicVisibility,
+		Title:           gitlab.String("Dummy Snippet"),
+		FileName:        gitlab.String("snippet.go"),
+		Code:            gitlab.String("package main...."),
+		VisibilityLevel: gitlab.VisibilityLevelPtr(gitlab.PublicVisibility),
 	}
 	_, _, err = git.ProjectSnippets.CreateSnippet(project.ID, s)
 	if err != nil {

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ func main() {
 		Description:          gitlab.String("Just a test project to play with"),
 		MergeRequestsEnabled: gitlab.Bool(true),
 		SnippetsEnabled:      gitlab.Bool(true),
-		VisibilityLevel:      gitlab.VisibilityLevelPtr(gitlab.PublicVisibility),
+		VisibilityLevel:      gitlab.VisibilityLevel(gitlab.PublicVisibility),
 	}
 	project, _, err := git.Projects.CreateProject(p)
 	if err != nil {
@@ -90,7 +90,7 @@ func main() {
 		Title:           gitlab.String("Dummy Snippet"),
 		FileName:        gitlab.String("snippet.go"),
 		Code:            gitlab.String("package main...."),
-		VisibilityLevel: gitlab.VisibilityLevelPtr(gitlab.PublicVisibility),
+		VisibilityLevel: gitlab.VisibilityLevel(gitlab.PublicVisibility),
 	}
 	_, _, err = git.ProjectSnippets.CreateSnippet(project.ID, s)
 	if err != nil {

--- a/branches.go
+++ b/branches.go
@@ -154,8 +154,8 @@ func (s *BranchesService) UnprotectBranch(
 // GitLab API docs:
 // http://doc.gitlab.com/ce/api/branches.html#create-repository-branch
 type CreateBranchOptions struct {
-	BranchName string `url:"branch_name,omitempty" json:"branch_name,omitempty"`
-	Ref        string `url:"ref,omitempty" json:"ref,omitempty"`
+	BranchName *string `url:"branch_name,omitempty" json:"branch_name,omitempty"`
+	Ref        *string `url:"ref,omitempty" json:"ref,omitempty"`
 }
 
 // CreateBranch creates branch from commit SHA or existing branch.

--- a/commits.go
+++ b/commits.go
@@ -55,7 +55,7 @@ func (c Commit) String() string {
 // GitLab API docs: http://doc.gitlab.com/ce/api/commits.html#list-commits
 type ListCommitsOptions struct {
 	ListOptions
-	RefName string `url:"ref_name,omitempty" json:"ref_name,omitempty"`
+	RefName *string `url:"ref_name,omitempty" json:"ref_name,omitempty"`
 }
 
 // ListCommits gets a list of repository commits in a project.
@@ -215,10 +215,10 @@ func (s *CommitsService) GetCommitComments(
 // GitLab API docs:
 // http://doc.gitlab.com/ce/api/commits.html#post-comment-to-commit
 type PostCommitCommentOptions struct {
-	Note     string `url:"note,omitempty" json:"note,omitempty"`
-	Path     string `url:"path" json:"path"`
-	Line     int    `url:"line" json:"line"`
-	LineType string `url:"line_type" json:"line_type"`
+	Note     *string `url:"note,omitempty" json:"note,omitempty"`
+	Path     *string `url:"path" json:"path"`
+	Line     *int    `url:"line" json:"line"`
+	LineType *string `url:"line_type" json:"line_type"`
 }
 
 // PostCommitComment adds a comment to a commit. Optionally you can post
@@ -255,10 +255,10 @@ func (s *CommitsService) PostCommitComment(
 //
 // GitLab API docs: http://doc.gitlab.com/ce/api/commits.html#get-the-status-of-a-commit
 type GetCommitStatusesOptions struct {
-	Ref   string `url:"ref,omitempty" json:"ref,omitempty"`
-	Stage string `url:"stage,omitempty" json:"stage,omitempty"`
-	Name  string `url:"name,omitempty" json:"name,omitempty"`
-	All   bool   `url:"all,omitempty" json:"all,omitempty"`
+	Ref   *string `url:"ref,omitempty" json:"ref,omitempty"`
+	Stage *string `url:"stage,omitempty" json:"stage,omitempty"`
+	Name  *string `url:"name,omitempty" json:"name,omitempty"`
+	All   *bool   `url:"all,omitempty" json:"all,omitempty"`
 }
 
 // CommitStatus represents a GitLab commit status.
@@ -310,11 +310,11 @@ func (s *CommitsService) GetCommitStatuses(
 // GitLab API docs: http://doc.gitlab.com/ce/api/commits.html#post-the-status-to-commit
 type SetCommitStatusOptions struct {
 	State       BuildState `url:"state" json:"state"`
-	Ref         string     `url:"ref,omitempty" json:"ref,omitempty"`
-	Name        string     `url:"name,omitempty" json:"name,omitempty"`
-	Context     string     `url:"context,omitempty" json:"context,omitempty"`
-	TargetUrl   string     `url:"target_url,omitempty" json:"target_url,omitempty"`
-	Description string     `url:"description,omitempty" json:"description,omitempty"`
+	Ref         *string     `url:"ref,omitempty" json:"ref,omitempty"`
+	Name        *string     `url:"name,omitempty" json:"name,omitempty"`
+	Context     *string     `url:"context,omitempty" json:"context,omitempty"`
+	TargetUrl   *string     `url:"target_url,omitempty" json:"target_url,omitempty"`
+	Description *string     `url:"description,omitempty" json:"description,omitempty"`
 }
 
 type BuildState string

--- a/commits_test.go
+++ b/commits_test.go
@@ -14,15 +14,15 @@ func TestGetCommitStatuses(t *testing.T) {
 	mux.HandleFunc("/projects/1/repository/commits/b0b3a907f41409829b307a28b82fdbd552ee5a27/statuses", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testFormValues(t, r, values{
-			"ref": "master",
+			"ref":   "master",
 			"stage": "test",
-			"name": "ci/jenkins",
-			"all": "true",
+			"name":  "ci/jenkins",
+			"all":   "true",
 		})
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
 
-	opt := &GetCommitStatusesOptions{"master", "test", "ci/jenkins", true}
+	opt := &GetCommitStatusesOptions{String("master"), String("test"), String("ci/jenkins"), Bool(true)}
 	statuses, _, err := client.Commits.GetCommitStatuses("1", "b0b3a907f41409829b307a28b82fdbd552ee5a27", opt)
 
 	if err != nil {
@@ -42,16 +42,17 @@ func TestSetCommitStatus(t *testing.T) {
 	mux.HandleFunc("/projects/1/statuses/b0b3a907f41409829b307a28b82fdbd552ee5a27", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 		testJsonBody(t, r, values{
-			"state": "running",
-			"ref": "master",
-			"name": "ci/jenkins",
-			"target_url": "http://abc",
+			"state":       "running",
+			"context":     "",
+			"ref":         "master",
+			"name":        "ci/jenkins",
+			"target_url":  "http://abc",
 			"description": "build",
 		})
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	opt := &SetCommitStatusOptions{Running, "master", "ci/jenkins", "", "http://abc", "build"}
+	opt := &SetCommitStatusOptions{Running, String("master"), String("ci/jenkins"), String(""), String("http://abc"), String("build")}
 	status, _, err := client.Commits.SetCommitStatus("1", "b0b3a907f41409829b307a28b82fdbd552ee5a27", opt)
 
 	if err != nil {

--- a/deploy_keys.go
+++ b/deploy_keys.go
@@ -99,8 +99,8 @@ func (s *DeployKeysService) GetDeployKey(
 // GitLab API docs:
 // http://doc.gitlab.com/ce/api/deploy_keys.html#add-deploy-key
 type AddDeployKeyOptions struct {
-	Title string `url:"title,omitempty" json:"title,omitempty"`
-	Key   string `url:"key,omitempty" json:"key,omitempty"`
+	Title *string `url:"title,omitempty" json:"title,omitempty"`
+	Key   *string `url:"key,omitempty" json:"key,omitempty"`
 }
 
 // AddDeployKey creates a new deploy key for a project. If deploy key already

--- a/examples/labels.go
+++ b/examples/labels.go
@@ -11,8 +11,8 @@ func labelExample() {
 
 	// Create new label
 	l := &gitlab.CreateLabelOptions{
-		Name:  "My Label",
-		Color: "#11FF22",
+		Name:  gitlab.String("My Label"),
+		Color: gitlab.String("#11FF22"),
 	}
 	label, _, err := git.Labels.CreateLabel("myname/myproject", l)
 	if err != nil {

--- a/examples/projects.go
+++ b/examples/projects.go
@@ -11,11 +11,11 @@ func projectExample() {
 
 	// Create new project
 	p := &gitlab.CreateProjectOptions{
-		Name:                 "My Project",
-		Description:          "Just a test project to play with",
-		MergeRequestsEnabled: true,
-		SnippetsEnabled:      true,
-		VisibilityLevel:      gitlab.PublicVisibility,
+		Name:                 gitlab.String("My Project"),
+		Description:          gitlab.String("Just a test project to play with"),
+		MergeRequestsEnabled: gitlab.Bool(true),
+		SnippetsEnabled:      gitlab.Bool(true),
+		VisibilityLevel:      gitlab.VisibilityLevelPtr(gitlab.PublicVisibility),
 	}
 	project, _, err := git.Projects.CreateProject(p)
 	if err != nil {
@@ -24,10 +24,10 @@ func projectExample() {
 
 	// Add a new snippet
 	s := &gitlab.CreateSnippetOptions{
-		Title:           "Dummy Snippet",
-		FileName:        "snippet.go",
-		Code:            "package main....",
-		VisibilityLevel: gitlab.PublicVisibility,
+		Title:           gitlab.String("Dummy Snippet"),
+		FileName:        gitlab.String("snippet.go"),
+		Code:            gitlab.String("package main...."),
+		VisibilityLevel: gitlab.VisibilityLevelPtr(gitlab.PublicVisibility),
 	}
 	_, _, err = git.ProjectSnippets.CreateSnippet(project.ID, s)
 	if err != nil {

--- a/examples/projects.go
+++ b/examples/projects.go
@@ -15,7 +15,7 @@ func projectExample() {
 		Description:          gitlab.String("Just a test project to play with"),
 		MergeRequestsEnabled: gitlab.Bool(true),
 		SnippetsEnabled:      gitlab.Bool(true),
-		VisibilityLevel:      gitlab.VisibilityLevelPtr(gitlab.PublicVisibility),
+		VisibilityLevel:      gitlab.VisibilityLevel(gitlab.PublicVisibility),
 	}
 	project, _, err := git.Projects.CreateProject(p)
 	if err != nil {
@@ -27,7 +27,7 @@ func projectExample() {
 		Title:           gitlab.String("Dummy Snippet"),
 		FileName:        gitlab.String("snippet.go"),
 		Code:            gitlab.String("package main...."),
-		VisibilityLevel: gitlab.VisibilityLevelPtr(gitlab.PublicVisibility),
+		VisibilityLevel: gitlab.VisibilityLevel(gitlab.PublicVisibility),
 	}
 	_, _, err = git.ProjectSnippets.CreateSnippet(project.ID, s)
 	if err != nil {

--- a/examples/repository_files.go
+++ b/examples/repository_files.go
@@ -12,11 +12,11 @@ func repositoryFileExample() {
 
 	// Create a new repository file
 	cf := &gitlab.CreateFileOptions{
-		FilePath:      "file.go",
-		BranchName:    "master",
-		Encoding:      "text",
-		Content:       "My file contenxst",
-		CommitMessage: "Adding a test file",
+		FilePath:      gitlab.String("file.go"),
+		BranchName:    gitlab.String("master"),
+		Encoding:      gitlab.String("text"),
+		Content:       gitlab.String("My file contents"),
+		CommitMessage: gitlab.String("Adding a test file"),
 	}
 	file, _, err := git.RepositoryFiles.CreateFile("myname/myproject", cf)
 	if err != nil {
@@ -25,11 +25,11 @@ func repositoryFileExample() {
 
 	// Update a repository file
 	uf := &gitlab.UpdateFileOptions{
-		FilePath:      file.FilePath,
-		BranchName:    "master",
-		Encoding:      "text",
-		Content:       "My file content",
-		CommitMessage: "Fixing typo",
+		FilePath:      gitlab.String(file.FilePath),
+		BranchName:    gitlab.String("master"),
+		Encoding:      gitlab.String("text"),
+		Content:       gitlab.String("My file content"),
+		CommitMessage: gitlab.String("Fixing typo"),
 	}
 	_, _, err = git.RepositoryFiles.UpdateFile("myname/myproject", uf)
 	if err != nil {
@@ -37,8 +37,8 @@ func repositoryFileExample() {
 	}
 
 	gf := &gitlab.GetFileOptions{
-		FilePath: file.FilePath,
-		Ref:      "master",
+		FilePath: gitlab.String(file.FilePath),
+		Ref:      gitlab.String("master"),
 	}
 	f, _, err := git.RepositoryFiles.GetFile("myname/myproject", gf)
 	if err != nil {

--- a/gitlab.go
+++ b/gitlab.go
@@ -140,7 +140,7 @@ type Client struct {
 // support pagination.
 type ListOptions struct {
 	// For paginated result sets, page of results to retrieve.
-	Page *int `url:"page,omitempty" json:"page,omitempty"`
+	Page int `url:"page,omitempty" json:"page,omitempty"`
 
 	// For paginated result sets, the number of results to include per page.
 	PerPage int `url:"per_page,omitempty" json:"per_page,omitempty"`

--- a/gitlab.go
+++ b/gitlab.go
@@ -49,50 +49,50 @@ const (
 	oAuthToken
 )
 
-// AccessLevel represents a permission level within GitLab.
+// AccessLevelValue represents a permission level within GitLab.
 //
 // GitLab API docs: http://doc.gitlab.com/ce/permissions/permissions.html
-type AccessLevel int
+type AccessLevelValue int
 
 // List of available access levels
 //
 // GitLab API docs: http://doc.gitlab.com/ce/permissions/permissions.html
 const (
-	GuestPermissions     AccessLevel = 10
-	ReporterPermissions  AccessLevel = 20
-	DeveloperPermissions AccessLevel = 30
-	MasterPermissions    AccessLevel = 40
-	OwnerPermission      AccessLevel = 50
+	GuestPermissions     AccessLevelValue = 10
+	ReporterPermissions  AccessLevelValue = 20
+	DeveloperPermissions AccessLevelValue = 30
+	MasterPermissions    AccessLevelValue = 40
+	OwnerPermission      AccessLevelValue = 50
 )
 
-// NotificationLevel represents a notification level within Gitlab.
+// NotificationLevelValue represents a notification level within Gitlab.
 //
 // GitLab API docs: http://doc.gitlab.com/ce/api/
-type NotificationLevel int
+type NotificationLevelValue int
 
 // List of available notification levels
 //
 // GitLab API docs: http://doc.gitlab.com/ce/api/
 const (
-	DisabledNotifications NotificationLevel = iota
+	DisabledNotifications NotificationLevelValue = iota
 	ParticipatingNotifications
 	WatchNotifications
 	GlobalNotifications
 	MentionNotifications
 )
 
-// VisibilityLevel represents a visibility level within GitLab.
+// VisibilityLevelValue represents a visibility level within GitLab.
 //
 // GitLab API docs: http://doc.gitlab.com/ce/api/
-type VisibilityLevel int
+type VisibilityLevelValue int
 
 // List of available visibility levels
 //
 // GitLab API docs: http://doc.gitlab.com/ce/api/
 const (
-	PrivateVisibility  VisibilityLevel = 0
-	InternalVisibility VisibilityLevel = 10
-	PublicVisibility   VisibilityLevel = 20
+	PrivateVisibility  VisibilityLevelValue = 0
+	InternalVisibility VisibilityLevelValue = 10
+	PublicVisibility   VisibilityLevelValue = 20
 )
 
 // A Client manages communication with the GitLab API.
@@ -470,18 +470,18 @@ func String(v string) *string {
 	return p
 }
 
-// AccessLevelPtr is a helper routine that allocates a new AccessLevel value
+// AccessLevel is a helper routine that allocates a new AccessLevelValue
 // to store v and returns a pointer to it.
-func AccessLevelPtr(v AccessLevel) *AccessLevel {
-	p := new(AccessLevel)
+func AccessLevel(v AccessLevelValue) *AccessLevelValue {
+	p := new(AccessLevelValue)
 	*p = v
 	return p
 }
 
-// VisibilityLevelPtr is a helper routine that allocates a new AccessLevel value
+// VisibilityLevel is a helper routine that allocates a new VisibilityLevelValue
 // to store v and returns a pointer to it.
-func VisibilityLevelPtr(v VisibilityLevel) *VisibilityLevel {
-	p := new(VisibilityLevel)
+func VisibilityLevel(v VisibilityLevelValue) *VisibilityLevelValue {
+	p := new(VisibilityLevelValue)
 	*p = v
 	return p
 }

--- a/gitlab.go
+++ b/gitlab.go
@@ -143,7 +143,7 @@ type ListOptions struct {
 	Page *int `url:"page,omitempty" json:"page,omitempty"`
 
 	// For paginated result sets, the number of results to include per page.
-	PerPage *int `url:"per_page,omitempty" json:"per_page,omitempty"`
+	PerPage int `url:"per_page,omitempty" json:"per_page,omitempty"`
 }
 
 // NewClient returns a new GitLab API client. If a nil httpClient is

--- a/gitlab.go
+++ b/gitlab.go
@@ -140,10 +140,10 @@ type Client struct {
 // support pagination.
 type ListOptions struct {
 	// For paginated result sets, page of results to retrieve.
-	Page int `url:"page,omitempty" json:"page,omitempty"`
+	Page *int `url:"page,omitempty" json:"page,omitempty"`
 
 	// For paginated result sets, the number of results to include per page.
-	PerPage int `url:"per_page,omitempty" json:"per_page,omitempty"`
+	PerPage *int `url:"per_page,omitempty" json:"per_page,omitempty"`
 }
 
 // NewClient returns a new GitLab API client. If a nil httpClient is
@@ -466,6 +466,22 @@ func Int(v int) *int {
 // to store v and returns a pointer to it.
 func String(v string) *string {
 	p := new(string)
+	*p = v
+	return p
+}
+
+// AccessLevelPtr is a helper routine that allocates a new AccessLevel value
+// to store v and returns a pointer to it.
+func AccessLevelPtr(v AccessLevel) *AccessLevel {
+	p := new(AccessLevel)
+	*p = v
+	return p
+}
+
+// VisibilityLevelPtr is a helper routine that allocates a new AccessLevel value
+// to store v and returns a pointer to it.
+func VisibilityLevelPtr(v VisibilityLevel) *VisibilityLevel {
+	p := new(VisibilityLevel)
 	*p = v
 	return p
 }

--- a/groups.go
+++ b/groups.go
@@ -95,10 +95,10 @@ func (s *GroupsService) GetGroup(gid interface{}) (*Group, *Response, error) {
 //
 // GitLab API docs: http://doc.gitlab.com/ce/api/groups.html#new-group
 type CreateGroupOptions struct {
-	Name            *string          `url:"name,omitempty" json:"name,omitempty"`
-	Path            *string          `url:"path,omitempty" json:"path,omitempty"`
-	Description     *string          `url:"description,omitempty" json:"description,omitempty"`
-	VisibilityLevel *VisibilityLevel `url:"visibility_level" json:"visibility_level,omitempty"`
+	Name            *string               `url:"name,omitempty" json:"name,omitempty"`
+	Path            *string               `url:"path,omitempty" json:"path,omitempty"`
+	Description     *string               `url:"description,omitempty" json:"description,omitempty"`
+	VisibilityLevel *VisibilityLevelValue `url:"visibility_level" json:"visibility_level,omitempty"`
 }
 
 // CreateGroup creates a new project group. Available only for users who can
@@ -196,13 +196,13 @@ func (s *GroupsService) SearchGroup(query string) ([]*Group, *Response, error) {
 //
 // GitLab API docs: http://doc.gitlab.com/ce/api/groups.html
 type GroupMember struct {
-	ID          int         `json:"id"`
-	Username    string      `json:"username"`
-	Email       string      `json:"email"`
-	Name        string      `json:"name"`
-	State       string      `json:"state"`
-	CreatedAt   time.Time   `json:"created_at"`
-	AccessLevel AccessLevel `json:"access_level"`
+	ID          int              `json:"id"`
+	Username    string           `json:"username"`
+	Email       string           `json:"email"`
+	Name        string           `json:"name"`
+	State       string           `json:"state"`
+	CreatedAt   time.Time        `json:"created_at"`
+	AccessLevel AccessLevelValue `json:"access_level"`
 }
 
 // ListGroupMembers get a list of group members viewable by the authenticated
@@ -235,8 +235,8 @@ func (s *GroupsService) ListGroupMembers(gid interface{}) ([]*GroupMember, *Resp
 //
 // GitLab API docs: http://doc.gitlab.com/ce/api/groups.html#add-group-member
 type AddGroupMemberOptions struct {
-	UserID      *int         `url:"user_id,omitempty" json:"user_id,omitempty"`
-	AccessLevel *AccessLevel `url:"access_level,omitempty" json:"access_level,omitempty"`
+	UserID      *int              `url:"user_id,omitempty" json:"user_id,omitempty"`
+	AccessLevel *AccessLevelValue `url:"access_level,omitempty" json:"access_level,omitempty"`
 }
 
 // AddGroupMember adds a user to the list of group members.
@@ -272,7 +272,7 @@ func (s *GroupsService) AddGroupMember(
 // GitLab API docs:
 // http://doc.gitlab.com/ce/api/groups.html#edit-group-team-member
 type UpdateGroupMemberOptions struct {
-	AccessLevel *AccessLevel `url:"access_level,omitempty" json:"access_level,omitempty"`
+	AccessLevel *AccessLevelValue `url:"access_level,omitempty" json:"access_level,omitempty"`
 }
 
 // UpdateGroupMember updates a group team member to a specified access level.

--- a/groups.go
+++ b/groups.go
@@ -45,7 +45,7 @@ type Group struct {
 // GitLab API docs: http://doc.gitlab.com/ce/api/groups.html#list-project-groups
 type ListGroupsOptions struct {
 	ListOptions
-	Search string `url:"search,omitempty" json:"search,omitempty"`
+	Search *string `url:"search,omitempty" json:"search,omitempty"`
 }
 
 // ListGroups gets a list of groups. (As user: my groups, as admin: all groups)
@@ -95,15 +95,10 @@ func (s *GroupsService) GetGroup(gid interface{}) (*Group, *Response, error) {
 //
 // GitLab API docs: http://doc.gitlab.com/ce/api/groups.html#new-group
 type CreateGroupOptions struct {
-	Name        string `url:"name,omitempty" json:"name,omitempty"`
-	Path        string `url:"path,omitempty" json:"path,omitempty"`
-	Description string `url:"description,omitempty" json:"description,omitempty"`
-
-	// TODO (SvH) This should have the `omitempty` tag, but until issue #29
-	// is implemented, there is no clean way of adding those tags and still
-	// being able to define private groups (as the visibility level for that
-	// is 0 and so it would be omitted defaulting to a public group instead).
-	VisibilityLevel VisibilityLevel `url:"visibility_level" json:"visibility_level"`
+	Name            *string          `url:"name,omitempty" json:"name,omitempty"`
+	Path            *string          `url:"path,omitempty" json:"path,omitempty"`
+	Description     *string          `url:"description,omitempty" json:"description,omitempty"`
+	VisibilityLevel *VisibilityLevel `url:"visibility_level" json:"visibility_level,omitempty"`
 }
 
 // CreateGroup creates a new project group. Available only for users who can
@@ -240,8 +235,8 @@ func (s *GroupsService) ListGroupMembers(gid interface{}) ([]*GroupMember, *Resp
 //
 // GitLab API docs: http://doc.gitlab.com/ce/api/groups.html#add-group-member
 type AddGroupMemberOptions struct {
-	UserID      int         `url:"user_id,omitempty" json:"user_id,omitempty"`
-	AccessLevel AccessLevel `url:"access_level,omitempty" json:"access_level,omitempty"`
+	UserID      *int         `url:"user_id,omitempty" json:"user_id,omitempty"`
+	AccessLevel *AccessLevel `url:"access_level,omitempty" json:"access_level,omitempty"`
 }
 
 // AddGroupMember adds a user to the list of group members.
@@ -277,7 +272,7 @@ func (s *GroupsService) AddGroupMember(
 // GitLab API docs:
 // http://doc.gitlab.com/ce/api/groups.html#edit-group-team-member
 type UpdateGroupMemberOptions struct {
-	AccessLevel AccessLevel `url:"access_level,omitempty" json:"access_level,omitempty"`
+	AccessLevel *AccessLevel `url:"access_level,omitempty" json:"access_level,omitempty"`
 }
 
 // UpdateGroupMember updates a group team member to a specified access level.

--- a/issues.go
+++ b/issues.go
@@ -90,10 +90,10 @@ func (l *Labels) MarshalJSON() ([]byte, error) {
 // GitLab API docs: http://doc.gitlab.com/ce/api/issues.html#list-issues
 type ListIssuesOptions struct {
 	ListOptions
-	State   string `url:"state,omitempty" json:"state,omitempty"`
-	Labels  Labels `url:"labels,comma,omitempty" json:"labels,omitempty"`
-	OrderBy string `url:"order_by,omitempty" json:"order_by,omitempty"`
-	Sort    string `url:"sort,omitempty" json:"sort,omitempty"`
+	State   *string `url:"state,omitempty" json:"state,omitempty"`
+	Labels  Labels  `url:"labels,comma,omitempty" json:"labels,omitempty"`
+	OrderBy *string `url:"order_by,omitempty" json:"order_by,omitempty"`
+	Sort    *string `url:"sort,omitempty" json:"sort,omitempty"`
 }
 
 // ListIssues gets all issues created by authenticated user. This function
@@ -120,12 +120,12 @@ func (s *IssuesService) ListIssues(opt *ListIssuesOptions) ([]*Issue, *Response,
 // GitLab API docs: http://doc.gitlab.com/ce/api/issues.html#list-issues
 type ListProjectIssuesOptions struct {
 	ListOptions
-	IID       int    `url:"iid,omitempty" json:"iid,omitempty"`
-	State     string `url:"state,omitempty" json:"state,omitempty"`
-	Labels    Labels `url:"labels,comma,omitempty" json:"labels,omitempty"`
-	Milestone string `url:"milestone,omitempty" json:"milestone,omitempty"`
-	OrderBy   string `url:"order_by,omitempty" json:"order_by,omitempty"`
-	Sort      string `url:"sort,omitempty" json:"sort,omitempty"`
+	IID       *int    `url:"iid,omitempty" json:"iid,omitempty"`
+	State     *string `url:"state,omitempty" json:"state,omitempty"`
+	Labels    Labels  `url:"labels,comma,omitempty" json:"labels,omitempty"`
+	Milestone *string `url:"milestone,omitempty" json:"milestone,omitempty"`
+	OrderBy   *string `url:"order_by,omitempty" json:"order_by,omitempty"`
+	Sort      *string `url:"sort,omitempty" json:"sort,omitempty"`
 }
 
 // ListProjectIssues gets a list of project issues. This function accepts
@@ -183,11 +183,11 @@ func (s *IssuesService) GetIssue(pid interface{}, issue int) (*Issue, *Response,
 //
 // GitLab API docs: http://doc.gitlab.com/ce/api/issues.html#new-issues
 type CreateIssueOptions struct {
-	Title       string `url:"title,omitempty" json:"title,omitempty"`
-	Description string `url:"description,omitempty" json:"description,omitempty"`
-	AssigneeID  int    `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
-	MilestoneID int    `url:"milestone_id,omitempty" json:"milestone_id,omitempty"`
-	Labels      Labels `url:"labels,comma,omitempty" json:"labels,omitempty"`
+	Title       *string `url:"title,omitempty" json:"title,omitempty"`
+	Description *string `url:"description,omitempty" json:"description,omitempty"`
+	AssigneeID  *int    `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
+	MilestoneID *int    `url:"milestone_id,omitempty" json:"milestone_id,omitempty"`
+	Labels      Labels  `url:"labels,comma,omitempty" json:"labels,omitempty"`
 }
 
 // CreateIssue creates a new project issue.
@@ -222,12 +222,12 @@ func (s *IssuesService) CreateIssue(
 //
 // GitLab API docs: http://doc.gitlab.com/ce/api/issues.html#edit-issues
 type UpdateIssueOptions struct {
-	Title       string `url:"title,omitempty" json:"title,omitempty"`
-	Description string `url:"description,omitempty" json:"description,omitempty"`
-	AssigneeID  int    `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
-	MilestoneID int    `url:"milestone_id,omitempty" json:"milestone_id,omitempty"`
-	Labels      Labels `url:"labels,comma,omitempty" json:"labels,omitempty"`
-	StateEvent  string `url:"state_event,omitempty" json:"state_event,omitempty"`
+	Title       *string `url:"title,omitempty" json:"title,omitempty"`
+	Description *string `url:"description,omitempty" json:"description,omitempty"`
+	AssigneeID  *int    `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
+	MilestoneID *int    `url:"milestone_id,omitempty" json:"milestone_id,omitempty"`
+	Labels      Labels  `url:"labels,comma,omitempty" json:"labels,omitempty"`
+	StateEvent  *string `url:"state_event,omitempty" json:"state_event,omitempty"`
 }
 
 // UpdateIssue updates an existing project issue. This function is also used

--- a/labels.go
+++ b/labels.go
@@ -73,9 +73,9 @@ func (s *LabelsService) ListLabels(pid interface{}) ([]*Label, *Response, error)
 //
 // GitLab API docs: http://doc.gitlab.com/ce/api/labels.html#create-a-new-label
 type CreateLabelOptions struct {
-	Name        string `url:"name,omitempty" json:"name,omitempty"`
-	Color       string `url:"color,omitempty" json:"color,omitempty"`
-	Description string `url:"description,omitempty" json:"description,omitempty"`
+	Name        *string `url:"name,omitempty" json:"name,omitempty"`
+	Color       *string `url:"color,omitempty" json:"color,omitempty"`
+	Description *string `url:"description,omitempty" json:"description,omitempty"`
 }
 
 // CreateLabel creates a new label for given repository with given name and
@@ -109,7 +109,7 @@ func (s *LabelsService) CreateLabel(
 //
 // GitLab API docs: http://doc.gitlab.com/ce/api/labels.html#delete-a-label
 type DeleteLabelOptions struct {
-	Name string `url:"name,omitempty" json:"name,omitempty"`
+	Name *string `url:"name,omitempty" json:"name,omitempty"`
 }
 
 // DeleteLabel deletes a label given by its name.
@@ -139,10 +139,10 @@ func (s *LabelsService) DeleteLabel(pid interface{}, opt *DeleteLabelOptions) (*
 //
 // GitLab API docs: http://doc.gitlab.com/ce/api/labels.html#delete-a-label
 type UpdateLabelOptions struct {
-	Name        string `url:"name,omitempty" json:"name,omitempty"`
-	NewName     string `url:"new_name,omitempty" json:"new_name,omitempty"`
-	Color       string `url:"color,omitempty" json:"color,omitempty"`
-	Description string `url:"description,omitempty" json:"description,omitempty"`
+	Name        *string `url:"name,omitempty" json:"name,omitempty"`
+	NewName     *string `url:"new_name,omitempty" json:"new_name,omitempty"`
+	Color       *string `url:"color,omitempty" json:"color,omitempty"`
+	Description *string `url:"description,omitempty" json:"description,omitempty"`
 }
 
 // UpdateLabel updates an existing label with new name or now color. At least

--- a/merge_requests.go
+++ b/merge_requests.go
@@ -104,10 +104,10 @@ func (m MergeRequest) String() string {
 // http://doc.gitlab.com/ce/api/merge_requests.html#list-merge-requests
 type ListMergeRequestsOptions struct {
 	ListOptions
-	IID     int    `url:"iid,omitempty" json:"iid,omitempty"`
-	State   string `url:"state,omitempty" json:"state,omitempty"`
-	OrderBy string `url:"order_by,omitempty" json:"order_by,omitempty"`
-	Sort    string `url:"sort,omitempty" json:"sort,omitempty"`
+	IID     *int    `url:"iid,omitempty" json:"iid,omitempty"`
+	State   *string `url:"state,omitempty" json:"state,omitempty"`
+	OrderBy *string `url:"order_by,omitempty" json:"order_by,omitempty"`
+	Sort    *string `url:"sort,omitempty" json:"sort,omitempty"`
 }
 
 // ListMergeRequests gets all merge requests for this project. The state
@@ -201,12 +201,12 @@ func (s *MergeRequestsService) GetMergeRequestChanges(
 // GitLab API docs:
 // http://doc.gitlab.com/ce/api/merge_requests.html#create-mr
 type CreateMergeRequestOptions struct {
-	Title           string `url:"title,omitempty" json:"title,omitempty"`
-	Description     string `url:"description,omitempty" json:"description,omitempty"`
-	SourceBranch    string `url:"source_branch,omitemtpy" json:"source_branch,omitemtpy"`
-	TargetBranch    string `url:"target_branch,omitemtpy" json:"target_branch,omitemtpy"`
-	AssigneeID      int    `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
-	TargetProjectID int    `url:"target_project_id,omitempty" json:"target_project_id,omitempty"`
+	Title           *string `url:"title,omitempty" json:"title,omitempty"`
+	Description     *string `url:"description,omitempty" json:"description,omitempty"`
+	SourceBranch    *string `url:"source_branch,omitemtpy" json:"source_branch,omitemtpy"`
+	TargetBranch    *string `url:"target_branch,omitemtpy" json:"target_branch,omitemtpy"`
+	AssigneeID      *int    `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
+	TargetProjectID *int    `url:"target_project_id,omitempty" json:"target_project_id,omitempty"`
 }
 
 // CreateMergeRequest creates a new merge request.
@@ -242,11 +242,11 @@ func (s *MergeRequestsService) CreateMergeRequest(
 // GitLab API docs:
 // http://doc.gitlab.com/ce/api/merge_requests.html#update-mr
 type UpdateMergeRequestOptions struct {
-	Title        string `url:"title,omitempty" json:"title,omitempty"`
-	Description  string `url:"description,omitempty" json:"description,omitempty"`
-	TargetBranch string `url:"target_branch,omitemtpy" json:"target_branch,omitemtpy"`
-	AssigneeID   int    `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
-	StateEvent   string `url:"state_event,omitempty" json:"state_event,omitempty"`
+	Title        *string `url:"title,omitempty" json:"title,omitempty"`
+	Description  *string `url:"description,omitempty" json:"description,omitempty"`
+	TargetBranch *string `url:"target_branch,omitemtpy" json:"target_branch,omitemtpy"`
+	AssigneeID   *int    `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
+	StateEvent   *string `url:"state_event,omitempty" json:"state_event,omitempty"`
 }
 
 // UpdateMergeRequest updates an existing project milestone.
@@ -370,7 +370,7 @@ func (s *MergeRequestsService) GetMergeRequestComments(
 // GitLab API docs:
 // http://doc.gitlab.com/ce/api/commits.html#post-comment-to-mr
 type PostMergeRequestCommentOptions struct {
-	Note string `url:"note,omitempty" json:"note,omitempty"`
+	Note *string `url:"note,omitempty" json:"note,omitempty"`
 }
 
 // PostMergeRequestComment dds a comment to a merge request.

--- a/milestones.go
+++ b/milestones.go
@@ -55,7 +55,7 @@ func (m Milestone) String() string {
 // http://doc.gitlab.com/ce/api/milestones.html#list-project-milestones
 type ListMilestonesOptions struct {
 	ListOptions
-	IID int `url:"iid,omitempty" json:"iid,omitempty"`
+	IID *int `url:"iid,omitempty" json:"iid,omitempty"`
 }
 
 // ListMilestones returns a list of project milestones.
@@ -117,9 +117,9 @@ func (s *MilestonesService) GetMilestone(
 // GitLab API docs:
 // http://doc.gitlab.com/ce/api/milestones.html#create-new-milestone
 type CreateMilestoneOptions struct {
-	Title       string `url:"title,omitempty" json:"title,omitempty"`
-	Description string `url:"description,omitempty" json:"description,omitempty"`
-	DueDate     string `url:"due_date,omitempty" json:"due_date,omitempty"`
+	Title       *string `url:"title,omitempty" json:"title,omitempty"`
+	Description *string `url:"description,omitempty" json:"description,omitempty"`
+	DueDate     *string `url:"due_date,omitempty" json:"due_date,omitempty"`
 }
 
 // CreateMilestone creates a new project milestone.
@@ -154,10 +154,10 @@ func (s *MilestonesService) CreateMilestone(
 // GitLab API docs:
 // http://doc.gitlab.com/ce/api/milestones.html#edit-milestone
 type UpdateMilestoneOptions struct {
-	Title       string `url:"title,omitempty" json:"title,omitempty"`
-	Description string `url:"description,omitempty" json:"description,omitempty"`
-	DueDate     string `url:"due_date,omitempty" json:"due_date,omitempty"`
-	StateEvent  string `url:"state_event,omitempty" json:"state_event,omitempty"`
+	Title       *string `url:"title,omitempty" json:"title,omitempty"`
+	Description *string `url:"description,omitempty" json:"description,omitempty"`
+	DueDate     *string `url:"due_date,omitempty" json:"due_date,omitempty"`
+	StateEvent  *string `url:"state_event,omitempty" json:"state_event,omitempty"`
 }
 
 // UpdateMilestone updates an existing project milestone.

--- a/namespaces.go
+++ b/namespaces.go
@@ -42,7 +42,7 @@ func (n Namespace) String() string {
 // GitLab API docs: http://doc.gitlab.com/ce/api/namespaces.html#list-namespaces
 type ListNamespacesOptions struct {
 	ListOptions
-	Search string `url:"search,omitempty" json:"search,omitempty"`
+	Search *string `url:"search,omitempty" json:"search,omitempty"`
 }
 
 // ListNamespaces gets a list of projects accessible by the authenticated user.

--- a/notes.go
+++ b/notes.go
@@ -126,7 +126,7 @@ func (s *NotesService) GetIssueNote(
 // GitLab API docs:
 // http://doc.gitlab.com/ce/api/notes.html#create-new-issue-note
 type CreateIssueNoteOptions struct {
-	Body string `url:"body,omitempty" json:"body,omitempty"`
+	Body *string `url:"body,omitempty" json:"body,omitempty"`
 }
 
 // CreateIssueNote creates a new note to a single project issue.
@@ -163,7 +163,7 @@ func (s *NotesService) CreateIssueNote(
 // GitLab API docs:
 // http://doc.gitlab.com/ce/api/notes.html#modify-existing-issue-note
 type UpdateIssueNoteOptions struct {
-	Body string `url:"body,omitempty" json:"body,omitempty"`
+	Body *string `url:"body,omitempty" json:"body,omitempty"`
 }
 
 // UpdateIssueNote modifies existing note of an issue.
@@ -254,7 +254,7 @@ func (s *NotesService) GetSnippetNote(
 // GitLab API docs:
 // http://doc.gitlab.com/ce/api/notes.html#create-new-snippet-note
 type CreateSnippetNoteOptions struct {
-	Body string `url:"body,omitempty" json:"body,omitempty"`
+	Body *string `url:"body,omitempty" json:"body,omitempty"`
 }
 
 // CreateSnippetNote creates a new note for a single snippet. Snippet notes are
@@ -292,7 +292,7 @@ func (s *NotesService) CreateSnippetNote(
 // GitLab API docs:
 // http://doc.gitlab.com/ce/api/notes.html#modify-existing-snippet-note
 type UpdateSnippetNoteOptions struct {
-	Body string `url:"body,omitempty" json:"body,omitempty"`
+	Body *string `url:"body,omitempty" json:"body,omitempty"`
 }
 
 // UpdateSnippetNote modifies existing note of a snippet.
@@ -384,7 +384,7 @@ func (s *NotesService) GetMergeRequestNote(
 // GitLab API docs:
 // http://doc.gitlab.com/ce/api/notes.html#create-new-merge-request-note
 type CreateMergeRequestNoteOptions struct {
-	Body string `url:"body,omitempty" json:"body,omitempty"`
+	Body *string `url:"body,omitempty" json:"body,omitempty"`
 }
 
 // CreateMergeRequestNote creates a new note for a single merge request.
@@ -421,7 +421,7 @@ func (s *NotesService) CreateMergeRequestNote(
 // GitLab API docs:
 // http://doc.gitlab.com/ce/api/notes.html#modify-existing-merge-request-note
 type UpdateMergeRequestNoteOptions struct {
-	Body string `url:"body,omitempty" json:"body,omitempty"`
+	Body *string `url:"body,omitempty" json:"body,omitempty"`
 }
 
 // UpdateMergeRequestNote modifies existing note of a merge request.

--- a/project_snippets.go
+++ b/project_snippets.go
@@ -120,10 +120,10 @@ func (s *ProjectSnippetsService) GetSnippet(
 // GitLab API docs:
 // http://doc.gitlab.com/ce/api/project_snippets.html#create-new-snippet
 type CreateSnippetOptions struct {
-	Title           *string          `url:"title,omitempty" json:"title,omitempty"`
-	FileName        *string          `url:"file_name,omitempty" json:"file_name,omitempty"`
-	Code            *string          `url:"code,omitempty" json:"code,omitempty"`
-	VisibilityLevel *VisibilityLevel `url:"visibility_level,omitempty" json:"visibility_level,omitempty"`
+	Title           *string               `url:"title,omitempty" json:"title,omitempty"`
+	FileName        *string               `url:"file_name,omitempty" json:"file_name,omitempty"`
+	Code            *string               `url:"code,omitempty" json:"code,omitempty"`
+	VisibilityLevel *VisibilityLevelValue `url:"visibility_level,omitempty" json:"visibility_level,omitempty"`
 }
 
 // CreateSnippet creates a new project snippet. The user must have permission
@@ -159,10 +159,10 @@ func (s *ProjectSnippetsService) CreateSnippet(
 // GitLab API docs:
 // http://doc.gitlab.com/ce/api/project_snippets.html#update-snippet
 type UpdateSnippetOptions struct {
-	Title           *string          `url:"title,omitempty" json:"title,omitempty"`
-	FileName        *string          `url:"file_name,omitempty" json:"file_name,omitempty"`
-	Code            *string          `url:"code,omitempty" json:"code,omitempty"`
-	VisibilityLevel *VisibilityLevel `url:"visibility_level,omitempty" json:"visibility_level,omitempty"`
+	Title           *string               `url:"title,omitempty" json:"title,omitempty"`
+	FileName        *string               `url:"file_name,omitempty" json:"file_name,omitempty"`
+	Code            *string               `url:"code,omitempty" json:"code,omitempty"`
+	VisibilityLevel *VisibilityLevelValue `url:"visibility_level,omitempty" json:"visibility_level,omitempty"`
 }
 
 // UpdateSnippet updates an existing project snippet. The user must have

--- a/project_snippets.go
+++ b/project_snippets.go
@@ -120,10 +120,10 @@ func (s *ProjectSnippetsService) GetSnippet(
 // GitLab API docs:
 // http://doc.gitlab.com/ce/api/project_snippets.html#create-new-snippet
 type CreateSnippetOptions struct {
-	Title           string          `url:"title,omitempty" json:"title,omitempty"`
-	FileName        string          `url:"file_name,omitempty" json:"file_name,omitempty"`
-	Code            string          `url:"code,omitempty" json:"code,omitempty"`
-	VisibilityLevel VisibilityLevel `url:"visibility_level,omitempty" json:"visibility_level,omitempty"`
+	Title           *string          `url:"title,omitempty" json:"title,omitempty"`
+	FileName        *string          `url:"file_name,omitempty" json:"file_name,omitempty"`
+	Code            *string          `url:"code,omitempty" json:"code,omitempty"`
+	VisibilityLevel *VisibilityLevel `url:"visibility_level,omitempty" json:"visibility_level,omitempty"`
 }
 
 // CreateSnippet creates a new project snippet. The user must have permission
@@ -159,10 +159,10 @@ func (s *ProjectSnippetsService) CreateSnippet(
 // GitLab API docs:
 // http://doc.gitlab.com/ce/api/project_snippets.html#update-snippet
 type UpdateSnippetOptions struct {
-	Title           string          `url:"title,omitempty" json:"title,omitempty"`
-	FileName        string          `url:"file_name,omitempty" json:"file_name,omitempty"`
-	Code            string          `url:"code,omitempty" json:"code,omitempty"`
-	VisibilityLevel VisibilityLevel `url:"visibility_level,omitempty" json:"visibility_level,omitempty"`
+	Title           *string          `url:"title,omitempty" json:"title,omitempty"`
+	FileName        *string          `url:"file_name,omitempty" json:"file_name,omitempty"`
+	Code            *string          `url:"code,omitempty" json:"code,omitempty"`
+	VisibilityLevel *VisibilityLevel `url:"visibility_level,omitempty" json:"visibility_level,omitempty"`
 }
 
 // UpdateSnippet updates an existing project snippet. The user must have

--- a/projects.go
+++ b/projects.go
@@ -102,11 +102,11 @@ func (s Project) String() string {
 // GitLab API docs: http://doc.gitlab.com/ce/api/projects.html#list-projects
 type ListProjectsOptions struct {
 	ListOptions
-	Archived       bool   `url:"archived,omitempty" json:"archived,omitempty"`
-	OrderBy        string `url:"order_by,omitempty" json:"order_by,omitempty"`
-	Sort           string `url:"sort,omitempty" json:"sort,omitempty"`
-	Search         string `url:"search,omitempty" json:"search,omitempty"`
-	CIEnabledFirst bool   `url:"ci_enabled_first,omitempty" json:"ci_enabled_first,omitempty"`
+	Archived       *bool   `url:"archived,omitempty" json:"archived,omitempty"`
+	OrderBy        *string `url:"order_by,omitempty" json:"order_by,omitempty"`
+	Sort           *string `url:"sort,omitempty" json:"sort,omitempty"`
+	Search         *string `url:"search,omitempty" json:"search,omitempty"`
+	CIEnabledFirst *bool   `url:"ci_enabled_first,omitempty" json:"ci_enabled_first,omitempty"`
 }
 
 // ListProjects gets a list of projects accessible by the authenticated user.
@@ -221,8 +221,8 @@ func (s *ProjectsService) GetProject(pid interface{}) (*Project, *Response, erro
 // http://doc.gitlab.com/ce/api/projects.html#search-for-projects-by-name
 type SearchProjectsOptions struct {
 	ListOptions
-	OrderBy string `url:"order_by,omitempty" json:"order_by,omitempty"`
-	Sort    string `url:"sort,omitempty" json:"sort,omitempty"`
+	OrderBy *string `url:"order_by,omitempty" json:"order_by,omitempty"`
+	Sort    *string `url:"sort,omitempty" json:"sort,omitempty"`
 }
 
 // SearchProjects searches for projects by name which are accessible to the
@@ -332,17 +332,17 @@ func (s *ProjectsService) GetProjectEvents(
 //
 // GitLab API docs: http://doc.gitlab.com/ce/api/projects.html#create-project
 type CreateProjectOptions struct {
-	Name                 string          `url:"name,omitempty" json:"name,omitempty"`
-	Path                 string          `url:"path,omitempty" json:"path,omitempty"`
-	NamespaceID          string          `url:"namespace_id,omitempty" json:"namespace_id,omitempty"`
-	Description          string          `url:"description,omitempty" json:"description,omitempty"`
-	IssuesEnabled        bool            `url:"issues_enabled,omitempty" json:"issues_enabled,omitempty"`
-	MergeRequestsEnabled bool            `url:"merge_requests_enabled,omitempty" json:"merge_requests_enabled,omitempty"`
-	WikiEnabled          bool            `url:"wiki_enabled,omitempty" json:"wiki_enabled,omitempty"`
-	SnippetsEnabled      bool            `url:"snippets_enabled,omitempty" json:"snippets_enabled,omitempty"`
-	Public               bool            `url:"public,omitempty" json:"public,omitempty"`
-	VisibilityLevel      VisibilityLevel `url:"visibility_level,omitempty" json:"visibility_level,omitempty"`
-	ImportURL            string          `url:"import_url,omitempty" json:"import_url,omitempty"`
+	Name                 *string          `url:"name,omitempty" json:"name,omitempty"`
+	Path                 *string          `url:"path,omitempty" json:"path,omitempty"`
+	NamespaceID          *string          `url:"namespace_id,omitempty" json:"namespace_id,omitempty"`
+	Description          *string          `url:"description,omitempty" json:"description,omitempty"`
+	IssuesEnabled        *bool            `url:"issues_enabled,omitempty" json:"issues_enabled,omitempty"`
+	MergeRequestsEnabled *bool            `url:"merge_requests_enabled,omitempty" json:"merge_requests_enabled,omitempty"`
+	WikiEnabled          *bool            `url:"wiki_enabled,omitempty" json:"wiki_enabled,omitempty"`
+	SnippetsEnabled      *bool            `url:"snippets_enabled,omitempty" json:"snippets_enabled,omitempty"`
+	Public               *bool            `url:"public,omitempty" json:"public,omitempty"`
+	VisibilityLevel      *VisibilityLevel `url:"visibility_level,omitempty" json:"visibility_level,omitempty"`
+	ImportURL            *string          `url:"import_url,omitempty" json:"import_url,omitempty"`
 }
 
 // CreateProject creates a new project owned by the authenticated user.
@@ -370,16 +370,16 @@ func (s *ProjectsService) CreateProject(
 // GitLab API docs:
 // http://doc.gitlab.com/ce/api/projects.html#create-project-for-user
 type CreateProjectForUserOptions struct {
-	Name                 string          `url:"name,omitempty" json:"name,omitempty"`
-	Description          string          `url:"description,omitempty" json:"description,omitempty"`
-	DefaultBranch        string          `url:"default_branch,omitempty" json:"default_branch,omitempty"`
-	IssuesEnabled        bool            `url:"issues_enabled,omitempty" json:"issues_enabled,omitempty"`
-	MergeRequestsEnabled bool            `url:"merge_requests_enabled,omitempty" json:"merge_requests_enabled,omitempty"`
-	WikiEnabled          bool            `url:"wiki_enabled,omitempty" json:"wiki_enabled,omitempty"`
-	SnippetsEnabled      bool            `url:"snippets_enabled,omitempty" json:"snippets_enabled,omitempty"`
-	Public               bool            `url:"public,omitempty" json:"public,omitempty"`
-	VisibilityLevel      VisibilityLevel `url:"visibility_level,omitempty" json:"visibility_level,omitempty"`
-	ImportURL            string          `url:"import_url,omitempty" json:"import_url,omitempty"`
+	Name                 *string          `url:"name,omitempty" json:"name,omitempty"`
+	Description          *string          `url:"description,omitempty" json:"description,omitempty"`
+	DefaultBranch        *string          `url:"default_branch,omitempty" json:"default_branch,omitempty"`
+	IssuesEnabled        *bool            `url:"issues_enabled,omitempty" json:"issues_enabled,omitempty"`
+	MergeRequestsEnabled *bool            `url:"merge_requests_enabled,omitempty" json:"merge_requests_enabled,omitempty"`
+	WikiEnabled          *bool            `url:"wiki_enabled,omitempty" json:"wiki_enabled,omitempty"`
+	SnippetsEnabled      *bool            `url:"snippets_enabled,omitempty" json:"snippets_enabled,omitempty"`
+	Public               *bool            `url:"public,omitempty" json:"public,omitempty"`
+	VisibilityLevel      *VisibilityLevel `url:"visibility_level,omitempty" json:"visibility_level,omitempty"`
+	ImportURL            *string          `url:"import_url,omitempty" json:"import_url,omitempty"`
 }
 
 // CreateProjectForUser creates a new project owned by the specified user.
@@ -410,16 +410,16 @@ func (s *ProjectsService) CreateProjectForUser(
 //
 // GitLab API docs: http://doc.gitlab.com/ce/api/projects.html#edit-project
 type EditProjectOptions struct {
-	Name                 string          `url:"name,omitempty" json:"name,omitempty"`
-	Path                 string          `url:"path,omitempty" json:"path,omitempty"`
-	Description          string          `url:"description,omitempty" json:"description,omitempty"`
-	DefaultBranch        string          `url:"default_branch,omitempty" json:"default_branch,omitempty"`
-	IssuesEnabled        bool            `url:"issues_enabled,omitempty" json:"issues_enabled,omitempty"`
-	MergeRequestsEnabled bool            `url:"merge_requests_enabled,omitempty" json:"merge_requests_enabled,omitempty"`
-	WikiEnabled          bool            `url:"wiki_enabled,omitempty" json:"wiki_enabled,omitempty"`
-	SnippetsEnabled      bool            `url:"snippets_enabled,omitempty" json:"snippets_enabled,omitempty"`
-	Public               bool            `url:"public,omitempty" json:"public,omitempty"`
-	VisibilityLevel      VisibilityLevel `url:"visibility_level,omitempty" json:"visibility_level,omitempty"`
+	Name                 *string          `url:"name,omitempty" json:"name,omitempty"`
+	Path                 *string          `url:"path,omitempty" json:"path,omitempty"`
+	Description          *string          `url:"description,omitempty" json:"description,omitempty"`
+	DefaultBranch        *string          `url:"default_branch,omitempty" json:"default_branch,omitempty"`
+	IssuesEnabled        *bool            `url:"issues_enabled,omitempty" json:"issues_enabled,omitempty"`
+	MergeRequestsEnabled *bool            `url:"merge_requests_enabled,omitempty" json:"merge_requests_enabled,omitempty"`
+	WikiEnabled          *bool            `url:"wiki_enabled,omitempty" json:"wiki_enabled,omitempty"`
+	SnippetsEnabled      *bool            `url:"snippets_enabled,omitempty" json:"snippets_enabled,omitempty"`
+	Public               *bool            `url:"public,omitempty" json:"public,omitempty"`
+	VisibilityLevel      *VisibilityLevel `url:"visibility_level,omitempty" json:"visibility_level,omitempty"`
 }
 
 // EditProject updates an existing project.
@@ -518,7 +518,7 @@ type ProjectMember struct {
 // http://doc.gitlab.com/ce/api/projects.html#list-project-team-members
 type ListProjectMembersOptions struct {
 	ListOptions
-	Query string `url:"query,omitempty" json:"query,omitempty"`
+	Query *string `url:"query,omitempty" json:"query,omitempty"`
 }
 
 // ListProjectMembers gets a list of a project's team members.
@@ -580,8 +580,8 @@ func (s *ProjectsService) GetProjectMember(
 // GitLab API docs:
 // http://doc.gitlab.com/ce/api/projects.html#add-project-team-member
 type AddProjectMemberOptions struct {
-	UserID      int         `url:"user_id,omitempty" json:"user_id,omitempty"`
-	AccessLevel AccessLevel `url:"access_level,omitempty" json:"access_level,omitempty"`
+	UserID      *int         `url:"user_id,omitempty" json:"user_id,omitempty"`
+	AccessLevel *AccessLevel `url:"access_level,omitempty" json:"access_level,omitempty"`
 }
 
 // AddProjectMember adds a user to a project team. This is an idempotent
@@ -619,7 +619,7 @@ func (s *ProjectsService) AddProjectMember(
 // GitLab API docs:
 // http://doc.gitlab.com/ce/api/projects.html#edit-project-team-member
 type EditProjectMemberOptions struct {
-	AccessLevel AccessLevel `url:"access_level,omitempty" json:"access_level,omitempty"`
+	AccessLevel *AccessLevel `url:"access_level,omitempty" json:"access_level,omitempty"`
 }
 
 // EditProjectMember updates a project team member to a specified access level..
@@ -754,11 +754,11 @@ func (s *ProjectsService) GetProjectHook(
 // GitLab API docs:
 // http://doc.gitlab.com/ce/api/projects.html#add-project-hook
 type AddProjectHookOptions struct {
-	URL                 string `url:"url,omitempty" json:"url,omitempty"`
-	PushEvents          bool   `url:"push_events,omitempty" json:"push_events,omitempty"`
-	IssuesEvents        bool   `url:"issues_events,omitempty" json:"issues_events,omitempty"`
-	MergeRequestsEvents bool   `url:"merge_requests_events,omitempty" json:"merge_requests_events,omitempty"`
-	TagPushEvents       bool   `url:"tag_push_events,omitempty" json:"tag_push_events,omitempty"`
+	URL                 *string `url:"url,omitempty" json:"url,omitempty"`
+	PushEvents          *bool   `url:"push_events,omitempty" json:"push_events,omitempty"`
+	IssuesEvents        *bool   `url:"issues_events,omitempty" json:"issues_events,omitempty"`
+	MergeRequestsEvents *bool   `url:"merge_requests_events,omitempty" json:"merge_requests_events,omitempty"`
+	TagPushEvents       *bool   `url:"tag_push_events,omitempty" json:"tag_push_events,omitempty"`
 }
 
 // AddProjectHook adds a hook to a specified project.
@@ -793,11 +793,11 @@ func (s *ProjectsService) AddProjectHook(
 // GitLab API docs:
 // http://doc.gitlab.com/ce/api/projects.html#edit-project-hook
 type EditProjectHookOptions struct {
-	URL                 string `url:"url,omitempty" json:"url,omitempty"`
-	PushEvents          bool   `url:"push_events,omitempty" json:"push_events,omitempty"`
-	IssuesEvents        bool   `url:"issues_events,omitempty" json:"issues_events,omitempty"`
-	MergeRequestsEvents bool   `url:"merge_requests_events,omitempty" json:"merge_requests_events,omitempty"`
-	TagPushEvents       bool   `url:"tag_push_events,omitempty" json:"tag_push_events,omitempty"`
+	URL                 *string `url:"url,omitempty" json:"url,omitempty"`
+	PushEvents          *bool   `url:"push_events,omitempty" json:"push_events,omitempty"`
+	IssuesEvents        *bool   `url:"issues_events,omitempty" json:"issues_events,omitempty"`
+	MergeRequestsEvents *bool   `url:"merge_requests_events,omitempty" json:"merge_requests_events,omitempty"`
+	TagPushEvents       *bool   `url:"tag_push_events,omitempty" json:"tag_push_events,omitempty"`
 }
 
 // EditProjectHook edits a hook for a specified project.

--- a/projects.go
+++ b/projects.go
@@ -34,38 +34,38 @@ type ProjectsService struct {
 //
 // GitLab API docs: http://doc.gitlab.com/ce/api/projects.html
 type Project struct {
-	ID                   *int              `json:"id"`
-	Description          *string           `json:"description"`
-	DefaultBranch        *string           `json:"default_branch"`
-	Public               *bool             `json:"public"`
-	VisibilityLevel      *VisibilityLevel  `json:"visibility_level"`
-	SSHURLToRepo         *string           `json:"ssh_url_to_repo"`
-	HTTPURLToRepo        *string           `json:"http_url_to_repo"`
-	WebURL               *string           `json:"web_url"`
-	TagList              *[]string         `json:"tag_list"`
-	Owner                *User             `json:"owner"`
-	Name                 *string           `json:"name"`
-	NameWithNamespace    *string           `json:"name_with_namespace"`
-	Path                 *string           `json:"path"`
-	PathWithNamespace    *string           `json:"path_with_namespace"`
-	IssuesEnabled        *bool             `json:"issues_enabled"`
-	OpenIssuesCount      *int              `json:"open_issues_count"`
-	MergeRequestsEnabled *bool             `json:"merge_requests_enabled"`
-	BuildsEnabled        *bool             `json:"builds_enabled"`
-	WikiEnabled          *bool             `json:"wiki_enabled"`
-	SnippetsEnabled      *bool             `json:"snippets_enabled"`
-	CreatedAt            *time.Time        `json:"created_at,omitempty"`
-	LastActivityAt       *time.Time        `json:"last_activity_at,omitempty"`
-	CreatorID            *int              `json:"creator_id"`
-	Namespace            *ProjectNamespace `json:"namespace"`
-	Permissions          *Permissions      `json:"permissions"`
-	Archived             *bool             `json:"archived"`
-	AvatarURL            *string           `json:"avatar_url"`
-	SharedRunnersEnabled *bool             `json:"shared_runners_enabled"`
-	ForksCount           *int              `json:"forks_count"`
-	StarCount            *int              `json:"star_count"`
-	RunnersToken         *string           `json:"runners_token"`
-	PublicBuilds         *bool             `json:"public_builds"`
+	ID                   *int                  `json:"id"`
+	Description          *string               `json:"description"`
+	DefaultBranch        *string               `json:"default_branch"`
+	Public               *bool                 `json:"public"`
+	VisibilityLevel      *VisibilityLevelValue `json:"visibility_level"`
+	SSHURLToRepo         *string               `json:"ssh_url_to_repo"`
+	HTTPURLToRepo        *string               `json:"http_url_to_repo"`
+	WebURL               *string               `json:"web_url"`
+	TagList              *[]string             `json:"tag_list"`
+	Owner                *User                 `json:"owner"`
+	Name                 *string               `json:"name"`
+	NameWithNamespace    *string               `json:"name_with_namespace"`
+	Path                 *string               `json:"path"`
+	PathWithNamespace    *string               `json:"path_with_namespace"`
+	IssuesEnabled        *bool                 `json:"issues_enabled"`
+	OpenIssuesCount      *int                  `json:"open_issues_count"`
+	MergeRequestsEnabled *bool                 `json:"merge_requests_enabled"`
+	BuildsEnabled        *bool                 `json:"builds_enabled"`
+	WikiEnabled          *bool                 `json:"wiki_enabled"`
+	SnippetsEnabled      *bool                 `json:"snippets_enabled"`
+	CreatedAt            *time.Time            `json:"created_at,omitempty"`
+	LastActivityAt       *time.Time            `json:"last_activity_at,omitempty"`
+	CreatorID            *int                  `json:"creator_id"`
+	Namespace            *ProjectNamespace     `json:"namespace"`
+	Permissions          *Permissions          `json:"permissions"`
+	Archived             *bool                 `json:"archived"`
+	AvatarURL            *string               `json:"avatar_url"`
+	SharedRunnersEnabled *bool                 `json:"shared_runners_enabled"`
+	ForksCount           *int                  `json:"forks_count"`
+	StarCount            *int                  `json:"star_count"`
+	RunnersToken         *string               `json:"runners_token"`
+	PublicBuilds         *bool                 `json:"public_builds"`
 }
 
 type ProjectNamespace struct {
@@ -79,18 +79,18 @@ type ProjectNamespace struct {
 }
 
 type Permissions struct {
-	ProjectAccess    *ProjectAccess `json:"project_access"`
-	GroupAccess      *GroupAccess   `json:"group_access"`
+	ProjectAccess *ProjectAccess `json:"project_access"`
+	GroupAccess   *GroupAccess   `json:"group_access"`
 }
 
 type ProjectAccess struct {
-	AccessLevel       AccessLevel       `json:"access_level"`
-	NotificationLevel NotificationLevel `json:"notification_level"`
+	AccessLevel       AccessLevelValue       `json:"access_level"`
+	NotificationLevel NotificationLevelValue `json:"notification_level"`
 }
 
 type GroupAccess struct {
-	AccessLevel       AccessLevel       `json:"access_level"`
-	NotificationLevel NotificationLevel `json:"notification_level"`
+	AccessLevel       AccessLevelValue       `json:"access_level"`
+	NotificationLevel NotificationLevelValue `json:"notification_level"`
 }
 
 func (s Project) String() string {
@@ -168,7 +168,6 @@ func (s *ProjectsService) ListStarredProjects(
 
 	return p, resp, err
 }
-
 
 // ListAllProjects gets a list of all GitLab projects (admin only).
 //
@@ -332,17 +331,17 @@ func (s *ProjectsService) GetProjectEvents(
 //
 // GitLab API docs: http://doc.gitlab.com/ce/api/projects.html#create-project
 type CreateProjectOptions struct {
-	Name                 *string          `url:"name,omitempty" json:"name,omitempty"`
-	Path                 *string          `url:"path,omitempty" json:"path,omitempty"`
-	NamespaceID          *string          `url:"namespace_id,omitempty" json:"namespace_id,omitempty"`
-	Description          *string          `url:"description,omitempty" json:"description,omitempty"`
-	IssuesEnabled        *bool            `url:"issues_enabled,omitempty" json:"issues_enabled,omitempty"`
-	MergeRequestsEnabled *bool            `url:"merge_requests_enabled,omitempty" json:"merge_requests_enabled,omitempty"`
-	WikiEnabled          *bool            `url:"wiki_enabled,omitempty" json:"wiki_enabled,omitempty"`
-	SnippetsEnabled      *bool            `url:"snippets_enabled,omitempty" json:"snippets_enabled,omitempty"`
-	Public               *bool            `url:"public,omitempty" json:"public,omitempty"`
-	VisibilityLevel      *VisibilityLevel `url:"visibility_level,omitempty" json:"visibility_level,omitempty"`
-	ImportURL            *string          `url:"import_url,omitempty" json:"import_url,omitempty"`
+	Name                 *string               `url:"name,omitempty" json:"name,omitempty"`
+	Path                 *string               `url:"path,omitempty" json:"path,omitempty"`
+	NamespaceID          *string               `url:"namespace_id,omitempty" json:"namespace_id,omitempty"`
+	Description          *string               `url:"description,omitempty" json:"description,omitempty"`
+	IssuesEnabled        *bool                 `url:"issues_enabled,omitempty" json:"issues_enabled,omitempty"`
+	MergeRequestsEnabled *bool                 `url:"merge_requests_enabled,omitempty" json:"merge_requests_enabled,omitempty"`
+	WikiEnabled          *bool                 `url:"wiki_enabled,omitempty" json:"wiki_enabled,omitempty"`
+	SnippetsEnabled      *bool                 `url:"snippets_enabled,omitempty" json:"snippets_enabled,omitempty"`
+	Public               *bool                 `url:"public,omitempty" json:"public,omitempty"`
+	VisibilityLevel      *VisibilityLevelValue `url:"visibility_level,omitempty" json:"visibility_level,omitempty"`
+	ImportURL            *string               `url:"import_url,omitempty" json:"import_url,omitempty"`
 }
 
 // CreateProject creates a new project owned by the authenticated user.
@@ -370,16 +369,16 @@ func (s *ProjectsService) CreateProject(
 // GitLab API docs:
 // http://doc.gitlab.com/ce/api/projects.html#create-project-for-user
 type CreateProjectForUserOptions struct {
-	Name                 *string          `url:"name,omitempty" json:"name,omitempty"`
-	Description          *string          `url:"description,omitempty" json:"description,omitempty"`
-	DefaultBranch        *string          `url:"default_branch,omitempty" json:"default_branch,omitempty"`
-	IssuesEnabled        *bool            `url:"issues_enabled,omitempty" json:"issues_enabled,omitempty"`
-	MergeRequestsEnabled *bool            `url:"merge_requests_enabled,omitempty" json:"merge_requests_enabled,omitempty"`
-	WikiEnabled          *bool            `url:"wiki_enabled,omitempty" json:"wiki_enabled,omitempty"`
-	SnippetsEnabled      *bool            `url:"snippets_enabled,omitempty" json:"snippets_enabled,omitempty"`
-	Public               *bool            `url:"public,omitempty" json:"public,omitempty"`
-	VisibilityLevel      *VisibilityLevel `url:"visibility_level,omitempty" json:"visibility_level,omitempty"`
-	ImportURL            *string          `url:"import_url,omitempty" json:"import_url,omitempty"`
+	Name                 *string               `url:"name,omitempty" json:"name,omitempty"`
+	Description          *string               `url:"description,omitempty" json:"description,omitempty"`
+	DefaultBranch        *string               `url:"default_branch,omitempty" json:"default_branch,omitempty"`
+	IssuesEnabled        *bool                 `url:"issues_enabled,omitempty" json:"issues_enabled,omitempty"`
+	MergeRequestsEnabled *bool                 `url:"merge_requests_enabled,omitempty" json:"merge_requests_enabled,omitempty"`
+	WikiEnabled          *bool                 `url:"wiki_enabled,omitempty" json:"wiki_enabled,omitempty"`
+	SnippetsEnabled      *bool                 `url:"snippets_enabled,omitempty" json:"snippets_enabled,omitempty"`
+	Public               *bool                 `url:"public,omitempty" json:"public,omitempty"`
+	VisibilityLevel      *VisibilityLevelValue `url:"visibility_level,omitempty" json:"visibility_level,omitempty"`
+	ImportURL            *string               `url:"import_url,omitempty" json:"import_url,omitempty"`
 }
 
 // CreateProjectForUser creates a new project owned by the specified user.
@@ -410,16 +409,16 @@ func (s *ProjectsService) CreateProjectForUser(
 //
 // GitLab API docs: http://doc.gitlab.com/ce/api/projects.html#edit-project
 type EditProjectOptions struct {
-	Name                 *string          `url:"name,omitempty" json:"name,omitempty"`
-	Path                 *string          `url:"path,omitempty" json:"path,omitempty"`
-	Description          *string          `url:"description,omitempty" json:"description,omitempty"`
-	DefaultBranch        *string          `url:"default_branch,omitempty" json:"default_branch,omitempty"`
-	IssuesEnabled        *bool            `url:"issues_enabled,omitempty" json:"issues_enabled,omitempty"`
-	MergeRequestsEnabled *bool            `url:"merge_requests_enabled,omitempty" json:"merge_requests_enabled,omitempty"`
-	WikiEnabled          *bool            `url:"wiki_enabled,omitempty" json:"wiki_enabled,omitempty"`
-	SnippetsEnabled      *bool            `url:"snippets_enabled,omitempty" json:"snippets_enabled,omitempty"`
-	Public               *bool            `url:"public,omitempty" json:"public,omitempty"`
-	VisibilityLevel      *VisibilityLevel `url:"visibility_level,omitempty" json:"visibility_level,omitempty"`
+	Name                 *string               `url:"name,omitempty" json:"name,omitempty"`
+	Path                 *string               `url:"path,omitempty" json:"path,omitempty"`
+	Description          *string               `url:"description,omitempty" json:"description,omitempty"`
+	DefaultBranch        *string               `url:"default_branch,omitempty" json:"default_branch,omitempty"`
+	IssuesEnabled        *bool                 `url:"issues_enabled,omitempty" json:"issues_enabled,omitempty"`
+	MergeRequestsEnabled *bool                 `url:"merge_requests_enabled,omitempty" json:"merge_requests_enabled,omitempty"`
+	WikiEnabled          *bool                 `url:"wiki_enabled,omitempty" json:"wiki_enabled,omitempty"`
+	SnippetsEnabled      *bool                 `url:"snippets_enabled,omitempty" json:"snippets_enabled,omitempty"`
+	Public               *bool                 `url:"public,omitempty" json:"public,omitempty"`
+	VisibilityLevel      *VisibilityLevelValue `url:"visibility_level,omitempty" json:"visibility_level,omitempty"`
 }
 
 // EditProject updates an existing project.
@@ -502,13 +501,13 @@ func (s *ProjectsService) DeleteProject(pid interface{}) (*Response, error) {
 // GitLab API docs:
 // http://doc.gitlab.com/ce/api/projects.html#list-project-team-members
 type ProjectMember struct {
-	ID          int         `json:"id"`
-	Username    string      `json:"username"`
-	Email       string      `json:"email"`
-	Name        string      `json:"name"`
-	State       string      `json:"state"`
-	CreatedAt   time.Time   `json:"created_at"`
-	AccessLevel AccessLevel `json:"access_level"`
+	ID          int              `json:"id"`
+	Username    string           `json:"username"`
+	Email       string           `json:"email"`
+	Name        string           `json:"name"`
+	State       string           `json:"state"`
+	CreatedAt   time.Time        `json:"created_at"`
+	AccessLevel AccessLevelValue `json:"access_level"`
 }
 
 // ListProjectMembersOptions represents the available ListProjectMembers()
@@ -580,8 +579,8 @@ func (s *ProjectsService) GetProjectMember(
 // GitLab API docs:
 // http://doc.gitlab.com/ce/api/projects.html#add-project-team-member
 type AddProjectMemberOptions struct {
-	UserID      *int         `url:"user_id,omitempty" json:"user_id,omitempty"`
-	AccessLevel *AccessLevel `url:"access_level,omitempty" json:"access_level,omitempty"`
+	UserID      *int              `url:"user_id,omitempty" json:"user_id,omitempty"`
+	AccessLevel *AccessLevelValue `url:"access_level,omitempty" json:"access_level,omitempty"`
 }
 
 // AddProjectMember adds a user to a project team. This is an idempotent
@@ -619,7 +618,7 @@ func (s *ProjectsService) AddProjectMember(
 // GitLab API docs:
 // http://doc.gitlab.com/ce/api/projects.html#edit-project-team-member
 type EditProjectMemberOptions struct {
-	AccessLevel *AccessLevel `url:"access_level,omitempty" json:"access_level,omitempty"`
+	AccessLevel *AccessLevelValue `url:"access_level,omitempty" json:"access_level,omitempty"`
 }
 
 // EditProjectMember updates a project team member to a specified access level..

--- a/projects_test.go
+++ b/projects_test.go
@@ -14,25 +14,25 @@ func TestListProjects(t *testing.T) {
 	mux.HandleFunc("/projects", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testFormValues(t, r, values{
-			"page": "2",
-			"per_page": "3",
-			"archived": "true",
-			"order_by": "name",
-			"sort": "asc",
-			"search": "query",
+			"page":             "2",
+			"per_page":         "3",
+			"archived":         "true",
+			"order_by":         "name",
+			"sort":             "asc",
+			"search":           "query",
 			"ci_enabled_first": "true",
 		})
 		fmt.Fprint(w, `[{"id":1},{"id":2}]`)
 	})
 
-	opt := &ListProjectsOptions{ListOptions{2, 3}, true, "name", "asc", "query", true}
+	opt := &ListProjectsOptions{ListOptions{Int(2), Int(3)}, Bool(true), String("name"), String("asc"), String("query"), Bool(true)}
 	projects, _, err := client.Projects.ListProjects(opt)
 
 	if err != nil {
 		t.Errorf("Projects.ListProjects returned error: %v", err)
 	}
 
-	want := []*Project{{ID: Int(1)},{ID: Int(2)}}
+	want := []*Project{{ID: Int(1)}, {ID: Int(2)}}
 	if !reflect.DeepEqual(want, projects) {
 		t.Errorf("Projects.ListProjects returned %+v, want %+v", projects, want)
 	}
@@ -45,25 +45,25 @@ func TestListOwnedProjects(t *testing.T) {
 	mux.HandleFunc("/projects/owned", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testFormValues(t, r, values{
-			"page": "2",
-			"per_page": "3",
-			"archived": "true",
-			"order_by": "name",
-			"sort": "asc",
-			"search": "query",
+			"page":             "2",
+			"per_page":         "3",
+			"archived":         "true",
+			"order_by":         "name",
+			"sort":             "asc",
+			"search":           "query",
 			"ci_enabled_first": "true",
 		})
 		fmt.Fprint(w, `[{"id":1},{"id":2}]`)
 	})
 
-	opt := &ListProjectsOptions{ListOptions{2, 3}, true, "name", "asc", "query", true}
+	opt := &ListProjectsOptions{ListOptions{Int(2), Int(3)}, Bool(true), String("name"), String("asc"), String("query"), Bool(true)}
 	projects, _, err := client.Projects.ListOwnedProjects(opt)
 
 	if err != nil {
 		t.Errorf("Projects.ListOwnedProjects returned error: %v", err)
 	}
 
-	want := []*Project{{ID: Int(1)},{ID: Int(2)}}
+	want := []*Project{{ID: Int(1)}, {ID: Int(2)}}
 	if !reflect.DeepEqual(want, projects) {
 		t.Errorf("Projects.ListOwnedProjects returned %+v, want %+v", projects, want)
 	}
@@ -76,25 +76,25 @@ func TestListStarredProjects(t *testing.T) {
 	mux.HandleFunc("/projects/starred", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testFormValues(t, r, values{
-			"page": "2",
-			"per_page": "3",
-			"archived": "true",
-			"order_by": "name",
-			"sort": "asc",
-			"search": "query",
+			"page":             "2",
+			"per_page":         "3",
+			"archived":         "true",
+			"order_by":         "name",
+			"sort":             "asc",
+			"search":           "query",
 			"ci_enabled_first": "true",
 		})
 		fmt.Fprint(w, `[{"id":1},{"id":2}]`)
 	})
 
-	opt := &ListProjectsOptions{ListOptions{2, 3}, true, "name", "asc", "query", true}
+	opt := &ListProjectsOptions{ListOptions{Int(2), Int(3)}, Bool(true), String("name"), String("asc"), String("query"), Bool(true)}
 	projects, _, err := client.Projects.ListStarredProjects(opt)
 
 	if err != nil {
 		t.Errorf("Projects.ListStarredProjects returned error: %v", err)
 	}
 
-	want := []*Project{{ID: Int(1)},{ID: Int(2)}}
+	want := []*Project{{ID: Int(1)}, {ID: Int(2)}}
 	if !reflect.DeepEqual(want, projects) {
 		t.Errorf("Projects.ListStarredProjects returned %+v, want %+v", projects, want)
 	}
@@ -107,25 +107,25 @@ func TestListAllProjects(t *testing.T) {
 	mux.HandleFunc("/projects/all", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testFormValues(t, r, values{
-			"page": "2",
-			"per_page": "3",
-			"archived": "true",
-			"order_by": "name",
-			"sort": "asc",
-			"search": "query",
+			"page":             "2",
+			"per_page":         "3",
+			"archived":         "true",
+			"order_by":         "name",
+			"sort":             "asc",
+			"search":           "query",
 			"ci_enabled_first": "true",
 		})
 		fmt.Fprint(w, `[{"id":1},{"id":2}]`)
 	})
 
-	opt := &ListProjectsOptions{ListOptions{2, 3}, true, "name", "asc", "query", true}
+	opt := &ListProjectsOptions{ListOptions{Int(2), Int(3)}, Bool(true), String("name"), String("asc"), String("query"), Bool(true)}
 	projects, _, err := client.Projects.ListAllProjects(opt)
 
 	if err != nil {
 		t.Errorf("Projects.ListAllProjects returned error: %v", err)
 	}
 
-	want := []*Project{{ID: Int(1)},{ID: Int(2)}}
+	want := []*Project{{ID: Int(1)}, {ID: Int(2)}}
 	if !reflect.DeepEqual(want, projects) {
 		t.Errorf("Projects.ListAllProjects returned %+v, want %+v", projects, want)
 	}
@@ -181,22 +181,22 @@ func TestSearchProjects(t *testing.T) {
 	mux.HandleFunc("/projects/search/query", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testFormValues(t, r, values{
-			"page": "2",
+			"page":     "2",
 			"per_page": "3",
 			"order_by": "name",
-			"sort": "asc",
+			"sort":     "asc",
 		})
 		fmt.Fprint(w, `[{"id":1},{"id":2}]`)
 	})
 
-	opt := &SearchProjectsOptions{ListOptions{2, 3}, "name", "asc"}
+	opt := &SearchProjectsOptions{ListOptions{Int(2), Int(3)}, String("name"), String("asc")}
 	projects, _, err := client.Projects.SearchProjects("query", opt)
 
 	if err != nil {
 		t.Errorf("Projects.SearchProjects returned error: %v", err)
 	}
 
-	want := []*Project{{ID: Int(1)},{ID: Int(2)}}
+	want := []*Project{{ID: Int(1)}, {ID: Int(2)}}
 	if !reflect.DeepEqual(want, projects) {
 		t.Errorf("Projects.SearchProjects returned %+v, want %+v", projects, want)
 	}
@@ -215,7 +215,7 @@ func TestCreateProject(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	opt := &CreateProjectOptions{Name: "n"}
+	opt := &CreateProjectOptions{Name: String("n")}
 	project, _, err := client.Projects.CreateProject(opt)
 
 	if err != nil {

--- a/projects_test.go
+++ b/projects_test.go
@@ -25,7 +25,7 @@ func TestListProjects(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1},{"id":2}]`)
 	})
 
-	opt := &ListProjectsOptions{ListOptions{Int(2), Int(3)}, Bool(true), String("name"), String("asc"), String("query"), Bool(true)}
+	opt := &ListProjectsOptions{ListOptions{Int(2), 3}, Bool(true), String("name"), String("asc"), String("query"), Bool(true)}
 	projects, _, err := client.Projects.ListProjects(opt)
 
 	if err != nil {
@@ -56,7 +56,7 @@ func TestListOwnedProjects(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1},{"id":2}]`)
 	})
 
-	opt := &ListProjectsOptions{ListOptions{Int(2), Int(3)}, Bool(true), String("name"), String("asc"), String("query"), Bool(true)}
+	opt := &ListProjectsOptions{ListOptions{Int(2), 3}, Bool(true), String("name"), String("asc"), String("query"), Bool(true)}
 	projects, _, err := client.Projects.ListOwnedProjects(opt)
 
 	if err != nil {
@@ -87,7 +87,7 @@ func TestListStarredProjects(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1},{"id":2}]`)
 	})
 
-	opt := &ListProjectsOptions{ListOptions{Int(2), Int(3)}, Bool(true), String("name"), String("asc"), String("query"), Bool(true)}
+	opt := &ListProjectsOptions{ListOptions{Int(2), 3}, Bool(true), String("name"), String("asc"), String("query"), Bool(true)}
 	projects, _, err := client.Projects.ListStarredProjects(opt)
 
 	if err != nil {
@@ -118,7 +118,7 @@ func TestListAllProjects(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1},{"id":2}]`)
 	})
 
-	opt := &ListProjectsOptions{ListOptions{Int(2), Int(3)}, Bool(true), String("name"), String("asc"), String("query"), Bool(true)}
+	opt := &ListProjectsOptions{ListOptions{Int(2), 3}, Bool(true), String("name"), String("asc"), String("query"), Bool(true)}
 	projects, _, err := client.Projects.ListAllProjects(opt)
 
 	if err != nil {
@@ -189,7 +189,7 @@ func TestSearchProjects(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1},{"id":2}]`)
 	})
 
-	opt := &SearchProjectsOptions{ListOptions{Int(2), Int(3)}, String("name"), String("asc")}
+	opt := &SearchProjectsOptions{ListOptions{Int(2), 3}, String("name"), String("asc")}
 	projects, _, err := client.Projects.SearchProjects("query", opt)
 
 	if err != nil {

--- a/projects_test.go
+++ b/projects_test.go
@@ -25,7 +25,7 @@ func TestListProjects(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1},{"id":2}]`)
 	})
 
-	opt := &ListProjectsOptions{ListOptions{Int(2), 3}, Bool(true), String("name"), String("asc"), String("query"), Bool(true)}
+	opt := &ListProjectsOptions{ListOptions{2, 3}, Bool(true), String("name"), String("asc"), String("query"), Bool(true)}
 	projects, _, err := client.Projects.ListProjects(opt)
 
 	if err != nil {
@@ -56,7 +56,7 @@ func TestListOwnedProjects(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1},{"id":2}]`)
 	})
 
-	opt := &ListProjectsOptions{ListOptions{Int(2), 3}, Bool(true), String("name"), String("asc"), String("query"), Bool(true)}
+	opt := &ListProjectsOptions{ListOptions{2, 3}, Bool(true), String("name"), String("asc"), String("query"), Bool(true)}
 	projects, _, err := client.Projects.ListOwnedProjects(opt)
 
 	if err != nil {
@@ -87,7 +87,7 @@ func TestListStarredProjects(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1},{"id":2}]`)
 	})
 
-	opt := &ListProjectsOptions{ListOptions{Int(2), 3}, Bool(true), String("name"), String("asc"), String("query"), Bool(true)}
+	opt := &ListProjectsOptions{ListOptions{2, 3}, Bool(true), String("name"), String("asc"), String("query"), Bool(true)}
 	projects, _, err := client.Projects.ListStarredProjects(opt)
 
 	if err != nil {
@@ -118,7 +118,7 @@ func TestListAllProjects(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1},{"id":2}]`)
 	})
 
-	opt := &ListProjectsOptions{ListOptions{Int(2), 3}, Bool(true), String("name"), String("asc"), String("query"), Bool(true)}
+	opt := &ListProjectsOptions{ListOptions{2, 3}, Bool(true), String("name"), String("asc"), String("query"), Bool(true)}
 	projects, _, err := client.Projects.ListAllProjects(opt)
 
 	if err != nil {
@@ -189,7 +189,7 @@ func TestSearchProjects(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1},{"id":2}]`)
 	})
 
-	opt := &SearchProjectsOptions{ListOptions{Int(2), 3}, String("name"), String("asc")}
+	opt := &SearchProjectsOptions{ListOptions{2, 3}, String("name"), String("asc")}
 	projects, _, err := client.Projects.SearchProjects("query", opt)
 
 	if err != nil {

--- a/repositories.go
+++ b/repositories.go
@@ -75,9 +75,9 @@ func (s *RepositoriesService) ListTags(pid interface{}) ([]*Tag, *Response, erro
 // GitLab API docs:
 // http://doc.gitlab.com/ce/api/repositories.html#create-a-new-tag
 type CreateTagOptions struct {
-	TagName string `url:"tag_name,omitempty" json:"tag_name,omitempty"`
-	Ref     string `url:"ref,omitempty" json:"ref,omitempty"`
-	Message string `url:"message,omitempty" json:"message,omitempty"`
+	TagName *string `url:"tag_name,omitempty" json:"tag_name,omitempty"`
+	Ref     *string `url:"ref,omitempty" json:"ref,omitempty"`
+	Message *string `url:"message,omitempty" json:"message,omitempty"`
 }
 
 // CreateTag creates a new tag in the repository that points to the supplied ref.
@@ -127,8 +127,8 @@ func (t TreeNode) String() string {
 // GitLab API docs:
 // http://doc.gitlab.com/ce/api/repositories.html#list-repository-tree
 type ListTreeOptions struct {
-	Path    string `url:"path,omitempty" json:"path,omitempty"`
-	RefName string `url:"ref_name,omitempty" json:"ref_name,omitempty"`
+	Path    *string `url:"path,omitempty" json:"path,omitempty"`
+	RefName *string `url:"ref_name,omitempty" json:"ref_name,omitempty"`
 }
 
 // ListTree gets a list of repository files and directories in a project.
@@ -163,7 +163,7 @@ func (s *RepositoriesService) ListTree(
 // GitLab API docs:
 // http://doc.gitlab.com/ce/api/repositories.html#raw-file-content
 type RawFileContentOptions struct {
-	FilePath string `url:"filepath,omitempty" json:"filepath,omitempty"`
+	FilePath *string `url:"filepath,omitempty" json:"filepath,omitempty"`
 }
 
 // RawFileContent gets the raw file contents for a file by commit SHA and path
@@ -226,7 +226,7 @@ func (s *RepositoriesService) RawBlobContent(
 // GitLab API docs:
 // http://doc.gitlab.com/ce/api/repositories.html#get-file-archive
 type ArchiveOptions struct {
-	SHA string `url:"sha,omitempty" json:"sha,omitempty"`
+	SHA *string `url:"sha,omitempty" json:"sha,omitempty"`
 }
 
 // Archive gets an archive of the repository.
@@ -277,8 +277,8 @@ func (c Compare) String() string {
 // GitLab API docs:
 // http://doc.gitlab.com/ce/api/repositories.html#compare-branches-tags-or-commits
 type CompareOptions struct {
-	From string `url:"from,omitempty" json:"from,omitempty"`
-	To   string `url:"to,omitempty" json:"to,omitempty"`
+	From *string `url:"from,omitempty" json:"from,omitempty"`
+	To   *string `url:"to,omitempty" json:"to,omitempty"`
 }
 
 // Compare compares branches, tags or commits.

--- a/repository_files.go
+++ b/repository_files.go
@@ -52,8 +52,8 @@ func (r File) String() string {
 // GitLab API docs:
 // http://doc.gitlab.com/ce/api/repository_files.html#get-file-from-respository
 type GetFileOptions struct {
-	FilePath string `url:"file_path,omitempty" json:"file_path,omitempty"`
-	Ref      string `url:"ref,omitempty" json:"ref,omitempty"`
+	FilePath *string `url:"file_path,omitempty" json:"file_path,omitempty"`
+	Ref      *string `url:"ref,omitempty" json:"ref,omitempty"`
 }
 
 // GetFile allows you to receive information about a file in repository like
@@ -101,11 +101,11 @@ func (r FileInfo) String() string {
 // GitLab API docs:
 // http://doc.gitlab.com/ce/api/repository_files.html#create-new-file-in-repository
 type CreateFileOptions struct {
-	FilePath      string `url:"file_path,omitempty" json:"file_path,omitempty"`
-	BranchName    string `url:"branch_name,omitempty" json:"branch_name,omitempty"`
-	Encoding      string `url:"encoding,omitempty" json:"encoding,omitempty"`
-	Content       string `url:"content,omitempty" json:"content,omitempty"`
-	CommitMessage string `url:"commit_message,omitempty" json:"commit_message,omitempty"`
+	FilePath      *string `url:"file_path,omitempty" json:"file_path,omitempty"`
+	BranchName    *string `url:"branch_name,omitempty" json:"branch_name,omitempty"`
+	Encoding      *string `url:"encoding,omitempty" json:"encoding,omitempty"`
+	Content       *string `url:"content,omitempty" json:"content,omitempty"`
+	CommitMessage *string `url:"commit_message,omitempty" json:"commit_message,omitempty"`
 }
 
 // CreateFile creates a new file in a repository.
@@ -140,11 +140,11 @@ func (s *RepositoryFilesService) CreateFile(
 // GitLab API docs:
 // http://doc.gitlab.com/ce/api/repository_files.html#update-existing-file-in-repository
 type UpdateFileOptions struct {
-	FilePath      string `url:"file_path,omitempty" json:"file_path,omitempty"`
-	BranchName    string `url:"branch_name,omitempty" json:"branch_name,omitempty"`
-	Encoding      string `url:"encoding,omitempty" json:"encoding,omitempty"`
-	Content       string `url:"content,omitempty" json:"content,omitempty"`
-	CommitMessage string `url:"commit_message,omitempty" json:"commit_message,omitempty"`
+	FilePath      *string `url:"file_path,omitempty" json:"file_path,omitempty"`
+	BranchName    *string `url:"branch_name,omitempty" json:"branch_name,omitempty"`
+	Encoding      *string `url:"encoding,omitempty" json:"encoding,omitempty"`
+	Content       *string `url:"content,omitempty" json:"content,omitempty"`
+	CommitMessage *string `url:"commit_message,omitempty" json:"commit_message,omitempty"`
 }
 
 // UpdateFile updates an existing file in a repository
@@ -179,9 +179,9 @@ func (s *RepositoryFilesService) UpdateFile(
 // GitLab API docs:
 // http://doc.gitlab.com/ce/api/repository_files.html#delete-existing-file-in-repository
 type DeleteFileOptions struct {
-	FilePath      string `url:"file_path,omitempty" json:"file_path,omitempty"`
-	BranchName    string `url:"branch_name,omitempty" json:"branch_name,omitempty"`
-	CommitMessage string `url:"commit_message,omitempty" json:"commit_message,omitempty"`
+	FilePath      *string `url:"file_path,omitempty" json:"file_path,omitempty"`
+	BranchName    *string `url:"branch_name,omitempty" json:"branch_name,omitempty"`
+	CommitMessage *string `url:"commit_message,omitempty" json:"commit_message,omitempty"`
 }
 
 // DeleteFile deletes an existing file in a repository

--- a/services.go
+++ b/services.go
@@ -49,8 +49,8 @@ type Service struct {
 // GitLab API docs:
 // http://doc.gitlab.com/ce/api/services.html#edit-gitlab-ci-service
 type SetGitLabCIServiceOptions struct {
-	Token      string `url:"token,omitempty" json:"token,omitempty"`
-	ProjectURL string `url:"project_url,omitempty" json:"project_url,omitempty"`
+	Token      *string `url:"token,omitempty" json:"token,omitempty"`
+	ProjectURL *string `url:"project_url,omitempty" json:"project_url,omitempty"`
 }
 
 // SetGitLabCIService sets GitLab CI service for a project.
@@ -109,8 +109,8 @@ func (s *ServicesService) DeleteGitLabCIService(pid interface{}) (*Response, err
 // GitLab API docs:
 // http://doc.gitlab.com/ce/api/services.html#edit-hipchat-service
 type SetHipChatServiceOptions struct {
-	Token string `url:"token,omitempty" json:"token,omitempty" `
-	Room  string `url:"room,omitempty" json:"room,omitempty"`
+	Token *string `url:"token,omitempty" json:"token,omitempty" `
+	Room  *string `url:"room,omitempty" json:"room,omitempty"`
 }
 
 // SetHipChatService sets HipChat service for a project
@@ -169,9 +169,9 @@ func (s *ServicesService) DeleteHipChatService(pid interface{}) (*Response, erro
 // GitLab API docs:
 // http://doc.gitlab.com/ce/api/services.html#createedit-drone-ci-service
 type SetDroneCIServiceOptions struct {
-	Token                   string `url:"token" json:"token" `
-	DroneURL                string `url:"drone_url" json:"drone_url"`
-	EnableSSLVerification   string `url:"enable_ssl_verification,omitempty" json:"enable_ssl_verification,omitempty"`
+	Token                   *string `url:"token" json:"token" `
+	DroneURL                *string `url:"drone_url" json:"drone_url"`
+	EnableSSLVerification   *string `url:"enable_ssl_verification,omitempty" json:"enable_ssl_verification,omitempty"`
 }
 
 // SetDroneCIService sets Drone CI service for a project.
@@ -268,9 +268,9 @@ func (s *ServicesService) GetDroneCIService(pid interface{}) (*DroneCIService, *
 // GitLab API docs:
 // http://doc.gitlab.com/ce/api/services.html#edit-slack-service
 type SetSlackServiceOptions struct {
-	WebHook  string `url:"webhook,omitempty" json:"webhook,omitempty" `
-	Username string `url:"username,omitempty" json:"username,omitempty" `
-	Channel  string `url:"channel,omitempty" json:"channel,omitempty"`
+	WebHook  *string `url:"webhook,omitempty" json:"webhook,omitempty" `
+	Username *string `url:"username,omitempty" json:"username,omitempty" `
+	Channel  *string `url:"channel,omitempty" json:"channel,omitempty"`
 }
 
 // SetSlackService sets Slack service for a project

--- a/services_test.go
+++ b/services_test.go
@@ -14,13 +14,13 @@ func TestSetDroneCIService(t *testing.T) {
 	mux.HandleFunc("/projects/1/services/drone-ci", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 		testJsonBody(t, r, values{
-			"token": "t",
-			"drone_url": "u",
+			"token":                   "t",
+			"drone_url":               "u",
 			"enable_ssl_verification": "true",
 		})
 	})
 
-	opt := &SetDroneCIServiceOptions{"t", "u", "true"}
+	opt := &SetDroneCIServiceOptions{String("t"), String("u"), String("true")}
 	_, err := client.Services.SetDroneCIService(1, opt)
 
 	if err != nil {

--- a/session.go
+++ b/session.go
@@ -54,9 +54,9 @@ type Session struct {
 //
 // GitLab API docs: http://doc.gitlab.com/ce/api/session.html#session
 type GetSessionOptions struct {
-	Login    string `url:"login,omitempty" json:"login,omitempty"`
-	Email    string `url:"email,omitempty" json:"email,omitempty"`
-	Password string `url:"password,omitempty" json:"password,omitempty"`
+	Login    *string `url:"login,omitempty" json:"login,omitempty"`
+	Email    *string `url:"email,omitempty" json:"email,omitempty"`
+	Password *string `url:"password,omitempty" json:"password,omitempty"`
 }
 
 // GetSession logs in to get private token.

--- a/settings.go
+++ b/settings.go
@@ -79,22 +79,22 @@ func (s *SettingsService) GetSettings() (*Settings, *Response, error) {
 // GitLab API docs:
 // http://doc.gitlab.com/ce/api/settings.html#change-application.settings
 type UpdateSettingsOptions struct {
-	DefaultProjectsLimit       int               `url:"default_projects_limit,omitempty" json:"default_projects_limit,omitempty"`
-	SignupEnabled              bool              `url:"signup_enabled,omitempty" json:"signup_enabled,omitempty"`
-	SigninEnabled              bool              `url:"signin_enabled,omitempty" json:"signin_enabled,omitempty"`
-	GravatarEnabled            bool              `url:"gravatar_enabled,omitempty" json:"gravatar_enabled,omitempty"`
-	SignInText                 string            `url:"sign_in_text,omitempty" json:"sign_in_text,omitempty"`
-	HomePageURL                string            `url:"home_page_url,omitempty" json:"home_page_url,omitempty"`
-	DefaultBranchProtection    int               `url:"default_branch_protection,omitempty" json:"default_branch_protection,omitempty"`
-	TwitterSharingEnabled      bool              `url:"twitter_sharing_enabled,omitempty" json:"twitter_sharing_enabled,omitempty"`
+	DefaultProjectsLimit       *int               `url:"default_projects_limit,omitempty" json:"default_projects_limit,omitempty"`
+	SignupEnabled              *bool              `url:"signup_enabled,omitempty" json:"signup_enabled,omitempty"`
+	SigninEnabled              *bool              `url:"signin_enabled,omitempty" json:"signin_enabled,omitempty"`
+	GravatarEnabled            *bool              `url:"gravatar_enabled,omitempty" json:"gravatar_enabled,omitempty"`
+	SignInText                 *string            `url:"sign_in_text,omitempty" json:"sign_in_text,omitempty"`
+	HomePageURL                *string            `url:"home_page_url,omitempty" json:"home_page_url,omitempty"`
+	DefaultBranchProtection    *int               `url:"default_branch_protection,omitempty" json:"default_branch_protection,omitempty"`
+	TwitterSharingEnabled      *bool              `url:"twitter_sharing_enabled,omitempty" json:"twitter_sharing_enabled,omitempty"`
 	RestrictedVisibilityLevels []VisibilityLevel `url:"restricted_visibility_levels,omitempty" json:"restricted_visibility_levels,omitempty"`
-	MaxAttachmentSize          int               `url:"max_attachment_size,omitempty" json:"max_attachment_size,omitempty"`
-	SessionExpireDelay         int               `url:"session_expire_delay,omitempty" json:"session_expire_delay,omitempty"`
-	DefaultProjectVisibility   int               `url:"default_project_visibility,omitempty" json:"default_project_visibility,omitempty"`
-	DefaultSnippetVisibility   int               `url:"default_snippet_visibility,omitempty" json:"default_snippet_visibility,omitempty"`
+	MaxAttachmentSize          *int               `url:"max_attachment_size,omitempty" json:"max_attachment_size,omitempty"`
+	SessionExpireDelay         *int               `url:"session_expire_delay,omitempty" json:"session_expire_delay,omitempty"`
+	DefaultProjectVisibility   *int               `url:"default_project_visibility,omitempty" json:"default_project_visibility,omitempty"`
+	DefaultSnippetVisibility   *int               `url:"default_snippet_visibility,omitempty" json:"default_snippet_visibility,omitempty"`
 	RestrictedSignupDomains    []string          `url:"restricted_signup_domains,omitempty" json:"restricted_signup_domains,omitempty"`
-	UserOauthApplications      bool              `url:"user_oauth_applications,omitempty" json:"user_oauth_applications,omitempty"`
-	AfterSignOutPath           string            `url:"after_sign_out_path,omitempty" json:"after_sign_out_path,omitempty"`
+	UserOauthApplications      *bool              `url:"user_oauth_applications,omitempty" json:"user_oauth_applications,omitempty"`
+	AfterSignOutPath           *string            `url:"after_sign_out_path,omitempty" json:"after_sign_out_path,omitempty"`
 }
 
 // UpdateSettings updates the application settings.

--- a/settings.go
+++ b/settings.go
@@ -30,25 +30,25 @@ type SettingsService struct {
 //
 // GitLab API docs: http://doc.gitlab.com/ce/api/settings.html
 type Settings struct {
-	ID                         int               `json:"id"`
-	DefaultProjectsLimit       int               `json:"default_projects_limit"`
-	SignupEnabled              bool              `json:"signup_enabled"`
-	SigninEnabled              bool              `json:"signin_enabled"`
-	GravatarEnabled            bool              `json:"gravatar_enabled"`
-	SignInText                 string            `json:"sign_in_text"`
-	CreatedAt                  time.Time         `json:"created_at"`
-	UpdatedAt                  time.Time         `json:"updated_at"`
-	HomePageURL                string            `json:"home_page_url"`
-	DefaultBranchProtection    int               `json:"default_branch_protection"`
-	TwitterSharingEnabled      bool              `json:"twitter_sharing_enabled"`
-	RestrictedVisibilityLevels []VisibilityLevel `json:"restricted_visibility_levels"`
-	MaxAttachmentSize          int               `json:"max_attachment_size"`
-	SessionExpireDelay         int               `json:"session_expire_delay"`
-	DefaultProjectVisibility   int               `json:"default_project_visibility"`
-	DefaultSnippetVisibility   int               `json:"default_snippet_visibility"`
-	RestrictedSignupDomains    []string          `json:"restricted_signup_domains"`
-	UserOauthApplications      bool              `json:"user_oauth_applications"`
-	AfterSignOutPath           string            `json:"after_sign_out_path"`
+	ID                         int                    `json:"id"`
+	DefaultProjectsLimit       int                    `json:"default_projects_limit"`
+	SignupEnabled              bool                   `json:"signup_enabled"`
+	SigninEnabled              bool                   `json:"signin_enabled"`
+	GravatarEnabled            bool                   `json:"gravatar_enabled"`
+	SignInText                 string                 `json:"sign_in_text"`
+	CreatedAt                  time.Time              `json:"created_at"`
+	UpdatedAt                  time.Time              `json:"updated_at"`
+	HomePageURL                string                 `json:"home_page_url"`
+	DefaultBranchProtection    int                    `json:"default_branch_protection"`
+	TwitterSharingEnabled      bool                   `json:"twitter_sharing_enabled"`
+	RestrictedVisibilityLevels []VisibilityLevelValue `json:"restricted_visibility_levels"`
+	MaxAttachmentSize          int                    `json:"max_attachment_size"`
+	SessionExpireDelay         int                    `json:"session_expire_delay"`
+	DefaultProjectVisibility   int                    `json:"default_project_visibility"`
+	DefaultSnippetVisibility   int                    `json:"default_snippet_visibility"`
+	RestrictedSignupDomains    []string               `json:"restricted_signup_domains"`
+	UserOauthApplications      bool                   `json:"user_oauth_applications"`
+	AfterSignOutPath           string                 `json:"after_sign_out_path"`
 }
 
 func (s Settings) String() string {
@@ -79,22 +79,22 @@ func (s *SettingsService) GetSettings() (*Settings, *Response, error) {
 // GitLab API docs:
 // http://doc.gitlab.com/ce/api/settings.html#change-application.settings
 type UpdateSettingsOptions struct {
-	DefaultProjectsLimit       *int               `url:"default_projects_limit,omitempty" json:"default_projects_limit,omitempty"`
-	SignupEnabled              *bool              `url:"signup_enabled,omitempty" json:"signup_enabled,omitempty"`
-	SigninEnabled              *bool              `url:"signin_enabled,omitempty" json:"signin_enabled,omitempty"`
-	GravatarEnabled            *bool              `url:"gravatar_enabled,omitempty" json:"gravatar_enabled,omitempty"`
-	SignInText                 *string            `url:"sign_in_text,omitempty" json:"sign_in_text,omitempty"`
-	HomePageURL                *string            `url:"home_page_url,omitempty" json:"home_page_url,omitempty"`
-	DefaultBranchProtection    *int               `url:"default_branch_protection,omitempty" json:"default_branch_protection,omitempty"`
-	TwitterSharingEnabled      *bool              `url:"twitter_sharing_enabled,omitempty" json:"twitter_sharing_enabled,omitempty"`
-	RestrictedVisibilityLevels []VisibilityLevel `url:"restricted_visibility_levels,omitempty" json:"restricted_visibility_levels,omitempty"`
-	MaxAttachmentSize          *int               `url:"max_attachment_size,omitempty" json:"max_attachment_size,omitempty"`
-	SessionExpireDelay         *int               `url:"session_expire_delay,omitempty" json:"session_expire_delay,omitempty"`
-	DefaultProjectVisibility   *int               `url:"default_project_visibility,omitempty" json:"default_project_visibility,omitempty"`
-	DefaultSnippetVisibility   *int               `url:"default_snippet_visibility,omitempty" json:"default_snippet_visibility,omitempty"`
-	RestrictedSignupDomains    []string          `url:"restricted_signup_domains,omitempty" json:"restricted_signup_domains,omitempty"`
-	UserOauthApplications      *bool              `url:"user_oauth_applications,omitempty" json:"user_oauth_applications,omitempty"`
-	AfterSignOutPath           *string            `url:"after_sign_out_path,omitempty" json:"after_sign_out_path,omitempty"`
+	DefaultProjectsLimit       *int                   `url:"default_projects_limit,omitempty" json:"default_projects_limit,omitempty"`
+	SignupEnabled              *bool                  `url:"signup_enabled,omitempty" json:"signup_enabled,omitempty"`
+	SigninEnabled              *bool                  `url:"signin_enabled,omitempty" json:"signin_enabled,omitempty"`
+	GravatarEnabled            *bool                  `url:"gravatar_enabled,omitempty" json:"gravatar_enabled,omitempty"`
+	SignInText                 *string                `url:"sign_in_text,omitempty" json:"sign_in_text,omitempty"`
+	HomePageURL                *string                `url:"home_page_url,omitempty" json:"home_page_url,omitempty"`
+	DefaultBranchProtection    *int                   `url:"default_branch_protection,omitempty" json:"default_branch_protection,omitempty"`
+	TwitterSharingEnabled      *bool                  `url:"twitter_sharing_enabled,omitempty" json:"twitter_sharing_enabled,omitempty"`
+	RestrictedVisibilityLevels []VisibilityLevelValue `url:"restricted_visibility_levels,omitempty" json:"restricted_visibility_levels,omitempty"`
+	MaxAttachmentSize          *int                   `url:"max_attachment_size,omitempty" json:"max_attachment_size,omitempty"`
+	SessionExpireDelay         *int                   `url:"session_expire_delay,omitempty" json:"session_expire_delay,omitempty"`
+	DefaultProjectVisibility   *int                   `url:"default_project_visibility,omitempty" json:"default_project_visibility,omitempty"`
+	DefaultSnippetVisibility   *int                   `url:"default_snippet_visibility,omitempty" json:"default_snippet_visibility,omitempty"`
+	RestrictedSignupDomains    []string               `url:"restricted_signup_domains,omitempty" json:"restricted_signup_domains,omitempty"`
+	UserOauthApplications      *bool                  `url:"user_oauth_applications,omitempty" json:"user_oauth_applications,omitempty"`
+	AfterSignOutPath           *string                `url:"after_sign_out_path,omitempty" json:"after_sign_out_path,omitempty"`
 }
 
 // UpdateSettings updates the application settings.

--- a/system_hooks.go
+++ b/system_hooks.go
@@ -66,7 +66,7 @@ func (s *SystemHooksService) ListHooks() ([]*Hook, *Response, error) {
 // GitLab API docs:
 // http://doc.gitlab.com/ce/api/system_hooks.html#add-new-system-hook-hook
 type AddHookOptions struct {
-	URL string `url:"url,omitempty" json:"url,omitempty"`
+	URL *string `url:"url,omitempty" json:"url,omitempty"`
 }
 
 // AddHook adds a new system hook hook.

--- a/users.go
+++ b/users.go
@@ -70,8 +70,8 @@ type UserIdentity struct {
 // GitLab API docs: http://doc.gitlab.com/ce/api/users.html#list-users
 type ListUsersOptions struct {
 	ListOptions
-	Active bool   `url:"active,omitempty" json:"active,omitempty"`
-	Search string `url:"search,omitempty" json:"search,omitempty"`
+	Active *bool   `url:"active,omitempty" json:"active,omitempty"`
+	Search *string `url:"search,omitempty" json:"search,omitempty"`
 }
 
 // ListUsers gets a list of users.
@@ -116,21 +116,21 @@ func (s *UsersService) GetUser(user int) (*User, *Response, error) {
 //
 // GitLab API docs: http://doc.gitlab.com/ce/api/users.html#user-creation
 type CreateUserOptions struct {
-	Email          string `url:"email,omitempty" json:"email,omitempty"`
-	Password       string `url:"password,omitempty" json:"password,omitempty"`
-	Username       string `url:"username,omitempty" json:"username,omitempty"`
-	Name           string `url:"name,omitempty" json:"name,omitempty"`
-	Skype          string `url:"skype,omitempty" json:"skype,omitempty"`
-	Linkedin       string `url:"linkedin,omitempty" json:"linkedin,omitempty"`
-	Twitter        string `url:"twitter,omitempty" json:"twitter,omitempty"`
-	WebsiteURL     string `url:"website_url,omitempty" json:"website_url,omitempty"`
-	ProjectsLimit  int    `url:"projects_limit,omitempty" json:"projects_limit,omitempty"`
-	ExternUID      string `url:"extern_uid,omitempty" json:"extern_uid,omitempty"`
-	Provider       string `url:"provider,omitempty" json:"provider,omitempty"`
-	Bio            string `url:"bio,omitempty" json:"bio,omitempty"`
-	Admin          bool   `url:"admin,omitempty" json:"admin,omitempty"`
-	CanCreateGroup bool   `url:"can_create_group,omitempty" json:"can_create_group,omitempty"`
-	Confirm        bool   `url:"confirm,omitempty" json:"confirm,omitempty"`
+	Email          *string `url:"email,omitempty" json:"email,omitempty"`
+	Password       *string `url:"password,omitempty" json:"password,omitempty"`
+	Username       *string `url:"username,omitempty" json:"username,omitempty"`
+	Name           *string `url:"name,omitempty" json:"name,omitempty"`
+	Skype          *string `url:"skype,omitempty" json:"skype,omitempty"`
+	Linkedin       *string `url:"linkedin,omitempty" json:"linkedin,omitempty"`
+	Twitter        *string `url:"twitter,omitempty" json:"twitter,omitempty"`
+	WebsiteURL     *string `url:"website_url,omitempty" json:"website_url,omitempty"`
+	ProjectsLimit  *int    `url:"projects_limit,omitempty" json:"projects_limit,omitempty"`
+	ExternUID      *string `url:"extern_uid,omitempty" json:"extern_uid,omitempty"`
+	Provider       *string `url:"provider,omitempty" json:"provider,omitempty"`
+	Bio            *string `url:"bio,omitempty" json:"bio,omitempty"`
+	Admin          *bool   `url:"admin,omitempty" json:"admin,omitempty"`
+	CanCreateGroup *bool   `url:"can_create_group,omitempty" json:"can_create_group,omitempty"`
+	Confirm        *bool   `url:"confirm,omitempty" json:"confirm,omitempty"`
 }
 
 // CreateUser creates a new user. Note only administrators can create new users.
@@ -155,20 +155,20 @@ func (s *UsersService) CreateUser(opt *CreateUserOptions) (*User, *Response, err
 //
 // GitLab API docs: http://doc.gitlab.com/ce/api/users.html#user-modification
 type ModifyUserOptions struct {
-	Email          string `url:"email,omitempty" json:"email,omitempty"`
-	Password       string `url:"password,omitempty" json:"password,omitempty"`
-	Username       string `url:"username,omitempty" json:"username,omitempty"`
-	Name           string `url:"name,omitempty" json:"name,omitempty"`
-	Skype          string `url:"skype,omitempty" json:"skype,omitempty"`
-	Linkedin       string `url:"linkedin,omitempty" json:"linkedin,omitempty"`
-	Twitter        string `url:"twitter,omitempty" json:"twitter,omitempty"`
-	WebsiteURL     string `url:"website_url,omitempty" json:"website_url,omitempty"`
-	ProjectsLimit  int    `url:"projects_limit,omitempty" json:"projects_limit,omitempty"`
-	ExternUID      string `url:"extern_uid,omitempty" json:"extern_uid,omitempty"`
-	Provider       string `url:"provider,omitempty" json:"provider,omitempty"`
-	Bio            string `url:"bio,omitempty" json:"bio,omitempty"`
-	Admin          bool   `url:"admin,omitempty" json:"admin,omitempty"`
-	CanCreateGroup bool   `url:"can_create_group,omitempty" json:"can_create_group,omitempty"`
+	Email          *string `url:"email,omitempty" json:"email,omitempty"`
+	Password       *string `url:"password,omitempty" json:"password,omitempty"`
+	Username       *string `url:"username,omitempty" json:"username,omitempty"`
+	Name           *string `url:"name,omitempty" json:"name,omitempty"`
+	Skype          *string `url:"skype,omitempty" json:"skype,omitempty"`
+	Linkedin       *string `url:"linkedin,omitempty" json:"linkedin,omitempty"`
+	Twitter        *string `url:"twitter,omitempty" json:"twitter,omitempty"`
+	WebsiteURL     *string `url:"website_url,omitempty" json:"website_url,omitempty"`
+	ProjectsLimit  *int    `url:"projects_limit,omitempty" json:"projects_limit,omitempty"`
+	ExternUID      *string `url:"extern_uid,omitempty" json:"extern_uid,omitempty"`
+	Provider       *string `url:"provider,omitempty" json:"provider,omitempty"`
+	Bio            *string `url:"bio,omitempty" json:"bio,omitempty"`
+	Admin          *bool   `url:"admin,omitempty" json:"admin,omitempty"`
+	CanCreateGroup *bool   `url:"can_create_group,omitempty" json:"can_create_group,omitempty"`
 }
 
 // ModifyUser modifies an existing user. Only administrators can change attributes
@@ -307,8 +307,8 @@ func (s *UsersService) GetSSHKey(kid int) (*SSHKey, *Response, error) {
 //
 // GitLab API docs: http://doc.gitlab.com/ce/api/projects.html#add-ssh-key
 type AddSSHKeyOptions struct {
-	Title string `url:"title,omitempty" json:"title,omitempty"`
-	Key   string `url:"key,omitempty" json:"key,omitempty"`
+	Title *string `url:"title,omitempty" json:"title,omitempty"`
+	Key   *string `url:"key,omitempty" json:"key,omitempty"`
 }
 
 // AddSSHKey creates a new key owned by the currently authenticated user.


### PR DESCRIPTION
Hi @svanharmelen,

Since I would very much like to be able to have 'false' being passed to some Gitlab requests, I've gone ahead and changed all the relevant *Options struct fields to pointers. Hopefully, this is enough to close #29.

Let me know if that works for you. I'm not completely satisfied with the new *LevelPtr funcs, but not adding them makes for very long lines in the code using it.

Cheers,

Clément