### PR TITLE
Update GetMergeRequestCommits URL to match the gitlab API spec

### DIFF
--- a/merge_requests.go
+++ b/merge_requests.go
@@ -173,7 +173,7 @@ func (s *MergeRequestsService) GetMergeRequestCommits(pid interface{}, mergeRequ
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/merge_request/%d/commits", url.QueryEscape(project), mergeRequest)
+	u := fmt.Sprintf("projects/%s/merge_requests/%d/commits", url.QueryEscape(project), mergeRequest)
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {


### PR DESCRIPTION
I noticed the URL was wrong for this method according to the spec:

Repo: https://github.com/xanzy/go-gitlab/blob/master/merge_requests.go#L176
Spec: https://docs.gitlab.com/ce/api/merge_requests.html#get-single-mr-commits