### PR TITLE
Add params on list repo commits

### DIFF
--- a/commits.go
+++ b/commits.go
@@ -55,7 +55,9 @@ func (c Commit) String() string {
 // GitLab API docs: http://doc.gitlab.com/ce/api/commits.html#list-commits
 type ListCommitsOptions struct {
 	ListOptions
-	RefName *string `url:"ref_name,omitempty" json:"ref_name,omitempty"`
+	RefName *string   `url:"ref_name,omitempty" json:"ref_name,omitempty"`
+	Since   time.Time `url:"since,omitempty" json:"since,omitempty"`
+	Until   time.Time `url:"until,omitempty" json:"until,omitempty"`
 }
 
 // ListCommits gets a list of repository commits in a project.

--- a/commits.go
+++ b/commits.go
@@ -52,7 +52,7 @@ func (c Commit) String() string {
 
 // ListCommitsOptions represents the available ListCommits() options.
 //
-// GitLab API docs: http://doc.gitlab.com/ce/api/commits.html#list-commits
+// GitLab API docs: https://docs.gitlab.com/ce/api/commits.html#list-repository-commits
 type ListCommitsOptions struct {
 	ListOptions
 	RefName *string   `url:"ref_name,omitempty" json:"ref_name,omitempty"`


### PR DESCRIPTION
I added `since` and `until` parameters on [List repository commits](https://docs.gitlab.com/ce/api/commits.html#list-repository-commits "GitLab Documentation"), and updated URL on doc comment.