### PR TITLE
Rename SudoUser and SudoFunc to be more idomatic

### DIFF
--- a/branches.go
+++ b/branches.go
@@ -47,14 +47,14 @@ func (b Branch) String() string {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/branches.html#list-repository-branches
-func (s *BranchesService) ListBranches(pid interface{}, sudoFunc ...SudoFunc) ([]*Branch, *Response, error) {
+func (s *BranchesService) ListBranches(pid interface{}, options ...OptionFunc) ([]*Branch, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/repository/branches", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("GET", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -72,14 +72,14 @@ func (s *BranchesService) ListBranches(pid interface{}, sudoFunc ...SudoFunc) ([
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/branches.html#get-single-repository-branch
-func (s *BranchesService) GetBranch(pid interface{}, branch string, sudoFunc ...SudoFunc) (*Branch, *Response, error) {
+func (s *BranchesService) GetBranch(pid interface{}, branch string, options ...OptionFunc) (*Branch, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/repository/branches/%s", url.QueryEscape(project), branch)
 
-	req, err := s.client.NewRequest("GET", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -99,14 +99,14 @@ func (s *BranchesService) GetBranch(pid interface{}, branch string, sudoFunc ...
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/branches.html#protect-repository-branch
-func (s *BranchesService) ProtectBranch(pid interface{}, branch string, sudoFunc ...SudoFunc) (*Branch, *Response, error) {
+func (s *BranchesService) ProtectBranch(pid interface{}, branch string, options ...OptionFunc) (*Branch, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/repository/branches/%s/protect", url.QueryEscape(project), branch)
 
-	req, err := s.client.NewRequest("PUT", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("PUT", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -126,14 +126,14 @@ func (s *BranchesService) ProtectBranch(pid interface{}, branch string, sudoFunc
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/branches.html#unprotect-repository-branch
-func (s *BranchesService) UnprotectBranch(pid interface{}, branch string, sudoFunc ...SudoFunc) (*Branch, *Response, error) {
+func (s *BranchesService) UnprotectBranch(pid interface{}, branch string, options ...OptionFunc) (*Branch, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/repository/branches/%s/unprotect", url.QueryEscape(project), branch)
 
-	req, err := s.client.NewRequest("PUT", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("PUT", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -160,14 +160,14 @@ type CreateBranchOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/branches.html#create-repository-branch
-func (s *BranchesService) CreateBranch(pid interface{}, opt *CreateBranchOptions, sudoFunc ...SudoFunc) (*Branch, *Response, error) {
+func (s *BranchesService) CreateBranch(pid interface{}, opt *CreateBranchOptions, options ...OptionFunc) (*Branch, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/repository/branches", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("POST", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("POST", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -185,14 +185,14 @@ func (s *BranchesService) CreateBranch(pid interface{}, opt *CreateBranchOptions
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/branches.html#delete-repository-branch
-func (s *BranchesService) DeleteBranch(pid interface{}, branch string, sudoFunc ...SudoFunc) (*Response, error) {
+func (s *BranchesService) DeleteBranch(pid interface{}, branch string, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, err
 	}
 	u := fmt.Sprintf("projects/%s/repository/branches/%s", url.QueryEscape(project), branch)
 
-	req, err := s.client.NewRequest("DELETE", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
 	if err != nil {
 		return nil, err
 	}

--- a/build_variables.go
+++ b/build_variables.go
@@ -29,14 +29,14 @@ func (v BuildVariable) String() string {
 //
 // Gitlab API Docs:
 // https://docs.gitlab.com/ce/api/build_variables.html#list-project-variables
-func (s *BuildVariablesService) ListBuildVariables(pid interface{}, sudoFunc ...SudoFunc) ([]*BuildVariable, *Response, error) {
+func (s *BuildVariablesService) ListBuildVariables(pid interface{}, options ...OptionFunc) ([]*BuildVariable, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/variables", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("GET", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -54,14 +54,14 @@ func (s *BuildVariablesService) ListBuildVariables(pid interface{}, sudoFunc ...
 //
 // Gitlab API Docs:
 // https://docs.gitlab.com/ce/api/build_variables.html#show-variable-details
-func (s *BuildVariablesService) GetBuildVariable(pid interface{}, key string, sudoFunc ...SudoFunc) (*BuildVariable, *Response, error) {
+func (s *BuildVariablesService) GetBuildVariable(pid interface{}, key string, options ...OptionFunc) (*BuildVariable, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/variables/%s", url.QueryEscape(project), key)
 
-	req, err := s.client.NewRequest("GET", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -79,14 +79,14 @@ func (s *BuildVariablesService) GetBuildVariable(pid interface{}, key string, su
 //
 // Gitlab API Docs:
 // https://docs.gitlab.com/ce/api/build_variables.html#create-variable
-func (s *BuildVariablesService) CreateBuildVariable(pid interface{}, key, value string, sudoFunc ...SudoFunc) (*BuildVariable, *Response, error) {
+func (s *BuildVariablesService) CreateBuildVariable(pid interface{}, key, value string, options ...OptionFunc) (*BuildVariable, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/variables", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("POST", u, BuildVariable{key, value}, sudoFunc)
+	req, err := s.client.NewRequest("POST", u, BuildVariable{key, value}, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -105,14 +105,14 @@ func (s *BuildVariablesService) CreateBuildVariable(pid interface{}, key, value 
 //
 // Gitlab API Docs:
 // https://docs.gitlab.com/ce/api/build_variables.html#update-variable
-func (s *BuildVariablesService) UpdateBuildVariable(pid interface{}, key, value string, sudoFunc ...SudoFunc) (*BuildVariable, *Response, error) {
+func (s *BuildVariablesService) UpdateBuildVariable(pid interface{}, key, value string, options ...OptionFunc) (*BuildVariable, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/variables/%s", url.QueryEscape(project), key)
 
-	req, err := s.client.NewRequest("PUT", u, BuildVariable{key, value}, sudoFunc)
+	req, err := s.client.NewRequest("PUT", u, BuildVariable{key, value}, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -130,14 +130,14 @@ func (s *BuildVariablesService) UpdateBuildVariable(pid interface{}, key, value 
 //
 // Gitlab API Docs:
 // https://docs.gitlab.com/ce/api/build_variables.html#remove-variable
-func (s *BuildVariablesService) RemoveBuildVariable(pid interface{}, key string, sudoFunc ...SudoFunc) (*Response, error) {
+func (s *BuildVariablesService) RemoveBuildVariable(pid interface{}, key string, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, err
 	}
 	u := fmt.Sprintf("projects/%s/variables/%s", url.QueryEscape(project), key)
 
-	req, err := s.client.NewRequest("DELETE", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
 	if err != nil {
 		return nil, err
 	}

--- a/builds.go
+++ b/builds.go
@@ -73,14 +73,14 @@ type Build struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/builds.html#list-project-builds
-func (s *BuildsService) ListProjectBuilds(pid interface{}, opts *ListBuildsOptions, sudoFunc ...SudoFunc) ([]Build, *Response, error) {
+func (s *BuildsService) ListProjectBuilds(pid interface{}, opts *ListBuildsOptions, options ...OptionFunc) ([]Build, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/builds", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("GET", u, opts, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, opts, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -99,14 +99,14 @@ func (s *BuildsService) ListProjectBuilds(pid interface{}, opts *ListBuildsOptio
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/builds.html#list-commit-builds
-func (s *BuildsService) ListCommitBuilds(pid interface{}, sha string, opts *ListBuildsOptions, sudoFunc ...SudoFunc) ([]Build, *Response, error) {
+func (s *BuildsService) ListCommitBuilds(pid interface{}, sha string, opts *ListBuildsOptions, options ...OptionFunc) ([]Build, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/repository/commits/%s/builds", project, sha)
 
-	req, err := s.client.NewRequest("GET", u, opts, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, opts, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -124,14 +124,14 @@ func (s *BuildsService) ListCommitBuilds(pid interface{}, sha string, opts *List
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/builds.html#get-a-single-build
-func (s *BuildsService) GetBuild(pid interface{}, buildID int, sudoFunc ...SudoFunc) (*Build, *Response, error) {
+func (s *BuildsService) GetBuild(pid interface{}, buildID int, options ...OptionFunc) (*Build, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/builds/%d", project, buildID)
 
-	req, err := s.client.NewRequest("GET", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -149,14 +149,14 @@ func (s *BuildsService) GetBuild(pid interface{}, buildID int, sudoFunc ...SudoF
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/builds.html#get-build-artifacts
-func (s *BuildsService) GetBuildArtifacts(pid interface{}, buildID int, sudoFunc ...SudoFunc) (io.Reader, *Response, error) {
+func (s *BuildsService) GetBuildArtifacts(pid interface{}, buildID int, options ...OptionFunc) (io.Reader, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/builds/%d/artifacts", project, buildID)
 
-	req, err := s.client.NewRequest("GET", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -175,14 +175,14 @@ func (s *BuildsService) GetBuildArtifacts(pid interface{}, buildID int, sudoFunc
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/builds.html#download-the-artifacts-file
-func (s *BuildsService) DownloadArtifactsFile(pid interface{}, refName string, job string, sudoFunc ...SudoFunc) (io.Reader, *Response, error) {
+func (s *BuildsService) DownloadArtifactsFile(pid interface{}, refName string, job string, options ...OptionFunc) (io.Reader, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/builds/artifacts/%s/download?job=%s", project, refName, job)
 
-	req, err := s.client.NewRequest("GET", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -200,14 +200,14 @@ func (s *BuildsService) DownloadArtifactsFile(pid interface{}, refName string, j
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/builds.html#get-a-trace-file
-func (s *BuildsService) GetTraceFile(pid interface{}, buildID int, sudoFunc ...SudoFunc) (io.Reader, *Response, error) {
+func (s *BuildsService) GetTraceFile(pid interface{}, buildID int, options ...OptionFunc) (io.Reader, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/builds/%d/trace", project, buildID)
 
-	req, err := s.client.NewRequest("GET", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -225,14 +225,14 @@ func (s *BuildsService) GetTraceFile(pid interface{}, buildID int, sudoFunc ...S
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/builds.html#cancel-a-build
-func (s *BuildsService) CancelBuild(pid interface{}, buildID int, sudoFunc ...SudoFunc) (*Build, *Response, error) {
+func (s *BuildsService) CancelBuild(pid interface{}, buildID int, options ...OptionFunc) (*Build, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/builds/%d/cancel", project, buildID)
 
-	req, err := s.client.NewRequest("POST", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("POST", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -250,14 +250,14 @@ func (s *BuildsService) CancelBuild(pid interface{}, buildID int, sudoFunc ...Su
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/builds.html#retry-a-build
-func (s *BuildsService) RetryBuild(pid interface{}, buildID int, sudoFunc ...SudoFunc) (*Build, *Response, error) {
+func (s *BuildsService) RetryBuild(pid interface{}, buildID int, options ...OptionFunc) (*Build, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/builds/%d/retry", project, buildID)
 
-	req, err := s.client.NewRequest("POST", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("POST", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -276,14 +276,14 @@ func (s *BuildsService) RetryBuild(pid interface{}, buildID int, sudoFunc ...Sud
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/builds.html#erase-a-build
-func (s *BuildsService) EraseBuild(pid interface{}, buildID int, sudoFunc ...SudoFunc) (*Build, *Response, error) {
+func (s *BuildsService) EraseBuild(pid interface{}, buildID int, options ...OptionFunc) (*Build, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/builds/%d/erase", project, buildID)
 
-	req, err := s.client.NewRequest("POST", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("POST", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -302,14 +302,14 @@ func (s *BuildsService) EraseBuild(pid interface{}, buildID int, sudoFunc ...Sud
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/builds.html#keep-artifacts
-func (s *BuildsService) KeepArtifacts(pid interface{}, buildID int, sudoFunc ...SudoFunc) (*Build, *Response, error) {
+func (s *BuildsService) KeepArtifacts(pid interface{}, buildID int, options ...OptionFunc) (*Build, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/builds/%d/artifacts/keep", project, buildID)
 
-	req, err := s.client.NewRequest("POST", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("POST", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -327,14 +327,14 @@ func (s *BuildsService) KeepArtifacts(pid interface{}, buildID int, sudoFunc ...
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/builds.html#play-a-build
-func (s *BuildsService) PlayBuild(pid interface{}, buildID int, sudoFunc ...SudoFunc) (*Build, *Response, error) {
+func (s *BuildsService) PlayBuild(pid interface{}, buildID int, options ...OptionFunc) (*Build, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/builds/%d/play", project, buildID)
 
-	req, err := s.client.NewRequest("POST", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("POST", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/commits.go
+++ b/commits.go
@@ -63,14 +63,14 @@ type ListCommitsOptions struct {
 // ListCommits gets a list of repository commits in a project.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/commits.html#list-commits
-func (s *CommitsService) ListCommits(pid interface{}, opt *ListCommitsOptions, sudoFunc ...SudoFunc) ([]*Commit, *Response, error) {
+func (s *CommitsService) ListCommits(pid interface{}, opt *ListCommitsOptions, options ...OptionFunc) ([]*Commit, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/repository/commits", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("GET", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -88,14 +88,14 @@ func (s *CommitsService) ListCommits(pid interface{}, opt *ListCommitsOptions, s
 // branch or tag.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/commits.html#get-a-single-commit
-func (s *CommitsService) GetCommit(pid interface{}, sha string, sudoFunc ...SudoFunc) (*Commit, *Response, error) {
+func (s *CommitsService) GetCommit(pid interface{}, sha string, options ...OptionFunc) (*Commit, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/repository/commits/%s", url.QueryEscape(project), sha)
 
-	req, err := s.client.NewRequest("GET", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -131,14 +131,14 @@ func (d Diff) String() string {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/commits.html#get-the-diff-of-a-commit
-func (s *CommitsService) GetCommitDiff(pid interface{}, sha string, sudoFunc ...SudoFunc) ([]*Diff, *Response, error) {
+func (s *CommitsService) GetCommitDiff(pid interface{}, sha string, options ...OptionFunc) ([]*Diff, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/repository/commits/%s/diff", url.QueryEscape(project), sha)
 
-	req, err := s.client.NewRequest("GET", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -182,14 +182,14 @@ func (c CommitComment) String() string {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/commits.html#get-the-comments-of-a-commit
-func (s *CommitsService) GetCommitComments(pid interface{}, sha string, sudoFunc ...SudoFunc) ([]*CommitComment, *Response, error) {
+func (s *CommitsService) GetCommitComments(pid interface{}, sha string, options ...OptionFunc) ([]*CommitComment, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/repository/commits/%s/comments", url.QueryEscape(project), sha)
 
-	req, err := s.client.NewRequest("GET", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -221,14 +221,14 @@ type PostCommitCommentOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/commits.html#post-comment-to-commit
-func (s *CommitsService) PostCommitComment(pid interface{}, sha string, opt *PostCommitCommentOptions, sudoFunc ...SudoFunc) (*CommitComment, *Response, error) {
+func (s *CommitsService) PostCommitComment(pid interface{}, sha string, opt *PostCommitCommentOptions, options ...OptionFunc) (*CommitComment, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/repository/commits/%s/comments", url.QueryEscape(project), sha)
 
-	req, err := s.client.NewRequest("POST", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("POST", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -272,14 +272,14 @@ type CommitStatus struct {
 // GetCommitStatuses gets the statuses of a commit in a project.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/commits.html#get-the-status-of-a-commit
-func (s *CommitsService) GetCommitStatuses(pid interface{}, sha string, opt *GetCommitStatusesOptions, sudoFunc ...SudoFunc) ([]*CommitStatus, *Response, error) {
+func (s *CommitsService) GetCommitStatuses(pid interface{}, sha string, opt *GetCommitStatusesOptions, options ...OptionFunc) ([]*CommitStatus, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/repository/commits/%s/statuses", url.QueryEscape(project), sha)
 
-	req, err := s.client.NewRequest("GET", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -320,14 +320,14 @@ const (
 // SetCommitStatus sets the status of a commit in a project.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/commits.html#post-the-status-to-commit
-func (s *CommitsService) SetCommitStatus(pid interface{}, sha string, opt *SetCommitStatusOptions, sudoFunc ...SudoFunc) (*CommitStatus, *Response, error) {
+func (s *CommitsService) SetCommitStatus(pid interface{}, sha string, opt *SetCommitStatusOptions, options ...OptionFunc) (*CommitStatus, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/statuses/%s", url.QueryEscape(project), sha)
 
-	req, err := s.client.NewRequest("POST", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("POST", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/deploy_keys.go
+++ b/deploy_keys.go
@@ -46,14 +46,14 @@ func (k DeployKey) String() string {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/deploy_keys.html#list-deploy-keys
-func (s *DeployKeysService) ListDeployKeys(pid interface{}, sudoFunc ...SudoFunc) ([]*DeployKey, *Response, error) {
+func (s *DeployKeysService) ListDeployKeys(pid interface{}, options ...OptionFunc) ([]*DeployKey, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/keys", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("GET", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -71,14 +71,14 @@ func (s *DeployKeysService) ListDeployKeys(pid interface{}, sudoFunc ...SudoFunc
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/deploy_keys.html#single-deploy-key
-func (s *DeployKeysService) GetDeployKey(pid interface{}, deployKey int, sudoFunc ...SudoFunc) (*DeployKey, *Response, error) {
+func (s *DeployKeysService) GetDeployKey(pid interface{}, deployKey int, options ...OptionFunc) (*DeployKey, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/keys/%d", url.QueryEscape(project), deployKey)
 
-	req, err := s.client.NewRequest("GET", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -107,14 +107,14 @@ type AddDeployKeyOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/deploy_keys.html#add-deploy-key
-func (s *DeployKeysService) AddDeployKey(pid interface{}, opt *AddDeployKeyOptions, sudoFunc ...SudoFunc) (*DeployKey, *Response, error) {
+func (s *DeployKeysService) AddDeployKey(pid interface{}, opt *AddDeployKeyOptions, options ...OptionFunc) (*DeployKey, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/keys", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("POST", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("POST", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -132,14 +132,14 @@ func (s *DeployKeysService) AddDeployKey(pid interface{}, opt *AddDeployKeyOptio
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/deploy_keys.html#delete-deploy-key
-func (s *DeployKeysService) DeleteDeployKey(pid interface{}, deployKey int, sudoFunc ...SudoFunc) (*Response, error) {
+func (s *DeployKeysService) DeleteDeployKey(pid interface{}, deployKey int, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, err
 	}
 	u := fmt.Sprintf("projects/%s/keys/%d", url.QueryEscape(project), deployKey)
 
-	req, err := s.client.NewRequest("DELETE", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
 	if err != nil {
 		return nil, err
 	}

--- a/gitlab.go
+++ b/gitlab.go
@@ -270,7 +270,7 @@ func (c *Client) SetBaseURL(urlStr string) error {
 // Relative URL paths should always be specified without a preceding slash. If
 // specified, the value pointed to by body is JSON encoded and included as the
 // request body.
-func (c *Client) NewRequest(method, path string, opt interface{}, sudoFunc []SudoFunc) (*http.Request, error) {
+func (c *Client) NewRequest(method, path string, opt interface{}, options []OptionFunc) (*http.Request, error) {
 	u := *c.baseURL
 	// Set the encoded opaque data
 	u.Opaque = c.baseURL.Path + path
@@ -293,7 +293,7 @@ func (c *Client) NewRequest(method, path string, opt interface{}, sudoFunc []Sud
 		Host:       u.Host,
 	}
 
-	for _, fn := range sudoFunc {
+	for _, fn := range options {
 		if err := fn(req); err != nil {
 			return nil, err
 		}
@@ -519,14 +519,14 @@ func parseError(raw interface{}) string {
 	}
 }
 
-// SudoFunc can be passed to all API requests to make the API call as if you were
+// OptionFunc can be passed to all API requests to make the API call as if you were
 // another user, provided your private token is from an administrator account.
 //
 // GitLab docs: https://docs.gitlab.com/ce/api/README.html#sudo
-type SudoFunc func(*http.Request) error
+type OptionFunc func(*http.Request) error
 
-// SudoUser takes either a username or user ID and sets the SUDO request header
-func SudoUser(uid interface{}) SudoFunc {
+// WithSudo takes either a username or user ID and sets the SUDO request header
+func WithSudo(uid interface{}) OptionFunc {
 	return func(req *http.Request) error {
 		switch uid := uid.(type) {
 		case int:

--- a/groups.go
+++ b/groups.go
@@ -52,8 +52,8 @@ type ListGroupsOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/groups.html#list-project-groups
-func (s *GroupsService) ListGroups(opt *ListGroupsOptions, sudoFunc ...SudoFunc) ([]*Group, *Response, error) {
-	req, err := s.client.NewRequest("GET", "groups", opt, sudoFunc)
+func (s *GroupsService) ListGroups(opt *ListGroupsOptions, options ...OptionFunc) ([]*Group, *Response, error) {
+	req, err := s.client.NewRequest("GET", "groups", opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -70,14 +70,14 @@ func (s *GroupsService) ListGroups(opt *ListGroupsOptions, sudoFunc ...SudoFunc)
 // GetGroup gets all details of a group.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/groups.html#details-of-a-group
-func (s *GroupsService) GetGroup(gid interface{}, sudoFunc ...SudoFunc) (*Group, *Response, error) {
+func (s *GroupsService) GetGroup(gid interface{}, options ...OptionFunc) (*Group, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("groups/%s", group)
 
-	req, err := s.client.NewRequest("GET", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -105,8 +105,8 @@ type CreateGroupOptions struct {
 // create groups.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/groups.html#new-group
-func (s *GroupsService) CreateGroup(opt *CreateGroupOptions, sudoFunc ...SudoFunc) (*Group, *Response, error) {
-	req, err := s.client.NewRequest("POST", "groups", opt, sudoFunc)
+func (s *GroupsService) CreateGroup(opt *CreateGroupOptions, options ...OptionFunc) (*Group, *Response, error) {
+	req, err := s.client.NewRequest("POST", "groups", opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -125,14 +125,14 @@ func (s *GroupsService) CreateGroup(opt *CreateGroupOptions, sudoFunc ...SudoFun
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/groups.html#transfer-project-to-group
-func (s *GroupsService) TransferGroup(gid interface{}, project int, sudoFunc ...SudoFunc) (*Group, *Response, error) {
+func (s *GroupsService) TransferGroup(gid interface{}, project int, options ...OptionFunc) (*Group, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("groups/%s/projects/%d", group, project)
 
-	req, err := s.client.NewRequest("POST", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("POST", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -149,14 +149,14 @@ func (s *GroupsService) TransferGroup(gid interface{}, project int, sudoFunc ...
 // DeleteGroup removes group with all projects inside.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/groups.html#remove-group
-func (s *GroupsService) DeleteGroup(gid interface{}, sudoFunc ...SudoFunc) (*Response, error) {
+func (s *GroupsService) DeleteGroup(gid interface{}, options ...OptionFunc) (*Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
 		return nil, err
 	}
 	u := fmt.Sprintf("groups/%s", group)
 
-	req, err := s.client.NewRequest("DELETE", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
 	if err != nil {
 		return nil, err
 	}
@@ -167,13 +167,13 @@ func (s *GroupsService) DeleteGroup(gid interface{}, sudoFunc ...SudoFunc) (*Res
 // SearchGroup get all groups that match your string in their name or path.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/groups.html#search-for-group
-func (s *GroupsService) SearchGroup(query string, sudoFunc ...SudoFunc) ([]*Group, *Response, error) {
+func (s *GroupsService) SearchGroup(query string, options ...OptionFunc) ([]*Group, *Response, error) {
 	var q struct {
 		Search string `url:"search,omitempty" json:"search,omitempty"`
 	}
 	q.Search = query
 
-	req, err := s.client.NewRequest("GET", "groups", &q, sudoFunc)
+	req, err := s.client.NewRequest("GET", "groups", &q, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -214,14 +214,14 @@ type ListGroupMembersOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/groups.html#list-group-members
-func (s *GroupsService) ListGroupMembers(gid interface{}, opt *ListGroupMembersOptions, sudoFunc ...SudoFunc) ([]*GroupMember, *Response, error) {
+func (s *GroupsService) ListGroupMembers(gid interface{}, opt *ListGroupMembersOptions, options ...OptionFunc) ([]*GroupMember, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("groups/%s/members", group)
 
-	req, err := s.client.NewRequest("GET", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -248,14 +248,14 @@ type ListGroupProjectsOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/groups.html#list-a-group-s-projects
-func (s *GroupsService) ListGroupProjects(gid interface{}, opt *ListGroupProjectsOptions, sudoFunc ...SudoFunc) ([]*Project, *Response, error) {
+func (s *GroupsService) ListGroupProjects(gid interface{}, opt *ListGroupProjectsOptions, options ...OptionFunc) ([]*Project, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("groups/%s/projects", group)
 
-	req, err := s.client.NewRequest("GET", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -281,14 +281,14 @@ type AddGroupMemberOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/groups.html#list-group-members
-func (s *GroupsService) AddGroupMember(gid interface{}, opt *AddGroupMemberOptions, sudoFunc ...SudoFunc) (*GroupMember, *Response, error) {
+func (s *GroupsService) AddGroupMember(gid interface{}, opt *AddGroupMemberOptions, options ...OptionFunc) (*GroupMember, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("groups/%s/members", group)
 
-	req, err := s.client.NewRequest("POST", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("POST", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -315,14 +315,14 @@ type UpdateGroupMemberOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/groups.html#list-group-members
-func (s *GroupsService) UpdateGroupMember(gid interface{}, user int, opt *UpdateGroupMemberOptions, sudoFunc ...SudoFunc) (*GroupMember, *Response, error) {
+func (s *GroupsService) UpdateGroupMember(gid interface{}, user int, opt *UpdateGroupMemberOptions, options ...OptionFunc) (*GroupMember, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("groups/%s/members/%d", group, user)
 
-	req, err := s.client.NewRequest("PUT", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("PUT", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -340,14 +340,14 @@ func (s *GroupsService) UpdateGroupMember(gid interface{}, user int, opt *Update
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/groups.html#remove-user-from-user-team
-func (s *GroupsService) RemoveGroupMember(gid interface{}, user int, sudoFunc ...SudoFunc) (*Response, error) {
+func (s *GroupsService) RemoveGroupMember(gid interface{}, user int, options ...OptionFunc) (*Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
 		return nil, err
 	}
 	u := fmt.Sprintf("groups/%s/members/%d", group, user)
 
-	req, err := s.client.NewRequest("DELETE", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
 	if err != nil {
 		return nil, err
 	}

--- a/issues.go
+++ b/issues.go
@@ -96,8 +96,8 @@ type ListIssuesOptions struct {
 // takes pagination parameters page and per_page to restrict the list of issues.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/issues.html#list-issues
-func (s *IssuesService) ListIssues(opt *ListIssuesOptions, sudoFunc ...SudoFunc) ([]*Issue, *Response, error) {
-	req, err := s.client.NewRequest("GET", "issues", opt, sudoFunc)
+func (s *IssuesService) ListIssues(opt *ListIssuesOptions, options ...OptionFunc) ([]*Issue, *Response, error) {
+	req, err := s.client.NewRequest("GET", "issues", opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -128,14 +128,14 @@ type ListProjectIssuesOptions struct {
 // pagination parameters page and per_page to return the list of project issues.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/issues.html#list-project-issues
-func (s *IssuesService) ListProjectIssues(pid interface{}, opt *ListProjectIssuesOptions, sudoFunc ...SudoFunc) ([]*Issue, *Response, error) {
+func (s *IssuesService) ListProjectIssues(pid interface{}, opt *ListProjectIssuesOptions, options ...OptionFunc) ([]*Issue, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/issues", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("GET", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -152,14 +152,14 @@ func (s *IssuesService) ListProjectIssues(pid interface{}, opt *ListProjectIssue
 // GetIssue gets a single project issue.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/issues.html#single-issues
-func (s *IssuesService) GetIssue(pid interface{}, issue int, sudoFunc ...SudoFunc) (*Issue, *Response, error) {
+func (s *IssuesService) GetIssue(pid interface{}, issue int, options ...OptionFunc) (*Issue, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/issues/%d", url.QueryEscape(project), issue)
 
-	req, err := s.client.NewRequest("GET", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -187,14 +187,14 @@ type CreateIssueOptions struct {
 // CreateIssue creates a new project issue.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/issues.html#new-issues
-func (s *IssuesService) CreateIssue(pid interface{}, opt *CreateIssueOptions, sudoFunc ...SudoFunc) (*Issue, *Response, error) {
+func (s *IssuesService) CreateIssue(pid interface{}, opt *CreateIssueOptions, options ...OptionFunc) (*Issue, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/issues", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("POST", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("POST", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -224,14 +224,14 @@ type UpdateIssueOptions struct {
 // to mark an issue as closed.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/issues.html#edit-issues
-func (s *IssuesService) UpdateIssue(pid interface{}, issue int, opt *UpdateIssueOptions, sudoFunc ...SudoFunc) (*Issue, *Response, error) {
+func (s *IssuesService) UpdateIssue(pid interface{}, issue int, opt *UpdateIssueOptions, options ...OptionFunc) (*Issue, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/issues/%d", url.QueryEscape(project), issue)
 
-	req, err := s.client.NewRequest("PUT", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("PUT", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -248,14 +248,14 @@ func (s *IssuesService) UpdateIssue(pid interface{}, issue int, opt *UpdateIssue
 // DeleteIssue deletes a single project issue.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/issues.html#delete-an-issue
-func (s *IssuesService) DeleteIssue(pid interface{}, issue int, sudoFunc ...SudoFunc) (*Response, error) {
+func (s *IssuesService) DeleteIssue(pid interface{}, issue int, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, err
 	}
 	u := fmt.Sprintf("projects/%s/issues/%d", url.QueryEscape(project), issue)
 
-	req, err := s.client.NewRequest("DELETE", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
 	if err != nil {
 		return nil, err
 	}

--- a/labels.go
+++ b/labels.go
@@ -48,14 +48,14 @@ func (l Label) String() string {
 // ListLabels gets all labels for given project.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/labels.html#list-labels
-func (s *LabelsService) ListLabels(pid interface{}, sudoFunc ...SudoFunc) ([]*Label, *Response, error) {
+func (s *LabelsService) ListLabels(pid interface{}, options ...OptionFunc) ([]*Label, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/labels", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("GET", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -82,14 +82,14 @@ type CreateLabelOptions struct {
 // color.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/labels.html#create-a-new-label
-func (s *LabelsService) CreateLabel(pid interface{}, opt *CreateLabelOptions, sudoFunc ...SudoFunc) (*Label, *Response, error) {
+func (s *LabelsService) CreateLabel(pid interface{}, opt *CreateLabelOptions, options ...OptionFunc) (*Label, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/labels", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("POST", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("POST", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -113,14 +113,14 @@ type DeleteLabelOptions struct {
 // DeleteLabel deletes a label given by its name.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/labels.html#delete-a-label
-func (s *LabelsService) DeleteLabel(pid interface{}, opt *DeleteLabelOptions, sudoFunc ...SudoFunc) (*Response, error) {
+func (s *LabelsService) DeleteLabel(pid interface{}, opt *DeleteLabelOptions, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, err
 	}
 	u := fmt.Sprintf("projects/%s/labels", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("DELETE", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("DELETE", u, opt, options)
 	if err != nil {
 		return nil, err
 	}
@@ -142,14 +142,14 @@ type UpdateLabelOptions struct {
 // one parameter is required, to update the label.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/labels.html#edit-an-existing-label
-func (s *LabelsService) UpdateLabel(pid interface{}, opt *UpdateLabelOptions, sudoFunc ...SudoFunc) (*Label, *Response, error) {
+func (s *LabelsService) UpdateLabel(pid interface{}, opt *UpdateLabelOptions, options ...OptionFunc) (*Label, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/labels", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("PUT", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("PUT", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/merge_requests.go
+++ b/merge_requests.go
@@ -118,14 +118,14 @@ type ListMergeRequestsOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/merge_requests.html#list-merge-requests
-func (s *MergeRequestsService) ListMergeRequests(pid interface{}, opt *ListMergeRequestsOptions, sudoFunc ...SudoFunc) ([]*MergeRequest, *Response, error) {
+func (s *MergeRequestsService) ListMergeRequests(pid interface{}, opt *ListMergeRequestsOptions, options ...OptionFunc) ([]*MergeRequest, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/merge_requests", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("GET", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -143,14 +143,14 @@ func (s *MergeRequestsService) ListMergeRequests(pid interface{}, opt *ListMerge
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/merge_requests.html#get-single-mr
-func (s *MergeRequestsService) GetMergeRequest(pid interface{}, mergeRequest int, sudoFunc ...SudoFunc) (*MergeRequest, *Response, error) {
+func (s *MergeRequestsService) GetMergeRequest(pid interface{}, mergeRequest int, options ...OptionFunc) (*MergeRequest, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/merge_requests/%d", url.QueryEscape(project), mergeRequest)
 
-	req, err := s.client.NewRequest("GET", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -168,14 +168,14 @@ func (s *MergeRequestsService) GetMergeRequest(pid interface{}, mergeRequest int
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/merge_requests.html#get-single-mr-commits
-func (s *MergeRequestsService) GetMergeRequestCommits(pid interface{}, mergeRequest int, sudoFunc ...SudoFunc) ([]*Commit, *Response, error) {
+func (s *MergeRequestsService) GetMergeRequestCommits(pid interface{}, mergeRequest int, options ...OptionFunc) ([]*Commit, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/merge_requests/%d/commits", url.QueryEscape(project), mergeRequest)
 
-	req, err := s.client.NewRequest("GET", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -194,14 +194,14 @@ func (s *MergeRequestsService) GetMergeRequestCommits(pid interface{}, mergeRequ
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/merge_requests.html#get-single-mr-changes
-func (s *MergeRequestsService) GetMergeRequestChanges(pid interface{}, mergeRequest int, sudoFunc ...SudoFunc) (*MergeRequest, *Response, error) {
+func (s *MergeRequestsService) GetMergeRequestChanges(pid interface{}, mergeRequest int, options ...OptionFunc) (*MergeRequest, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/merge_requests/%d/changes", url.QueryEscape(project), mergeRequest)
 
-	req, err := s.client.NewRequest("GET", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -233,14 +233,14 @@ type CreateMergeRequestOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/merge_requests.html#create-mr
-func (s *MergeRequestsService) CreateMergeRequest(pid interface{}, opt *CreateMergeRequestOptions, sudoFunc ...SudoFunc) (*MergeRequest, *Response, error) {
+func (s *MergeRequestsService) CreateMergeRequest(pid interface{}, opt *CreateMergeRequestOptions, options ...OptionFunc) (*MergeRequest, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/merge_requests", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("POST", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("POST", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -271,14 +271,14 @@ type UpdateMergeRequestOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/merge_requests.html#update-mr
-func (s *MergeRequestsService) UpdateMergeRequest(pid interface{}, mergeRequest int, opt *UpdateMergeRequestOptions, sudoFunc ...SudoFunc) (*MergeRequest, *Response, error) {
+func (s *MergeRequestsService) UpdateMergeRequest(pid interface{}, mergeRequest int, opt *UpdateMergeRequestOptions, options ...OptionFunc) (*MergeRequest, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/merge_requests/%d", url.QueryEscape(project), mergeRequest)
 
-	req, err := s.client.NewRequest("PUT", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("PUT", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -311,14 +311,14 @@ type AcceptMergeRequestOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/merge_requests.html#accept-mr
-func (s *MergeRequestsService) AcceptMergeRequest(pid interface{}, mergeRequest int, opt *AcceptMergeRequestOptions, sudoFunc ...SudoFunc) (*MergeRequest, *Response, error) {
+func (s *MergeRequestsService) AcceptMergeRequest(pid interface{}, mergeRequest int, opt *AcceptMergeRequestOptions, options ...OptionFunc) (*MergeRequest, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/merge_requests/%d/merge", url.QueryEscape(project), mergeRequest)
 
-	req, err := s.client.NewRequest("PUT", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("PUT", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/milestones.go
+++ b/milestones.go
@@ -63,14 +63,14 @@ type ListMilestonesOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/milestones.html#list-project-milestones
-func (s *MilestonesService) ListMilestones(pid interface{}, opt *ListMilestonesOptions, sudoFunc ...SudoFunc) ([]*Milestone, *Response, error) {
+func (s *MilestonesService) ListMilestones(pid interface{}, opt *ListMilestonesOptions, options ...OptionFunc) ([]*Milestone, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/milestones", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("GET", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -88,14 +88,14 @@ func (s *MilestonesService) ListMilestones(pid interface{}, opt *ListMilestonesO
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/milestones.html#get-single-milestone
-func (s *MilestonesService) GetMilestone(pid interface{}, milestone int, sudoFunc ...SudoFunc) (*Milestone, *Response, error) {
+func (s *MilestonesService) GetMilestone(pid interface{}, milestone int, options ...OptionFunc) (*Milestone, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/milestones/%d", url.QueryEscape(project), milestone)
 
-	req, err := s.client.NewRequest("GET", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -124,14 +124,14 @@ type CreateMilestoneOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/milestones.html#create-new-milestone
-func (s *MilestonesService) CreateMilestone(pid interface{}, opt *CreateMilestoneOptions, sudoFunc ...SudoFunc) (*Milestone, *Response, error) {
+func (s *MilestonesService) CreateMilestone(pid interface{}, opt *CreateMilestoneOptions, options ...OptionFunc) (*Milestone, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/milestones", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("POST", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("POST", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -161,14 +161,14 @@ type UpdateMilestoneOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/milestones.html#edit-milestone
-func (s *MilestonesService) UpdateMilestone(pid interface{}, milestone int, opt *UpdateMilestoneOptions, sudoFunc ...SudoFunc) (*Milestone, *Response, error) {
+func (s *MilestonesService) UpdateMilestone(pid interface{}, milestone int, opt *UpdateMilestoneOptions, options ...OptionFunc) (*Milestone, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/milestones/%d", url.QueryEscape(project), milestone)
 
-	req, err := s.client.NewRequest("PUT", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("PUT", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -194,14 +194,14 @@ type GetMilestoneIssuesOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/milestones.html#get-all-issues-assigned-to-a-single-milestone
-func (s *MilestonesService) GetMilestoneIssues(pid interface{}, milestone int, opt *GetMilestoneIssuesOptions, sudoFunc ...SudoFunc) ([]*Issue, *Response, error) {
+func (s *MilestonesService) GetMilestoneIssues(pid interface{}, milestone int, opt *GetMilestoneIssuesOptions, options ...OptionFunc) ([]*Issue, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/milestones/%d/issues", url.QueryEscape(project), milestone)
 
-	req, err := s.client.NewRequest("GET", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/namespaces.go
+++ b/namespaces.go
@@ -48,8 +48,8 @@ type ListNamespacesOptions struct {
 // ListNamespaces gets a list of projects accessible by the authenticated user.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/namespaces.html#list-namespaces
-func (s *NamespacesService) ListNamespaces(opt *ListNamespacesOptions, sudoFunc ...SudoFunc) ([]*Namespace, *Response, error) {
-	req, err := s.client.NewRequest("GET", "namespaces", opt, sudoFunc)
+func (s *NamespacesService) ListNamespaces(opt *ListNamespacesOptions, options ...OptionFunc) ([]*Namespace, *Response, error) {
+	req, err := s.client.NewRequest("GET", "namespaces", opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -68,13 +68,13 @@ func (s *NamespacesService) ListNamespaces(opt *ListNamespacesOptions, sudoFunc 
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/namespaces.html#search-for-namespace
-func (s *NamespacesService) SearchNamespace(query string, sudoFunc ...SudoFunc) ([]*Namespace, *Response, error) {
+func (s *NamespacesService) SearchNamespace(query string, options ...OptionFunc) ([]*Namespace, *Response, error) {
 	var q struct {
 		Search string `url:"search,omitempty" json:"search,omitempty"`
 	}
 	q.Search = query
 
-	req, err := s.client.NewRequest("GET", "namespaces", &q, sudoFunc)
+	req, err := s.client.NewRequest("GET", "namespaces", &q, options)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/notes.go
+++ b/notes.go
@@ -68,14 +68,14 @@ type ListIssueNotesOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/notes.html#list-project-issue-notes
-func (s *NotesService) ListIssueNotes(pid interface{}, issue int, opt *ListIssueNotesOptions, sudoFunc ...SudoFunc) ([]*Note, *Response, error) {
+func (s *NotesService) ListIssueNotes(pid interface{}, issue int, opt *ListIssueNotesOptions, options ...OptionFunc) ([]*Note, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/issues/%d/notes", url.QueryEscape(project), issue)
 
-	req, err := s.client.NewRequest("GET", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -93,14 +93,14 @@ func (s *NotesService) ListIssueNotes(pid interface{}, issue int, opt *ListIssue
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/notes.html#get-single-issue-note
-func (s *NotesService) GetIssueNote(pid interface{}, issue int, note int, sudoFunc ...SudoFunc) (*Note, *Response, error) {
+func (s *NotesService) GetIssueNote(pid interface{}, issue int, note int, options ...OptionFunc) (*Note, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/issues/%d/notes/%d", url.QueryEscape(project), issue, note)
 
-	req, err := s.client.NewRequest("GET", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -127,14 +127,14 @@ type CreateIssueNoteOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/notes.html#create-new-issue-note
-func (s *NotesService) CreateIssueNote(pid interface{}, issue int, opt *CreateIssueNoteOptions, sudoFunc ...SudoFunc) (*Note, *Response, error) {
+func (s *NotesService) CreateIssueNote(pid interface{}, issue int, opt *CreateIssueNoteOptions, options ...OptionFunc) (*Note, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/issues/%d/notes", url.QueryEscape(project), issue)
 
-	req, err := s.client.NewRequest("POST", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("POST", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -160,14 +160,14 @@ type UpdateIssueNoteOptions struct {
 // UpdateIssueNote modifies existing note of an issue.
 //
 // https://docs.gitlab.com/ce/api/notes.html#modify-existing-issue-note
-func (s *NotesService) UpdateIssueNote(pid interface{}, issue int, note int, opt *UpdateIssueNoteOptions, sudoFunc ...SudoFunc) (*Note, *Response, error) {
+func (s *NotesService) UpdateIssueNote(pid interface{}, issue int, note int, opt *UpdateIssueNoteOptions, options ...OptionFunc) (*Note, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/issues/%d/notes/%d", url.QueryEscape(project), issue, note)
 
-	req, err := s.client.NewRequest("PUT", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("PUT", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -186,14 +186,14 @@ func (s *NotesService) UpdateIssueNote(pid interface{}, issue int, note int, opt
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/notes.html#list-all-snippet-notes
-func (s *NotesService) ListSnippetNotes(pid interface{}, snippet int, sudoFunc ...SudoFunc) ([]*Note, *Response, error) {
+func (s *NotesService) ListSnippetNotes(pid interface{}, snippet int, options ...OptionFunc) ([]*Note, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/snippets/%d/notes", url.QueryEscape(project), snippet)
 
-	req, err := s.client.NewRequest("GET", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -211,14 +211,14 @@ func (s *NotesService) ListSnippetNotes(pid interface{}, snippet int, sudoFunc .
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/notes.html#get-single-snippet-note
-func (s *NotesService) GetSnippetNote(pid interface{}, snippet int, note int, sudoFunc ...SudoFunc) (*Note, *Response, error) {
+func (s *NotesService) GetSnippetNote(pid interface{}, snippet int, note int, options ...OptionFunc) (*Note, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/snippets/%d/notes/%d", url.QueryEscape(project), snippet, note)
 
-	req, err := s.client.NewRequest("GET", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -246,14 +246,14 @@ type CreateSnippetNoteOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/notes.html#create-new-snippet-note
-func (s *NotesService) CreateSnippetNote(pid interface{}, snippet int, opt *CreateSnippetNoteOptions, sudoFunc ...SudoFunc) (*Note, *Response, error) {
+func (s *NotesService) CreateSnippetNote(pid interface{}, snippet int, opt *CreateSnippetNoteOptions, options ...OptionFunc) (*Note, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/snippets/%d/notes", url.QueryEscape(project), snippet)
 
-	req, err := s.client.NewRequest("POST", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("POST", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -279,14 +279,14 @@ type UpdateSnippetNoteOptions struct {
 // UpdateSnippetNote modifies existing note of a snippet.
 //
 // https://docs.gitlab.com/ce/api/notes.html#modify-existing-snippet-note
-func (s *NotesService) UpdateSnippetNote(pid interface{}, snippet int, note int, opt *UpdateSnippetNoteOptions, sudoFunc ...SudoFunc) (*Note, *Response, error) {
+func (s *NotesService) UpdateSnippetNote(pid interface{}, snippet int, note int, opt *UpdateSnippetNoteOptions, options ...OptionFunc) (*Note, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/snippets/%d/notes/%d", url.QueryEscape(project), snippet, note)
 
-	req, err := s.client.NewRequest("PUT", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("PUT", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -304,14 +304,14 @@ func (s *NotesService) UpdateSnippetNote(pid interface{}, snippet int, note int,
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/notes.html#list-all-merge-request-notes
-func (s *NotesService) ListMergeRequestNotes(pid interface{}, mergeRequest int, sudoFunc ...SudoFunc) ([]*Note, *Response, error) {
+func (s *NotesService) ListMergeRequestNotes(pid interface{}, mergeRequest int, options ...OptionFunc) ([]*Note, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/merge_requests/%d/notes", url.QueryEscape(project), mergeRequest)
 
-	req, err := s.client.NewRequest("GET", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -329,14 +329,14 @@ func (s *NotesService) ListMergeRequestNotes(pid interface{}, mergeRequest int, 
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/notes.html#get-single-merge-request-note
-func (s *NotesService) GetMergeRequestNote(pid interface{}, mergeRequest int, note int, sudoFunc ...SudoFunc) (*Note, *Response, error) {
+func (s *NotesService) GetMergeRequestNote(pid interface{}, mergeRequest int, note int, options ...OptionFunc) (*Note, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/merge_requests/%d/notes/%d", url.QueryEscape(project), mergeRequest, note)
 
-	req, err := s.client.NewRequest("GET", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -363,14 +363,14 @@ type CreateMergeRequestNoteOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/notes.html#create-new-merge-request-note
-func (s *NotesService) CreateMergeRequestNote(pid interface{}, mergeRequest int, opt *CreateMergeRequestNoteOptions, sudoFunc ...SudoFunc) (*Note, *Response, error) {
+func (s *NotesService) CreateMergeRequestNote(pid interface{}, mergeRequest int, opt *CreateMergeRequestNoteOptions, options ...OptionFunc) (*Note, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/merge_requests/%d/notes", url.QueryEscape(project), mergeRequest)
 
-	req, err := s.client.NewRequest("POST", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("POST", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -396,14 +396,14 @@ type UpdateMergeRequestNoteOptions struct {
 // UpdateMergeRequestNote modifies existing note of a merge request.
 //
 // https://docs.gitlab.com/ce/api/notes.html#modify-existing-merge-request-note
-func (s *NotesService) UpdateMergeRequestNote(pid interface{}, mergeRequest int, note int, opt *UpdateMergeRequestNoteOptions, sudoFunc ...SudoFunc) (*Note, *Response, error) {
+func (s *NotesService) UpdateMergeRequestNote(pid interface{}, mergeRequest int, note int, opt *UpdateMergeRequestNoteOptions, options ...OptionFunc) (*Note, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf(
 		"projects/%s/merge_requests/%d/notes/%d", url.QueryEscape(project), mergeRequest, note)
-	req, err := s.client.NewRequest("PUT", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("PUT", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/notifications.go
+++ b/notifications.go
@@ -51,10 +51,10 @@ func (ns NotificationSettings) String() string {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/notification_settings.html#global-notification-settings
-func (s *NotificationSettingsService) GetGlobalSettings(sudoFunc ...SudoFunc) (*NotificationSettings, *Response, error) {
+func (s *NotificationSettingsService) GetGlobalSettings(options ...OptionFunc) (*NotificationSettings, *Response, error) {
 	u := "notification_settings"
 
-	req, err := s.client.NewRequest("GET", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -91,7 +91,7 @@ type NotificationSettingsOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/notification_settings.html#update-global-notification-settings
-func (s *NotificationSettingsService) UpdateGlobalSettings(opt *NotificationSettingsOptions, sudoFunc ...SudoFunc) (*NotificationSettings, *Response, error) {
+func (s *NotificationSettingsService) UpdateGlobalSettings(opt *NotificationSettingsOptions, options ...OptionFunc) (*NotificationSettings, *Response, error) {
 	if opt.Level != nil && *opt.Level == GlobalNotificationLevel {
 		return nil, nil, errors.New(
 			"notification level 'global' is not valid for global notification settings")
@@ -99,7 +99,7 @@ func (s *NotificationSettingsService) UpdateGlobalSettings(opt *NotificationSett
 
 	u := "notification_settings"
 
-	req, err := s.client.NewRequest("PUT", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("PUT", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -117,14 +117,14 @@ func (s *NotificationSettingsService) UpdateGlobalSettings(opt *NotificationSett
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/notification_settings.html#group-project-level-notification-settings
-func (s *NotificationSettingsService) GetSettingsForGroup(gid interface{}, sudoFunc ...SudoFunc) (*NotificationSettings, *Response, error) {
+func (s *NotificationSettingsService) GetSettingsForGroup(gid interface{}, options ...OptionFunc) (*NotificationSettings, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("groups/%s/notification_settings", url.QueryEscape(group))
 
-	req, err := s.client.NewRequest("GET", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -142,14 +142,14 @@ func (s *NotificationSettingsService) GetSettingsForGroup(gid interface{}, sudoF
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/notification_settings.html#group-project-level-notification-settings
-func (s *NotificationSettingsService) GetSettingsForProject(pid interface{}, sudoFunc ...SudoFunc) (*NotificationSettings, *Response, error) {
+func (s *NotificationSettingsService) GetSettingsForProject(pid interface{}, options ...OptionFunc) (*NotificationSettings, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/notification_settings", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("GET", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -167,14 +167,14 @@ func (s *NotificationSettingsService) GetSettingsForProject(pid interface{}, sud
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/notification_settings.html#update-group-project-level-notification-settings
-func (s *NotificationSettingsService) UpdateSettingsForGroup(gid interface{}, opt *NotificationSettingsOptions, sudoFunc ...SudoFunc) (*NotificationSettings, *Response, error) {
+func (s *NotificationSettingsService) UpdateSettingsForGroup(gid interface{}, opt *NotificationSettingsOptions, options ...OptionFunc) (*NotificationSettings, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("groups/%s/notification_settings", url.QueryEscape(group))
 
-	req, err := s.client.NewRequest("PUT", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("PUT", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -192,14 +192,14 @@ func (s *NotificationSettingsService) UpdateSettingsForGroup(gid interface{}, op
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/notification_settings.html#update-group-project-level-notification-settings
-func (s *NotificationSettingsService) UpdateSettingsForProject(pid interface{}, opt *NotificationSettingsOptions, sudoFunc ...SudoFunc) (*NotificationSettings, *Response, error) {
+func (s *NotificationSettingsService) UpdateSettingsForProject(pid interface{}, opt *NotificationSettingsOptions, options ...OptionFunc) (*NotificationSettings, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/notification_settings", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("PUT", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("PUT", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pipelines.go
+++ b/pipelines.go
@@ -65,14 +65,14 @@ func (i Pipeline) String() string {
 // ListProjectPipelines gets a list of project piplines.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/pipelines.html#list-project-pipelines
-func (s *PipelinesService) ListProjectPipelines(pid interface{}, sudoFunc ...SudoFunc) ([]*Pipeline, *Response, error) {
+func (s *PipelinesService) ListProjectPipelines(pid interface{}, options ...OptionFunc) ([]*Pipeline, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/pipelines", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("GET", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -88,14 +88,14 @@ func (s *PipelinesService) ListProjectPipelines(pid interface{}, sudoFunc ...Sud
 // GetPipeline gets a single project pipeline.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/pipelines.html#get-a-single-pipeline
-func (s *PipelinesService) GetPipeline(pid interface{}, pipeline int, sudoFunc ...SudoFunc) (*Pipeline, *Response, error) {
+func (s *PipelinesService) GetPipeline(pid interface{}, pipeline int, options ...OptionFunc) (*Pipeline, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/pipelines/%d", url.QueryEscape(project), pipeline)
 
-	req, err := s.client.NewRequest("GET", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -119,14 +119,14 @@ type CreatePipelineOptions struct {
 // CreatePipeline creates a new project pipeline.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/pipelines.html#create-a-new-pipeline
-func (s *PipelinesService) CreatePipeline(pid interface{}, opt *CreatePipelineOptions, sudoFunc ...SudoFunc) (*Pipeline, *Response, error) {
+func (s *PipelinesService) CreatePipeline(pid interface{}, opt *CreatePipelineOptions, options ...OptionFunc) (*Pipeline, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/pipeline", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("POST", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("POST", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -144,14 +144,14 @@ func (s *PipelinesService) CreatePipeline(pid interface{}, opt *CreatePipelineOp
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/pipelines.html#retry-failed-builds-in-a-pipeline
-func (s *PipelinesService) RetryPipelineBuild(pid interface{}, pipelineID int, sudoFunc ...SudoFunc) (*Pipeline, *Response, error) {
+func (s *PipelinesService) RetryPipelineBuild(pid interface{}, pipelineID int, options ...OptionFunc) (*Pipeline, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/pipelines/%d/retry", project, pipelineID)
 
-	req, err := s.client.NewRequest("POST", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("POST", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -169,14 +169,14 @@ func (s *PipelinesService) RetryPipelineBuild(pid interface{}, pipelineID int, s
 //
 // GitLab API docs:
 //https://docs.gitlab.com/ce/api/pipelines.html#cancel-a-pipelines-builds
-func (s *PipelinesService) CancelPipelineBuild(pid interface{}, pipelineID int, sudoFunc ...SudoFunc) (*Pipeline, *Response, error) {
+func (s *PipelinesService) CancelPipelineBuild(pid interface{}, pipelineID int, options ...OptionFunc) (*Pipeline, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/pipelines/%d/cancel", project, pipelineID)
 
-	req, err := s.client.NewRequest("POST", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("POST", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/project_snippets.go
+++ b/project_snippets.go
@@ -65,14 +65,14 @@ type ListSnippetsOptions struct {
 // ListSnippets gets a list of project snippets.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/project_snippets.html#list-snippets
-func (s *ProjectSnippetsService) ListSnippets(pid interface{}, opt *ListSnippetsOptions, sudoFunc ...SudoFunc) ([]*Snippet, *Response, error) {
+func (s *ProjectSnippetsService) ListSnippets(pid interface{}, opt *ListSnippetsOptions, options ...OptionFunc) ([]*Snippet, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/snippets", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("GET", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -90,14 +90,14 @@ func (s *ProjectSnippetsService) ListSnippets(pid interface{}, opt *ListSnippets
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/project_snippets.html#single-snippet
-func (s *ProjectSnippetsService) GetSnippet(pid interface{}, snippet int, sudoFunc ...SudoFunc) (*Snippet, *Response, error) {
+func (s *ProjectSnippetsService) GetSnippet(pid interface{}, snippet int, options ...OptionFunc) (*Snippet, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/snippets/%d", url.QueryEscape(project), snippet)
 
-	req, err := s.client.NewRequest("GET", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -127,14 +127,14 @@ type CreateSnippetOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/project_snippets.html#create-new-snippet
-func (s *ProjectSnippetsService) CreateSnippet(pid interface{}, opt *CreateSnippetOptions, sudoFunc ...SudoFunc) (*Snippet, *Response, error) {
+func (s *ProjectSnippetsService) CreateSnippet(pid interface{}, opt *CreateSnippetOptions, options ...OptionFunc) (*Snippet, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/snippets", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("POST", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("POST", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -164,14 +164,14 @@ type UpdateSnippetOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/project_snippets.html#update-snippet
-func (s *ProjectSnippetsService) UpdateSnippet(pid interface{}, snippet int, opt *UpdateSnippetOptions, sudoFunc ...SudoFunc) (*Snippet, *Response, error) {
+func (s *ProjectSnippetsService) UpdateSnippet(pid interface{}, snippet int, opt *UpdateSnippetOptions, options ...OptionFunc) (*Snippet, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/snippets/%d", url.QueryEscape(project), snippet)
 
-	req, err := s.client.NewRequest("PUT", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("PUT", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -191,14 +191,14 @@ func (s *ProjectSnippetsService) UpdateSnippet(pid interface{}, snippet int, opt
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/project_snippets.html#delete-snippet
-func (s *ProjectSnippetsService) DeleteSnippet(pid interface{}, snippet int, sudoFunc ...SudoFunc) (*Response, error) {
+func (s *ProjectSnippetsService) DeleteSnippet(pid interface{}, snippet int, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, err
 	}
 	u := fmt.Sprintf("projects/%s/snippets/%d", url.QueryEscape(project), snippet)
 
-	req, err := s.client.NewRequest("DELETE", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
 	if err != nil {
 		return nil, err
 	}
@@ -210,14 +210,14 @@ func (s *ProjectSnippetsService) DeleteSnippet(pid interface{}, snippet int, sud
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/project_snippets.html#snippet-content
-func (s *ProjectSnippetsService) SnippetContent(pid interface{}, snippet int, sudoFunc ...SudoFunc) ([]byte, *Response, error) {
+func (s *ProjectSnippetsService) SnippetContent(pid interface{}, snippet int, options ...OptionFunc) ([]byte, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/snippets/%d/raw", url.QueryEscape(project), snippet)
 
-	req, err := s.client.NewRequest("GET", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/projects.go
+++ b/projects.go
@@ -146,8 +146,8 @@ type ListProjectsOptions struct {
 // ListProjects gets a list of projects accessible by the authenticated user.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#list-projects
-func (s *ProjectsService) ListProjects(opt *ListProjectsOptions, sudoFunc ...SudoFunc) ([]*Project, *Response, error) {
-	req, err := s.client.NewRequest("GET", "projects", opt, sudoFunc)
+func (s *ProjectsService) ListProjects(opt *ListProjectsOptions, options ...OptionFunc) ([]*Project, *Response, error) {
+	req, err := s.client.NewRequest("GET", "projects", opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -166,8 +166,8 @@ func (s *ProjectsService) ListProjects(opt *ListProjectsOptions, sudoFunc ...Sud
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/projects.html#list-owned-projects
-func (s *ProjectsService) ListOwnedProjects(opt *ListProjectsOptions, sudoFunc ...SudoFunc) ([]*Project, *Response, error) {
-	req, err := s.client.NewRequest("GET", "projects/owned", opt, sudoFunc)
+func (s *ProjectsService) ListOwnedProjects(opt *ListProjectsOptions, options ...OptionFunc) ([]*Project, *Response, error) {
+	req, err := s.client.NewRequest("GET", "projects/owned", opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -186,8 +186,8 @@ func (s *ProjectsService) ListOwnedProjects(opt *ListProjectsOptions, sudoFunc .
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/projects.html#list-starred-projects
-func (s *ProjectsService) ListStarredProjects(opt *ListProjectsOptions, sudoFunc ...SudoFunc) ([]*Project, *Response, error) {
-	req, err := s.client.NewRequest("GET", "projects/starred", opt, sudoFunc)
+func (s *ProjectsService) ListStarredProjects(opt *ListProjectsOptions, options ...OptionFunc) ([]*Project, *Response, error) {
+	req, err := s.client.NewRequest("GET", "projects/starred", opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -205,8 +205,8 @@ func (s *ProjectsService) ListStarredProjects(opt *ListProjectsOptions, sudoFunc
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/projects.html#list-all-projects
-func (s *ProjectsService) ListAllProjects(opt *ListProjectsOptions, sudoFunc ...SudoFunc) ([]*Project, *Response, error) {
-	req, err := s.client.NewRequest("GET", "projects/all", opt, sudoFunc)
+func (s *ProjectsService) ListAllProjects(opt *ListProjectsOptions, options ...OptionFunc) ([]*Project, *Response, error) {
+	req, err := s.client.NewRequest("GET", "projects/all", opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -225,14 +225,14 @@ func (s *ProjectsService) ListAllProjects(opt *ListProjectsOptions, sudoFunc ...
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/projects.html#get-single-project
-func (s *ProjectsService) GetProject(pid interface{}, sudoFunc ...SudoFunc) (*Project, *Response, error) {
+func (s *ProjectsService) GetProject(pid interface{}, options ...OptionFunc) (*Project, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("GET", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -261,10 +261,10 @@ type SearchProjectsOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/projects.html#search-for-projects-by-name
-func (s *ProjectsService) SearchProjects(query string, opt *SearchProjectsOptions, sudoFunc ...SudoFunc) ([]*Project, *Response, error) {
+func (s *ProjectsService) SearchProjects(query string, opt *SearchProjectsOptions, options ...OptionFunc) ([]*Project, *Response, error) {
 	u := fmt.Sprintf("projects/search/%s", query)
 
-	req, err := s.client.NewRequest("GET", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -320,14 +320,14 @@ type GetProjectEventsOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/projects.html#get-project-events
-func (s *ProjectsService) GetProjectEvents(pid interface{}, opt *GetProjectEventsOptions, sudoFunc ...SudoFunc) ([]*ProjectEvent, *Response, error) {
+func (s *ProjectsService) GetProjectEvents(pid interface{}, opt *GetProjectEventsOptions, options ...OptionFunc) ([]*ProjectEvent, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/events", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("GET", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -368,8 +368,8 @@ type CreateProjectOptions struct {
 // CreateProject creates a new project owned by the authenticated user.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#create-project
-func (s *ProjectsService) CreateProject(opt *CreateProjectOptions, sudoFunc ...SudoFunc) (*Project, *Response, error) {
-	req, err := s.client.NewRequest("POST", "projects", opt, sudoFunc)
+func (s *ProjectsService) CreateProject(opt *CreateProjectOptions, options ...OptionFunc) (*Project, *Response, error) {
+	req, err := s.client.NewRequest("POST", "projects", opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -406,10 +406,10 @@ type CreateProjectForUserOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/projects.html#create-project-for-user
-func (s *ProjectsService) CreateProjectForUser(user int, opt *CreateProjectForUserOptions, sudoFunc ...SudoFunc) (*Project, *Response, error) {
+func (s *ProjectsService) CreateProjectForUser(user int, opt *CreateProjectForUserOptions, options ...OptionFunc) (*Project, *Response, error) {
 	u := fmt.Sprintf("projects/user/%d", user)
 
-	req, err := s.client.NewRequest("POST", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("POST", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -452,14 +452,14 @@ type EditProjectOptions struct {
 // EditProject updates an existing project.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#edit-project
-func (s *ProjectsService) EditProject(pid interface{}, opt *EditProjectOptions, sudoFunc ...SudoFunc) (*Project, *Response, error) {
+func (s *ProjectsService) EditProject(pid interface{}, opt *EditProjectOptions, options ...OptionFunc) (*Project, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("PUT", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("PUT", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -477,14 +477,14 @@ func (s *ProjectsService) EditProject(pid interface{}, opt *EditProjectOptions, 
 // user.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#fork-project
-func (s *ProjectsService) ForkProject(pid interface{}, sudoFunc ...SudoFunc) (*Project, *Response, error) {
+func (s *ProjectsService) ForkProject(pid interface{}, options ...OptionFunc) (*Project, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/fork/%s", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("POST", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("POST", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -502,14 +502,14 @@ func (s *ProjectsService) ForkProject(pid interface{}, sudoFunc ...SudoFunc) (*P
 // (issues, merge requests etc.)
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#remove-project
-func (s *ProjectsService) DeleteProject(pid interface{}, sudoFunc ...SudoFunc) (*Response, error) {
+func (s *ProjectsService) DeleteProject(pid interface{}, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, err
 	}
 	u := fmt.Sprintf("projects/%s", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("DELETE", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
 	if err != nil {
 		return nil, err
 	}
@@ -545,14 +545,14 @@ type ListProjectMembersOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/projects.html#list-project-team-members
-func (s *ProjectsService) ListProjectMembers(pid interface{}, opt *ListProjectMembersOptions, sudoFunc ...SudoFunc) ([]*ProjectMember, *Response, error) {
+func (s *ProjectsService) ListProjectMembers(pid interface{}, opt *ListProjectMembersOptions, options ...OptionFunc) ([]*ProjectMember, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/members", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("GET", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -570,14 +570,14 @@ func (s *ProjectsService) ListProjectMembers(pid interface{}, opt *ListProjectMe
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/projects.html#get-project-team-member
-func (s *ProjectsService) GetProjectMember(pid interface{}, user int, sudoFunc ...SudoFunc) (*ProjectMember, *Response, error) {
+func (s *ProjectsService) GetProjectMember(pid interface{}, user int, options ...OptionFunc) (*ProjectMember, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/members/%d", url.QueryEscape(project), user)
 
-	req, err := s.client.NewRequest("GET", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -607,14 +607,14 @@ type AddProjectMemberOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/projects.html#add-project-team-member
-func (s *ProjectsService) AddProjectMember(pid interface{}, opt *AddProjectMemberOptions, sudoFunc ...SudoFunc) (*ProjectMember, *Response, error) {
+func (s *ProjectsService) AddProjectMember(pid interface{}, opt *AddProjectMemberOptions, options ...OptionFunc) (*ProjectMember, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/members", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("POST", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("POST", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -640,14 +640,14 @@ type EditProjectMemberOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/projects.html#edit-project-team-member
-func (s *ProjectsService) EditProjectMember(pid interface{}, user int, opt *EditProjectMemberOptions, sudoFunc ...SudoFunc) (*ProjectMember, *Response, error) {
+func (s *ProjectsService) EditProjectMember(pid interface{}, user int, opt *EditProjectMemberOptions, options ...OptionFunc) (*ProjectMember, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/members/%d", url.QueryEscape(project), user)
 
-	req, err := s.client.NewRequest("PUT", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("PUT", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -665,14 +665,14 @@ func (s *ProjectsService) EditProjectMember(pid interface{}, user int, opt *Edit
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/projects.html#remove-project-team-member
-func (s *ProjectsService) DeleteProjectMember(pid interface{}, user int, sudoFunc ...SudoFunc) (*Response, error) {
+func (s *ProjectsService) DeleteProjectMember(pid interface{}, user int, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, err
 	}
 	u := fmt.Sprintf("projects/%s/members/%d", url.QueryEscape(project), user)
 
-	req, err := s.client.NewRequest("DELETE", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
 	if err != nil {
 		return nil, err
 	}
@@ -711,14 +711,14 @@ type ListProjectHooksOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/projects.html#list-project-hooks
-func (s *ProjectsService) ListProjectHooks(pid interface{}, opt *ListProjectHooksOptions, sudoFunc ...SudoFunc) ([]*ProjectHook, *Response, error) {
+func (s *ProjectsService) ListProjectHooks(pid interface{}, opt *ListProjectHooksOptions, options ...OptionFunc) ([]*ProjectHook, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/hooks", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("GET", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -736,14 +736,14 @@ func (s *ProjectsService) ListProjectHooks(pid interface{}, opt *ListProjectHook
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/projects.html#get-project-hook
-func (s *ProjectsService) GetProjectHook(pid interface{}, hook int, sudoFunc ...SudoFunc) (*ProjectHook, *Response, error) {
+func (s *ProjectsService) GetProjectHook(pid interface{}, hook int, options ...OptionFunc) (*ProjectHook, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/hooks/%d", url.QueryEscape(project), hook)
 
-	req, err := s.client.NewRequest("GET", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -779,14 +779,14 @@ type AddProjectHookOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/projects.html#add-project-hook
-func (s *ProjectsService) AddProjectHook(pid interface{}, opt *AddProjectHookOptions, sudoFunc ...SudoFunc) (*ProjectHook, *Response, error) {
+func (s *ProjectsService) AddProjectHook(pid interface{}, opt *AddProjectHookOptions, options ...OptionFunc) (*ProjectHook, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/hooks", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("POST", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("POST", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -822,14 +822,14 @@ type EditProjectHookOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/projects.html#edit-project-hook
-func (s *ProjectsService) EditProjectHook(pid interface{}, hook int, opt *EditProjectHookOptions, sudoFunc ...SudoFunc) (*ProjectHook, *Response, error) {
+func (s *ProjectsService) EditProjectHook(pid interface{}, hook int, opt *EditProjectHookOptions, options ...OptionFunc) (*ProjectHook, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/hooks/%d", url.QueryEscape(project), hook)
 
-	req, err := s.client.NewRequest("PUT", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("PUT", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -848,14 +848,14 @@ func (s *ProjectsService) EditProjectHook(pid interface{}, hook int, opt *EditPr
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/projects.html#delete-project-hook
-func (s *ProjectsService) DeleteProjectHook(pid interface{}, hook int, sudoFunc ...SudoFunc) (*Response, error) {
+func (s *ProjectsService) DeleteProjectHook(pid interface{}, hook int, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, err
 	}
 	u := fmt.Sprintf("projects/%s/hooks/%d", url.QueryEscape(project), hook)
 
-	req, err := s.client.NewRequest("DELETE", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
 	if err != nil {
 		return nil, err
 	}
@@ -880,10 +880,10 @@ type ProjectForkRelation struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/projects.html#create-a-forked-fromto-relation-between-existing-projects.
-func (s *ProjectsService) CreateProjectForkRelation(pid int, fork int, sudoFunc ...SudoFunc) (*ProjectForkRelation, *Response, error) {
+func (s *ProjectsService) CreateProjectForkRelation(pid int, fork int, options ...OptionFunc) (*ProjectForkRelation, *Response, error) {
 	u := fmt.Sprintf("projects/%d/fork/%d", pid, fork)
 
-	req, err := s.client.NewRequest("POST", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("POST", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -901,10 +901,10 @@ func (s *ProjectsService) CreateProjectForkRelation(pid int, fork int, sudoFunc 
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/projects.html#delete-an-existing-forked-from-relationship
-func (s *ProjectsService) DeleteProjectForkRelation(pid int, sudoFunc ...SudoFunc) (*Response, error) {
+func (s *ProjectsService) DeleteProjectForkRelation(pid int, options ...OptionFunc) (*Response, error) {
 	u := fmt.Sprintf("projects/%d/fork", pid)
 
-	req, err := s.client.NewRequest("DELETE", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
 	if err != nil {
 		return nil, err
 	}
@@ -917,14 +917,14 @@ func (s *ProjectsService) DeleteProjectForkRelation(pid int, sudoFunc ...SudoFun
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/projects.html#archive-a-project
-func (s *ProjectsService) ArchiveProject(pid interface{}, sudoFunc ...SudoFunc) (*Project, *Response, error) {
+func (s *ProjectsService) ArchiveProject(pid interface{}, options ...OptionFunc) (*Project, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/archive", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("POST", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("POST", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -943,14 +943,14 @@ func (s *ProjectsService) ArchiveProject(pid interface{}, sudoFunc ...SudoFunc) 
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/projects.html#unarchive-a-project
-func (s *ProjectsService) UnarchiveProject(pid interface{}, sudoFunc ...SudoFunc) (*Project, *Response, error) {
+func (s *ProjectsService) UnarchiveProject(pid interface{}, options ...OptionFunc) (*Project, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/unarchive", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("POST", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("POST", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/repositories.go
+++ b/repositories.go
@@ -57,14 +57,14 @@ type ListTreeOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/repositories.html#list-repository-tree
-func (s *RepositoriesService) ListTree(pid interface{}, opt *ListTreeOptions, sudoFunc ...SudoFunc) ([]*TreeNode, *Response, error) {
+func (s *RepositoriesService) ListTree(pid interface{}, opt *ListTreeOptions, options ...OptionFunc) ([]*TreeNode, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/repository/tree", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("GET", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -90,14 +90,14 @@ type RawFileContentOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/repositories.html#raw-file-content
-func (s *RepositoriesService) RawFileContent(pid interface{}, sha string, opt *RawFileContentOptions, sudoFunc ...SudoFunc) ([]byte, *Response, error) {
+func (s *RepositoriesService) RawFileContent(pid interface{}, sha string, opt *RawFileContentOptions, options ...OptionFunc) ([]byte, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/repository/blobs/%s", url.QueryEscape(project), sha)
 
-	req, err := s.client.NewRequest("GET", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -115,14 +115,14 @@ func (s *RepositoriesService) RawFileContent(pid interface{}, sha string, opt *R
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/repositories.html#raw-blob-content
-func (s *RepositoriesService) RawBlobContent(pid interface{}, sha string, sudoFunc ...SudoFunc) ([]byte, *Response, error) {
+func (s *RepositoriesService) RawBlobContent(pid interface{}, sha string, options ...OptionFunc) ([]byte, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/repository/raw_blobs/%s", url.QueryEscape(project), sha)
 
-	req, err := s.client.NewRequest("GET", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -148,14 +148,14 @@ type ArchiveOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/repositories.html#get-file-archive
-func (s *RepositoriesService) Archive(pid interface{}, opt *ArchiveOptions, sudoFunc ...SudoFunc) ([]byte, *Response, error) {
+func (s *RepositoriesService) Archive(pid interface{}, opt *ArchiveOptions, options ...OptionFunc) ([]byte, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/repository/archive", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("GET", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -198,14 +198,14 @@ type CompareOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/repositories.html#compare-branches-tags-or-commits
-func (s *RepositoriesService) Compare(pid interface{}, opt *CompareOptions, sudoFunc ...SudoFunc) (*Compare, *Response, error) {
+func (s *RepositoriesService) Compare(pid interface{}, opt *CompareOptions, options ...OptionFunc) (*Compare, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/repository/compare", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("GET", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -237,14 +237,14 @@ func (c Contributor) String() string {
 // Contributors gets the repository contributors list.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/repositories.html#contributer
-func (s *RepositoriesService) Contributors(pid interface{}, sudoFunc ...SudoFunc) ([]*Contributor, *Response, error) {
+func (s *RepositoriesService) Contributors(pid interface{}, options ...OptionFunc) ([]*Contributor, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/repository/contributors", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("GET", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/repository_files.go
+++ b/repository_files.go
@@ -61,14 +61,14 @@ type GetFileOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/repository_files.html#get-file-from-respository
-func (s *RepositoryFilesService) GetFile(pid interface{}, opt *GetFileOptions, sudoFunc ...SudoFunc) (*File, *Response, error) {
+func (s *RepositoryFilesService) GetFile(pid interface{}, opt *GetFileOptions, options ...OptionFunc) (*File, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/repository/files", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("GET", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -112,14 +112,14 @@ type CreateFileOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/repository_files.html#create-new-file-in-repository
-func (s *RepositoryFilesService) CreateFile(pid interface{}, opt *CreateFileOptions, sudoFunc ...SudoFunc) (*FileInfo, *Response, error) {
+func (s *RepositoryFilesService) CreateFile(pid interface{}, opt *CreateFileOptions, options ...OptionFunc) (*FileInfo, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/repository/files", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("POST", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("POST", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -151,14 +151,14 @@ type UpdateFileOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/repository_files.html#update-existing-file-in-repository
-func (s *RepositoryFilesService) UpdateFile(pid interface{}, opt *UpdateFileOptions, sudoFunc ...SudoFunc) (*FileInfo, *Response, error) {
+func (s *RepositoryFilesService) UpdateFile(pid interface{}, opt *UpdateFileOptions, options ...OptionFunc) (*FileInfo, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/repository/files", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("PUT", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("PUT", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -188,14 +188,14 @@ type DeleteFileOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/repository_files.html#delete-existing-file-in-repository
-func (s *RepositoryFilesService) DeleteFile(pid interface{}, opt *DeleteFileOptions, sudoFunc ...SudoFunc) (*FileInfo, *Response, error) {
+func (s *RepositoryFilesService) DeleteFile(pid interface{}, opt *DeleteFileOptions, options ...OptionFunc) (*FileInfo, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/repository/files", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("DELETE", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("DELETE", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/services.go
+++ b/services.go
@@ -60,14 +60,14 @@ type SetGitLabCIServiceOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/services.html#edit-gitlab-ci-service
-func (s *ServicesService) SetGitLabCIService(pid interface{}, opt *SetGitLabCIServiceOptions, sudoFunc ...SudoFunc) (*Response, error) {
+func (s *ServicesService) SetGitLabCIService(pid interface{}, opt *SetGitLabCIServiceOptions, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, err
 	}
 	u := fmt.Sprintf("projects/%s/services/gitlab-ci", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("PUT", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("PUT", u, opt, options)
 	if err != nil {
 		return nil, err
 	}
@@ -79,14 +79,14 @@ func (s *ServicesService) SetGitLabCIService(pid interface{}, opt *SetGitLabCISe
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/services.html#delete-gitlab-ci-service
-func (s *ServicesService) DeleteGitLabCIService(pid interface{}, sudoFunc ...SudoFunc) (*Response, error) {
+func (s *ServicesService) DeleteGitLabCIService(pid interface{}, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, err
 	}
 	u := fmt.Sprintf("projects/%s/services/gitlab-ci", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("DELETE", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
 	if err != nil {
 		return nil, err
 	}
@@ -108,14 +108,14 @@ type SetHipChatServiceOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/services.html#edit-hipchat-service
-func (s *ServicesService) SetHipChatService(pid interface{}, opt *SetHipChatServiceOptions, sudoFunc ...SudoFunc) (*Response, error) {
+func (s *ServicesService) SetHipChatService(pid interface{}, opt *SetHipChatServiceOptions, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, err
 	}
 	u := fmt.Sprintf("projects/%s/services/hipchat", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("PUT", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("PUT", u, opt, options)
 	if err != nil {
 		return nil, err
 	}
@@ -127,14 +127,14 @@ func (s *ServicesService) SetHipChatService(pid interface{}, opt *SetHipChatServ
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/services.html#delete-hipchat-service
-func (s *ServicesService) DeleteHipChatService(pid interface{}, sudoFunc ...SudoFunc) (*Response, error) {
+func (s *ServicesService) DeleteHipChatService(pid interface{}, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, err
 	}
 	u := fmt.Sprintf("projects/%s/services/hipchat", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("DELETE", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
 	if err != nil {
 		return nil, err
 	}
@@ -157,14 +157,14 @@ type SetDroneCIServiceOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/services.html#createedit-drone-ci-service
-func (s *ServicesService) SetDroneCIService(pid interface{}, opt *SetDroneCIServiceOptions, sudoFunc ...SudoFunc) (*Response, error) {
+func (s *ServicesService) SetDroneCIService(pid interface{}, opt *SetDroneCIServiceOptions, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, err
 	}
 	u := fmt.Sprintf("projects/%s/services/drone-ci", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("PUT", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("PUT", u, opt, options)
 	if err != nil {
 		return nil, err
 	}
@@ -176,14 +176,14 @@ func (s *ServicesService) SetDroneCIService(pid interface{}, opt *SetDroneCIServ
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/services.html#delete-drone-ci-service
-func (s *ServicesService) DeleteDroneCIService(pid interface{}, sudoFunc ...SudoFunc) (*Response, error) {
+func (s *ServicesService) DeleteDroneCIService(pid interface{}, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, err
 	}
 	u := fmt.Sprintf("projects/%s/services/drone-ci", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("DELETE", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
 	if err != nil {
 		return nil, err
 	}
@@ -208,14 +208,14 @@ type DroneCIService struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/services.html#get-drone-ci-service-settings
-func (s *ServicesService) GetDroneCIService(pid interface{}, sudoFunc ...SudoFunc) (*DroneCIService, *Response, error) {
+func (s *ServicesService) GetDroneCIService(pid interface{}, options ...OptionFunc) (*DroneCIService, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/services/drone-ci", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("GET", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -244,14 +244,14 @@ type SetSlackServiceOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/services.html#edit-slack-service
-func (s *ServicesService) SetSlackService(pid interface{}, opt *SetSlackServiceOptions, sudoFunc ...SudoFunc) (*Response, error) {
+func (s *ServicesService) SetSlackService(pid interface{}, opt *SetSlackServiceOptions, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, err
 	}
 	u := fmt.Sprintf("projects/%s/services/slack", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("PUT", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("PUT", u, opt, options)
 	if err != nil {
 		return nil, err
 	}
@@ -263,14 +263,14 @@ func (s *ServicesService) SetSlackService(pid interface{}, opt *SetSlackServiceO
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/services.html#delete-slack-service
-func (s *ServicesService) DeleteSlackService(pid interface{}, sudoFunc ...SudoFunc) (*Response, error) {
+func (s *ServicesService) DeleteSlackService(pid interface{}, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, err
 	}
 	u := fmt.Sprintf("projects/%s/services/slack", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("DELETE", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
 	if err != nil {
 		return nil, err
 	}

--- a/session.go
+++ b/session.go
@@ -62,8 +62,8 @@ type GetSessionOptions struct {
 // GetSession logs in to get private token.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/session.html#session
-func (s *SessionService) GetSession(opt *GetSessionOptions, sudoFunc ...SudoFunc) (*Session, *Response, error) {
-	req, err := s.client.NewRequest("POST", "session", opt, sudoFunc)
+func (s *SessionService) GetSession(opt *GetSessionOptions, options ...OptionFunc) (*Session, *Response, error) {
+	req, err := s.client.NewRequest("POST", "session", opt, options)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/settings.go
+++ b/settings.go
@@ -59,8 +59,8 @@ func (s Settings) String() string {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/settings.html#get-current-application.settings
-func (s *SettingsService) GetSettings(sudoFunc ...SudoFunc) (*Settings, *Response, error) {
-	req, err := s.client.NewRequest("GET", "application/settings", nil, sudoFunc)
+func (s *SettingsService) GetSettings(options ...OptionFunc) (*Settings, *Response, error) {
+	req, err := s.client.NewRequest("GET", "application/settings", nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -101,8 +101,8 @@ type UpdateSettingsOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/settings.html#change-application.settings
-func (s *SettingsService) UpdateSettings(opt *UpdateSettingsOptions, sudoFunc ...SudoFunc) (*Settings, *Response, error) {
-	req, err := s.client.NewRequest("PUT", "application/settings", opt, sudoFunc)
+func (s *SettingsService) UpdateSettings(opt *UpdateSettingsOptions, options ...OptionFunc) (*Settings, *Response, error) {
+	req, err := s.client.NewRequest("PUT", "application/settings", opt, options)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/system_hooks.go
+++ b/system_hooks.go
@@ -46,8 +46,8 @@ func (h Hook) String() string {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/system_hooks.html#list-system-hooks
-func (s *SystemHooksService) ListHooks(sudoFunc ...SudoFunc) ([]*Hook, *Response, error) {
-	req, err := s.client.NewRequest("GET", "hooks", nil, sudoFunc)
+func (s *SystemHooksService) ListHooks(options ...OptionFunc) ([]*Hook, *Response, error) {
+	req, err := s.client.NewRequest("GET", "hooks", nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -73,8 +73,8 @@ type AddHookOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/system_hooks.html#add-new-system-hook-hook
-func (s *SystemHooksService) AddHook(opt *AddHookOptions, sudoFunc ...SudoFunc) (*Hook, *Response, error) {
-	req, err := s.client.NewRequest("POST", "hooks", opt, sudoFunc)
+func (s *SystemHooksService) AddHook(opt *AddHookOptions, options ...OptionFunc) (*Hook, *Response, error) {
+	req, err := s.client.NewRequest("POST", "hooks", opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -108,10 +108,10 @@ func (h HookEvent) String() string {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/system_hooks.html#test-system-hook
-func (s *SystemHooksService) TestHook(hook int, sudoFunc ...SudoFunc) (*HookEvent, *Response, error) {
+func (s *SystemHooksService) TestHook(hook int, options ...OptionFunc) (*HookEvent, *Response, error) {
 	u := fmt.Sprintf("hooks/%d", hook)
 
-	req, err := s.client.NewRequest("GET", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -131,10 +131,10 @@ func (s *SystemHooksService) TestHook(hook int, sudoFunc ...SudoFunc) (*HookEven
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/system_hooks.html#delete-system-hook
-func (s *SystemHooksService) DeleteHook(hook int, sudoFunc ...SudoFunc) (*Response, error) {
+func (s *SystemHooksService) DeleteHook(hook int, options ...OptionFunc) (*Response, error) {
 	u := fmt.Sprintf("hooks/%d", hook)
 
-	req, err := s.client.NewRequest("DELETE", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
 	if err != nil {
 		return nil, err
 	}

--- a/tags.go
+++ b/tags.go
@@ -47,14 +47,14 @@ func (r Tag) String() string {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/tags.html#list-project-repository-tags
-func (s *TagsService) ListTags(pid interface{}, sudoFunc ...SudoFunc) ([]*Tag, *Response, error) {
+func (s *TagsService) ListTags(pid interface{}, options ...OptionFunc) ([]*Tag, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/repository/tags", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("GET", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -73,14 +73,14 @@ func (s *TagsService) ListTags(pid interface{}, sudoFunc ...SudoFunc) ([]*Tag, *
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/tags.html#get-a-single-repository-tag
-func (s *TagsService) GetTag(pid interface{}, tag string, sudoFunc ...SudoFunc) (*Tag, *Response, error) {
+func (s *TagsService) GetTag(pid interface{}, tag string, options ...OptionFunc) (*Tag, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/repository/tags/%s", url.QueryEscape(project), tag)
 
-	req, err := s.client.NewRequest("GET", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -108,14 +108,14 @@ type CreateTagOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/tags.html#create-a-new-tag
-func (s *TagsService) CreateTag(pid interface{}, opt *CreateTagOptions, sudoFunc ...SudoFunc) (*Tag, *Response, error) {
+func (s *TagsService) CreateTag(pid interface{}, opt *CreateTagOptions, options ...OptionFunc) (*Tag, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/repository/tags", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("POST", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("POST", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -133,14 +133,14 @@ func (s *TagsService) CreateTag(pid interface{}, opt *CreateTagOptions, sudoFunc
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/tags.html#delete-a-tag
-func (s *TagsService) DeleteTag(pid interface{}, tag string, sudoFunc ...SudoFunc) (*Response, error) {
+func (s *TagsService) DeleteTag(pid interface{}, tag string, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, err
 	}
 	u := fmt.Sprintf("projects/%s/repository/tags/%s", url.QueryEscape(project), tag)
 
-	req, err := s.client.NewRequest("DELETE", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
 	if err != nil {
 		return nil, err
 	}

--- a/time_stats.go
+++ b/time_stats.go
@@ -41,14 +41,14 @@ type SetTimeEstimateOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/issues.html#set-a-time-estimate-for-an-issue
-func (s *TimeStatsService) SetTimeEstimate(pid interface{}, issue int, opt *SetTimeEstimateOptions, sudoFunc ...SudoFunc) (*TimeStats, *Response, error) {
+func (s *TimeStatsService) SetTimeEstimate(pid interface{}, issue int, opt *SetTimeEstimateOptions, options ...OptionFunc) (*TimeStats, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/issues/%d/time_estimate", url.QueryEscape(project), issue)
 
-	req, err := s.client.NewRequest("POST", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("POST", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -66,14 +66,14 @@ func (s *TimeStatsService) SetTimeEstimate(pid interface{}, issue int, opt *SetT
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/issues.html#reset-the-time-estimate-for-an-issue
-func (s *TimeStatsService) ResetTimeEstimate(pid interface{}, issue int, sudoFunc ...SudoFunc) (*TimeStats, *Response, error) {
+func (s *TimeStatsService) ResetTimeEstimate(pid interface{}, issue int, options ...OptionFunc) (*TimeStats, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/issues/%d/reset_time_estimate", url.QueryEscape(project), issue)
 
-	req, err := s.client.NewRequest("POST", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("POST", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -99,14 +99,14 @@ type AddSpentTimeOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/issues.html#add-spent-time-for-an-issue
-func (s *TimeStatsService) AddSpentTime(pid interface{}, issue int, opt *AddSpentTimeOptions, sudoFunc ...SudoFunc) (*TimeStats, *Response, error) {
+func (s *TimeStatsService) AddSpentTime(pid interface{}, issue int, opt *AddSpentTimeOptions, options ...OptionFunc) (*TimeStats, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/issues/%d/add_spent_time", url.QueryEscape(project), issue)
 
-	req, err := s.client.NewRequest("POST", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("POST", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -124,14 +124,14 @@ func (s *TimeStatsService) AddSpentTime(pid interface{}, issue int, opt *AddSpen
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/issues.html#reset-spent-time-for-an-issue
-func (s *TimeStatsService) ResetSpentTime(pid interface{}, issue int, sudoFunc ...SudoFunc) (*TimeStats, *Response, error) {
+func (s *TimeStatsService) ResetSpentTime(pid interface{}, issue int, options ...OptionFunc) (*TimeStats, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/issues/%d/reset_spent_time", url.QueryEscape(project), issue)
 
-	req, err := s.client.NewRequest("POST", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("POST", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -149,14 +149,14 @@ func (s *TimeStatsService) ResetSpentTime(pid interface{}, issue int, sudoFunc .
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/issues.html#get-time-tracking-stats
-func (s *TimeStatsService) GetTimeSpent(pid interface{}, issue int, sudoFunc ...SudoFunc) (*TimeStats, *Response, error) {
+func (s *TimeStatsService) GetTimeSpent(pid interface{}, issue int, options ...OptionFunc) (*TimeStats, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/issues/%d/time_stats", url.QueryEscape(project), issue)
 
-	req, err := s.client.NewRequest("GET", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/users.go
+++ b/users.go
@@ -79,8 +79,8 @@ type ListUsersOptions struct {
 // ListUsers gets a list of users.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/users.html#list-users
-func (s *UsersService) ListUsers(opt *ListUsersOptions, sudoFunc ...SudoFunc) ([]*User, *Response, error) {
-	req, err := s.client.NewRequest("GET", "users", opt, sudoFunc)
+func (s *UsersService) ListUsers(opt *ListUsersOptions, options ...OptionFunc) ([]*User, *Response, error) {
+	req, err := s.client.NewRequest("GET", "users", opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -97,10 +97,10 @@ func (s *UsersService) ListUsers(opt *ListUsersOptions, sudoFunc ...SudoFunc) ([
 // GetUser gets a single user.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/users.html#single-user
-func (s *UsersService) GetUser(user int, sudoFunc ...SudoFunc) (*User, *Response, error) {
+func (s *UsersService) GetUser(user int, options ...OptionFunc) (*User, *Response, error) {
 	u := fmt.Sprintf("users/%d", user)
 
-	req, err := s.client.NewRequest("GET", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -138,8 +138,8 @@ type CreateUserOptions struct {
 // CreateUser creates a new user. Note only administrators can create new users.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/users.html#user-creation
-func (s *UsersService) CreateUser(opt *CreateUserOptions, sudoFunc ...SudoFunc) (*User, *Response, error) {
-	req, err := s.client.NewRequest("POST", "users", opt, sudoFunc)
+func (s *UsersService) CreateUser(opt *CreateUserOptions, options ...OptionFunc) (*User, *Response, error) {
+	req, err := s.client.NewRequest("POST", "users", opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -177,10 +177,10 @@ type ModifyUserOptions struct {
 // of a user.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/users.html#user-modification
-func (s *UsersService) ModifyUser(user int, opt *ModifyUserOptions, sudoFunc ...SudoFunc) (*User, *Response, error) {
+func (s *UsersService) ModifyUser(user int, opt *ModifyUserOptions, options ...OptionFunc) (*User, *Response, error) {
 	u := fmt.Sprintf("users/%d", user)
 
-	req, err := s.client.NewRequest("PUT", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("PUT", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -201,10 +201,10 @@ func (s *UsersService) ModifyUser(user int, opt *ModifyUserOptions, sudoFunc ...
 // latter not.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/users.html#user-deletion
-func (s *UsersService) DeleteUser(user int, sudoFunc ...SudoFunc) (*Response, error) {
+func (s *UsersService) DeleteUser(user int, options ...OptionFunc) (*Response, error) {
 	u := fmt.Sprintf("users/%d", user)
 
-	req, err := s.client.NewRequest("DELETE", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
 	if err != nil {
 		return nil, err
 	}
@@ -215,8 +215,8 @@ func (s *UsersService) DeleteUser(user int, sudoFunc ...SudoFunc) (*Response, er
 // CurrentUser gets currently authenticated user.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/users.html#current-user
-func (s *UsersService) CurrentUser(sudoFunc ...SudoFunc) (*User, *Response, error) {
-	req, err := s.client.NewRequest("GET", "user", nil, sudoFunc)
+func (s *UsersService) CurrentUser(options ...OptionFunc) (*User, *Response, error) {
+	req, err := s.client.NewRequest("GET", "user", nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -243,8 +243,8 @@ type SSHKey struct {
 // ListSSHKeys gets a list of currently authenticated user's SSH keys.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/users.html#list-ssh-keys
-func (s *UsersService) ListSSHKeys(sudoFunc ...SudoFunc) ([]*SSHKey, *Response, error) {
-	req, err := s.client.NewRequest("GET", "user/keys", nil, sudoFunc)
+func (s *UsersService) ListSSHKeys(options ...OptionFunc) ([]*SSHKey, *Response, error) {
+	req, err := s.client.NewRequest("GET", "user/keys", nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -263,10 +263,10 @@ func (s *UsersService) ListSSHKeys(sudoFunc ...SudoFunc) ([]*SSHKey, *Response, 
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/users.html#list-ssh-keys-for-user
-func (s *UsersService) ListSSHKeysForUser(user int, sudoFunc ...SudoFunc) ([]*SSHKey, *Response, error) {
+func (s *UsersService) ListSSHKeysForUser(user int, options ...OptionFunc) ([]*SSHKey, *Response, error) {
 	u := fmt.Sprintf("users/%d/keys", user)
 
-	req, err := s.client.NewRequest("GET", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -283,10 +283,10 @@ func (s *UsersService) ListSSHKeysForUser(user int, sudoFunc ...SudoFunc) ([]*SS
 // GetSSHKey gets a single key.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/users.html#single-ssh-key
-func (s *UsersService) GetSSHKey(kid int, sudoFunc ...SudoFunc) (*SSHKey, *Response, error) {
+func (s *UsersService) GetSSHKey(kid int, options ...OptionFunc) (*SSHKey, *Response, error) {
 	u := fmt.Sprintf("user/keys/%d", kid)
 
-	req, err := s.client.NewRequest("GET", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -311,8 +311,8 @@ type AddSSHKeyOptions struct {
 // AddSSHKey creates a new key owned by the currently authenticated user.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/users.html#add-ssh-key
-func (s *UsersService) AddSSHKey(opt *AddSSHKeyOptions, sudoFunc ...SudoFunc) (*SSHKey, *Response, error) {
-	req, err := s.client.NewRequest("POST", "user/keys", opt, sudoFunc)
+func (s *UsersService) AddSSHKey(opt *AddSSHKeyOptions, options ...OptionFunc) (*SSHKey, *Response, error) {
+	req, err := s.client.NewRequest("POST", "user/keys", opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -330,10 +330,10 @@ func (s *UsersService) AddSSHKey(opt *AddSSHKeyOptions, sudoFunc ...SudoFunc) (*
 // admin.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/users.html#add-ssh-key-for-user
-func (s *UsersService) AddSSHKeyForUser(user int, opt *AddSSHKeyOptions, sudoFunc ...SudoFunc) (*SSHKey, *Response, error) {
+func (s *UsersService) AddSSHKeyForUser(user int, opt *AddSSHKeyOptions, options ...OptionFunc) (*SSHKey, *Response, error) {
 	u := fmt.Sprintf("users/%d/keys", user)
 
-	req, err := s.client.NewRequest("POST", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("POST", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -353,10 +353,10 @@ func (s *UsersService) AddSSHKeyForUser(user int, opt *AddSSHKeyOptions, sudoFun
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/users.html#delete-ssh-key-for-current-owner
-func (s *UsersService) DeleteSSHKey(kid int, sudoFunc ...SudoFunc) (*Response, error) {
+func (s *UsersService) DeleteSSHKey(kid int, options ...OptionFunc) (*Response, error) {
 	u := fmt.Sprintf("user/keys/%d", kid)
 
-	req, err := s.client.NewRequest("DELETE", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
 	if err != nil {
 		return nil, err
 	}
@@ -369,10 +369,10 @@ func (s *UsersService) DeleteSSHKey(kid int, sudoFunc ...SudoFunc) (*Response, e
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/users.html#delete-ssh-key-for-given-user
-func (s *UsersService) DeleteSSHKeyForUser(user int, kid int, sudoFunc ...SudoFunc) (*Response, error) {
+func (s *UsersService) DeleteSSHKeyForUser(user int, kid int, options ...OptionFunc) (*Response, error) {
 	u := fmt.Sprintf("users/%d/keys/%d", user, kid)
 
-	req, err := s.client.NewRequest("DELETE", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
 	if err != nil {
 		return nil, err
 	}
@@ -383,10 +383,10 @@ func (s *UsersService) DeleteSSHKeyForUser(user int, kid int, sudoFunc ...SudoFu
 // BlockUser blocks the specified user. Available only for admin.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/users.html#block-user
-func (s *UsersService) BlockUser(user int, sudoFunc ...SudoFunc) error {
+func (s *UsersService) BlockUser(user int, options ...OptionFunc) error {
 	u := fmt.Sprintf("users/%d/block", user)
 
-	req, err := s.client.NewRequest("PUT", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("PUT", u, nil, options)
 	if err != nil {
 		return err
 	}
@@ -411,10 +411,10 @@ func (s *UsersService) BlockUser(user int, sudoFunc ...SudoFunc) error {
 // UnblockUser unblocks the specified user. Available only for admin.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/users.html#unblock-user
-func (s *UsersService) UnblockUser(user int, sudoFunc ...SudoFunc) error {
+func (s *UsersService) UnblockUser(user int, options ...OptionFunc) error {
 	u := fmt.Sprintf("users/%d/unblock", user)
 
-	req, err := s.client.NewRequest("PUT", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("PUT", u, nil, options)
 	if err != nil {
 		return err
 	}
@@ -447,8 +447,8 @@ type Email struct {
 // ListEmails gets a list of currently authenticated user's Emails.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/users.html#list-emails
-func (s *UsersService) ListEmails(sudoFunc ...SudoFunc) ([]*Email, *Response, error) {
-	req, err := s.client.NewRequest("GET", "user/emails", nil, sudoFunc)
+func (s *UsersService) ListEmails(options ...OptionFunc) ([]*Email, *Response, error) {
+	req, err := s.client.NewRequest("GET", "user/emails", nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -467,10 +467,10 @@ func (s *UsersService) ListEmails(sudoFunc ...SudoFunc) ([]*Email, *Response, er
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/users.html#list-emails-for-user
-func (s *UsersService) ListEmailsForUser(uid int, sudoFunc ...SudoFunc) ([]*Email, *Response, error) {
+func (s *UsersService) ListEmailsForUser(uid int, options ...OptionFunc) ([]*Email, *Response, error) {
 	u := fmt.Sprintf("users/%d/emails", uid)
 
-	req, err := s.client.NewRequest("GET", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -487,10 +487,10 @@ func (s *UsersService) ListEmailsForUser(uid int, sudoFunc ...SudoFunc) ([]*Emai
 // GetEmail gets a single email.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/users.html#single-email
-func (s *UsersService) GetEmail(eid int, sudoFunc ...SudoFunc) (*Email, *Response, error) {
+func (s *UsersService) GetEmail(eid int, options ...OptionFunc) (*Email, *Response, error) {
 	u := fmt.Sprintf("user/emails/%d", eid)
 
-	req, err := s.client.NewRequest("GET", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -514,8 +514,8 @@ type AddEmailOptions struct {
 // AddEmail creates a new email owned by the currently authenticated user.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/users.html#add-email
-func (s *UsersService) AddEmail(opt *AddEmailOptions, sudoFunc ...SudoFunc) (*Email, *Response, error) {
-	req, err := s.client.NewRequest("POST", "user/emails", opt, sudoFunc)
+func (s *UsersService) AddEmail(opt *AddEmailOptions, options ...OptionFunc) (*Email, *Response, error) {
+	req, err := s.client.NewRequest("POST", "user/emails", opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -533,10 +533,10 @@ func (s *UsersService) AddEmail(opt *AddEmailOptions, sudoFunc ...SudoFunc) (*Em
 // admin.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/users.html#add-email-for-user
-func (s *UsersService) AddEmailForUser(uid int, opt *AddEmailOptions, sudoFunc ...SudoFunc) (*Email, *Response, error) {
+func (s *UsersService) AddEmailForUser(uid int, opt *AddEmailOptions, options ...OptionFunc) (*Email, *Response, error) {
 	u := fmt.Sprintf("users/%d/emails", uid)
 
-	req, err := s.client.NewRequest("POST", u, opt, sudoFunc)
+	req, err := s.client.NewRequest("POST", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -556,10 +556,10 @@ func (s *UsersService) AddEmailForUser(uid int, opt *AddEmailOptions, sudoFunc .
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/users.html#delete-email-for-current-owner
-func (s *UsersService) DeleteEmail(eid int, sudoFunc ...SudoFunc) (*Response, error) {
+func (s *UsersService) DeleteEmail(eid int, options ...OptionFunc) (*Response, error) {
 	u := fmt.Sprintf("user/emails/%d", eid)
 
-	req, err := s.client.NewRequest("DELETE", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
 	if err != nil {
 		return nil, err
 	}
@@ -572,10 +572,10 @@ func (s *UsersService) DeleteEmail(eid int, sudoFunc ...SudoFunc) (*Response, er
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/users.html#delete-email-for-given-user
-func (s *UsersService) DeleteEmailForUser(uid int, eid int, sudoFunc ...SudoFunc) (*Response, error) {
+func (s *UsersService) DeleteEmailForUser(uid int, eid int, options ...OptionFunc) (*Response, error) {
 	u := fmt.Sprintf("users/%d/emails/%d", uid, eid)
 
-	req, err := s.client.NewRequest("DELETE", u, nil, sudoFunc)
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
It looks like these options functions are pretty much always called `With…` which makes them better recognizable. So I renamed the `SudoUser` func as well as the `SudoFunc` type to make them more generic and idiomatic.