### PR TITLE
Add username parameter to user search

### DIFF
--- a/users.go
+++ b/users.go
@@ -71,8 +71,9 @@ type UserIdentity struct {
 // GitLab API docs: http://doc.gitlab.com/ce/api/users.html#list-users
 type ListUsersOptions struct {
 	ListOptions
-	Active *bool   `url:"active,omitempty" json:"active,omitempty"`
-	Search *string `url:"search,omitempty" json:"search,omitempty"`
+	Active   *bool   `url:"active,omitempty" json:"active,omitempty"`
+	Search   *string `url:"search,omitempty" json:"search,omitempty"`
+	Username *string `url:"username,omitempty" json:"username,omitempty"`
 }
 
 // ListUsers gets a list of users.


### PR DESCRIPTION
Check out http://docs.gitlab.com/ce/api/users.html

```
You can search for users by email or username with: /users?search=John

In addition, you can lookup users by username:

GET /users?username=:username
```