### PR TITLE
Add parameters Visibility Simple to ListProjectsOptions struct

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -138,6 +138,7 @@ type ListProjectsOptions struct {
 	Sort           *string `url:"sort,omitempty" json:"sort,omitempty"`
 	Search         *string `url:"search,omitempty" json:"search,omitempty"`
 	CIEnabledFirst *bool   `url:"ci_enabled_first,omitempty" json:"ci_enabled_first,omitempty"`
+	Simple         *bool   `url:"simple,omitempty" json:"simple,omitempty"`
 }
 
 // ListProjects gets a list of projects accessible by the authenticated user.

--- a/projects.go
+++ b/projects.go
@@ -139,6 +139,7 @@ type ListProjectsOptions struct {
 	Search         *string `url:"search,omitempty" json:"search,omitempty"`
 	CIEnabledFirst *bool   `url:"ci_enabled_first,omitempty" json:"ci_enabled_first,omitempty"`
 	Simple         *bool   `url:"simple,omitempty" json:"simple,omitempty"`
+	Visibility     *string `url:"visibility,omitempty" json:"visibility,omitempty"`
 }
 
 // ListProjects gets a list of projects accessible by the authenticated user.

--- a/projects_test.go
+++ b/projects_test.go
@@ -22,11 +22,12 @@ func TestListProjects(t *testing.T) {
 			"search":           "query",
 			"ci_enabled_first": "true",
 			"simple":           "true",
+			"visibility":       "public",
 		})
 		fmt.Fprint(w, `[{"id":1},{"id":2}]`)
 	})
 
-	opt := &ListProjectsOptions{ListOptions{2, 3}, Bool(true), String("name"), String("asc"), String("query"), Bool(true), Bool(true)}
+	opt := &ListProjectsOptions{ListOptions{2, 3}, Bool(true), String("name"), String("asc"), String("query"), Bool(true), Bool(true), String("public")}
 	projects, _, err := client.Projects.ListProjects(opt)
 
 	if err != nil {
@@ -54,11 +55,12 @@ func TestListOwnedProjects(t *testing.T) {
 			"search":           "query",
 			"ci_enabled_first": "true",
 			"simple":           "true",
+			"visibility":       "public",
 		})
 		fmt.Fprint(w, `[{"id":1},{"id":2}]`)
 	})
 
-	opt := &ListProjectsOptions{ListOptions{2, 3}, Bool(true), String("name"), String("asc"), String("query"), Bool(true), Bool(true)}
+	opt := &ListProjectsOptions{ListOptions{2, 3}, Bool(true), String("name"), String("asc"), String("query"), Bool(true), Bool(true), String("public")}
 	projects, _, err := client.Projects.ListOwnedProjects(opt)
 
 	if err != nil {
@@ -86,11 +88,12 @@ func TestListStarredProjects(t *testing.T) {
 			"search":           "query",
 			"ci_enabled_first": "true",
 			"simple":           "true",
+			"visibility":       "public",
 		})
 		fmt.Fprint(w, `[{"id":1},{"id":2}]`)
 	})
 
-	opt := &ListProjectsOptions{ListOptions{2, 3}, Bool(true), String("name"), String("asc"), String("query"), Bool(true), Bool(true)}
+	opt := &ListProjectsOptions{ListOptions{2, 3}, Bool(true), String("name"), String("asc"), String("query"), Bool(true), Bool(true), String("public")}
 	projects, _, err := client.Projects.ListStarredProjects(opt)
 
 	if err != nil {
@@ -118,11 +121,12 @@ func TestListAllProjects(t *testing.T) {
 			"search":           "query",
 			"ci_enabled_first": "true",
 			"simple":           "true",
+			"visibility":       "public",
 		})
 		fmt.Fprint(w, `[{"id":1},{"id":2}]`)
 	})
 
-	opt := &ListProjectsOptions{ListOptions{2, 3}, Bool(true), String("name"), String("asc"), String("query"), Bool(true), Bool(true)}
+	opt := &ListProjectsOptions{ListOptions{2, 3}, Bool(true), String("name"), String("asc"), String("query"), Bool(true), Bool(true), String("public")}
 	projects, _, err := client.Projects.ListAllProjects(opt)
 
 	if err != nil {

--- a/projects_test.go
+++ b/projects_test.go
@@ -21,11 +21,12 @@ func TestListProjects(t *testing.T) {
 			"sort":             "asc",
 			"search":           "query",
 			"ci_enabled_first": "true",
+			"simple":           "true",
 		})
 		fmt.Fprint(w, `[{"id":1},{"id":2}]`)
 	})
 
-	opt := &ListProjectsOptions{ListOptions{2, 3}, Bool(true), String("name"), String("asc"), String("query"), Bool(true)}
+	opt := &ListProjectsOptions{ListOptions{2, 3}, Bool(true), String("name"), String("asc"), String("query"), Bool(true), Bool(true)}
 	projects, _, err := client.Projects.ListProjects(opt)
 
 	if err != nil {
@@ -52,11 +53,12 @@ func TestListOwnedProjects(t *testing.T) {
 			"sort":             "asc",
 			"search":           "query",
 			"ci_enabled_first": "true",
+			"simple":           "true",
 		})
 		fmt.Fprint(w, `[{"id":1},{"id":2}]`)
 	})
 
-	opt := &ListProjectsOptions{ListOptions{2, 3}, Bool(true), String("name"), String("asc"), String("query"), Bool(true)}
+	opt := &ListProjectsOptions{ListOptions{2, 3}, Bool(true), String("name"), String("asc"), String("query"), Bool(true), Bool(true)}
 	projects, _, err := client.Projects.ListOwnedProjects(opt)
 
 	if err != nil {
@@ -83,11 +85,12 @@ func TestListStarredProjects(t *testing.T) {
 			"sort":             "asc",
 			"search":           "query",
 			"ci_enabled_first": "true",
+			"simple":           "true",
 		})
 		fmt.Fprint(w, `[{"id":1},{"id":2}]`)
 	})
 
-	opt := &ListProjectsOptions{ListOptions{2, 3}, Bool(true), String("name"), String("asc"), String("query"), Bool(true)}
+	opt := &ListProjectsOptions{ListOptions{2, 3}, Bool(true), String("name"), String("asc"), String("query"), Bool(true), Bool(true)}
 	projects, _, err := client.Projects.ListStarredProjects(opt)
 
 	if err != nil {
@@ -114,11 +117,12 @@ func TestListAllProjects(t *testing.T) {
 			"sort":             "asc",
 			"search":           "query",
 			"ci_enabled_first": "true",
+			"simple":           "true",
 		})
 		fmt.Fprint(w, `[{"id":1},{"id":2}]`)
 	})
 
-	opt := &ListProjectsOptions{ListOptions{2, 3}, Bool(true), String("name"), String("asc"), String("query"), Bool(true)}
+	opt := &ListProjectsOptions{ListOptions{2, 3}, Bool(true), String("name"), String("asc"), String("query"), Bool(true), Bool(true)}
 	projects, _, err := client.Projects.ListAllProjects(opt)
 
 	if err != nil {


### PR DESCRIPTION
```go
ListProjectsOptions{
  // Limit by visibility public, internal or private
  Simple         *bool   `url:"simple,omitempty" json:"simple,omitempty"`
  // Enables you to query list of projects with minimal information much faster.
  Visibility     *string `url:"visibility,omitempty" json:"visibility,omitempty"`
}
```

Fields returned with Simple:
- ID 
- HTTPURLToRepo
- WebURL
- Name
- NameWithNameSpace
- Path
- PathWithNamesPace

