### PR TITLE
Commit: Fix parent_ids field (typo)

### DIFF
--- a/commits.go
+++ b/commits.go
@@ -43,7 +43,7 @@ type Commit struct {
 	CommittedDate *time.Time `json:"committed_date"`
 	CreatedAt     *time.Time `json:"created_at"`
 	Message       string     `json:"message"`
-	ParentsIds    []string   `json:"parents_ids"`
+	ParentIds     []string   `json:"parent_ids"`
 }
 
 func (c Commit) String() string {


### PR DESCRIPTION
This also renames the Go field, which may break things. Probably not a
lot though - ParentIds never had any content.

This typo probably is a result from invalid Gitlab API documentation
on tags, which also wrongly uses `parents_ids`.

I created a merge request there as well:

https://gitlab.com/gitlab-org/gitlab-ce/merge_requests/9550