### PR TITLE
Update MergeRequest URLs to match spec

### DIFF
--- a/merge_requests.go
+++ b/merge_requests.go
@@ -148,7 +148,7 @@ func (s *MergeRequestsService) GetMergeRequest(pid interface{}, mergeRequest int
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/merge_request/%d", url.QueryEscape(project), mergeRequest)
+	u := fmt.Sprintf("projects/%s/merge_requests/%d", url.QueryEscape(project), mergeRequest)
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -199,7 +199,7 @@ func (s *MergeRequestsService) GetMergeRequestChanges(pid interface{}, mergeRequ
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/merge_request/%d/changes", url.QueryEscape(project), mergeRequest)
+	u := fmt.Sprintf("projects/%s/merge_requests/%d/changes", url.QueryEscape(project), mergeRequest)
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -276,7 +276,7 @@ func (s *MergeRequestsService) UpdateMergeRequest(pid interface{}, mergeRequest 
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/merge_request/%d", url.QueryEscape(project), mergeRequest)
+	u := fmt.Sprintf("projects/%s/merge_requests/%d", url.QueryEscape(project), mergeRequest)
 
 	req, err := s.client.NewRequest("PUT", u, opt)
 	if err != nil {
@@ -316,7 +316,7 @@ func (s *MergeRequestsService) AcceptMergeRequest(pid interface{}, mergeRequest 
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/merge_request/%d/merge", url.QueryEscape(project), mergeRequest)
+	u := fmt.Sprintf("projects/%s/merge_requests/%d/merge", url.QueryEscape(project), mergeRequest)
 
 	req, err := s.client.NewRequest("PUT", u, opt)
 	if err != nil {


### PR DESCRIPTION
Updated:
- GetMergeRequest
Repo: https://github.com/xanzy/go-gitlab/blob/master/merge_requests.go#L151
Spec: https://docs.gitlab.com/ce/api/merge_requests.html#get-single-mr
- GetMergeRequestChanges
Repo: https://github.com/xanzy/go-gitlab/blob/master/merge_requests.go#L202
Spec: https://docs.gitlab.com/ce/api/merge_requests.html#get-single-mr-changes
- UpdateMergeRequest
Repo: https://github.com/xanzy/go-gitlab/blob/master/merge_requests.go#L279
Spec: https://docs.gitlab.com/ce/api/merge_requests.html#update-mr
- AcceptMergeRequest
Repo: https://github.com/xanzy/go-gitlab/blob/master/merge_requests.go#L319
Spec: https://docs.gitlab.com/ce/api/merge_requests.html#accept-mr

I'm trying to use the `GetMergeRequest` function but I noticed the others were also not correct so I went ahead and fixed them as well. 

I did not change 2 functions: `GetMergeRequestComments` & `PostMergeRequestComment` because I did not find them in the spec (https://docs.gitlab.com/ce/api/merge_requests.html) but I also did not feel comfortable removing them.