### PR TITLE
Extend CommitsService (create commits / cherry-pick)

### DIFF
--- a/commits.go
+++ b/commits.go
@@ -89,10 +89,10 @@ type Commit struct {
 	Title          string       `json:"title"`
 	AuthorName     string       `json:"author_name"`
 	AuthorEmail    string       `json:"author_email"`
-  AuthoredDate   *time.Time   `json:"authored_date"`
+  	AuthoredDate   *time.Time   `json:"authored_date"`
 	CommitterName  string       `json:"committer_name"`
 	CommitterEmail string       `json:"committer_email"`
-  CommittedDate  *time.Time   `json:"committed_date"`
+  	CommittedDate  *time.Time   `json:"committed_date"`
 	CreatedAt      *time.Time   `json:"created_at"`
 	Message        string       `json:"message"`
 	ParentIDs      []string     `json:"parent_ids"`


### PR DESCRIPTION
This PR extends the `CommitsService` to also allow creating new commits and cherry-picking a commit.

See:
https://docs.gitlab.com/ce/api/commits.html#create-a-commit-with-multiple-files-and-actions
https://docs.gitlab.com/ce/api/commits.html#cherry-pick-a-commit

Also added some missing fields to the `Commit` struct.