### PR TITLE
Add statistics information and flag to query options

### DIFF
--- a/groups.go
+++ b/groups.go
@@ -33,12 +33,12 @@ type GroupsService struct {
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/groups.html
 type Group struct {
-	ID          int               `json:"id"`
-	Name        string            `json:"name"`
-	Path        string            `json:"path"`
-	Description string            `json:"description"`
-	Projects    *[]Project        `json:"projects,omitempty"`
-	Statistics  StorageStatistics `json:"statistics"`
+	ID          int                `json:"id"`
+	Name        string             `json:"name"`
+	Path        string             `json:"path"`
+	Description string             `json:"description"`
+	Projects    *[]Project         `json:"projects,omitempty"`
+	Statistics  *StorageStatistics `json:"statistics"`
 }
 
 // ListGroupsOptions represents the available ListGroups() options.

--- a/groups.go
+++ b/groups.go
@@ -37,7 +37,7 @@ type Group struct {
 	Name        string             `json:"name"`
 	Path        string             `json:"path"`
 	Description string             `json:"description"`
-	Projects    *[]Project         `json:"projects,omitempty"`
+	Projects    *[]Project         `json:"projects"`
 	Statistics  *StorageStatistics `json:"statistics"`
 }
 

--- a/groups.go
+++ b/groups.go
@@ -33,11 +33,12 @@ type GroupsService struct {
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/groups.html
 type Group struct {
-	ID          int        `json:"id"`
-	Name        string     `json:"name"`
-	Path        string     `json:"path"`
-	Description string     `json:"description"`
-	Projects    *[]Project `json:"projects,omitempty"`
+	ID          int               `json:"id"`
+	Name        string            `json:"name"`
+	Path        string            `json:"path"`
+	Description string            `json:"description"`
+	Projects    *[]Project        `json:"projects,omitempty"`
+	Statistics  ProjectStatistics `json:"statistics"`
 }
 
 // ListGroupsOptions represents the available ListGroups() options.
@@ -45,7 +46,8 @@ type Group struct {
 // GitLab API docs: https://docs.gitlab.com/ce/api/groups.html#list-project-groups
 type ListGroupsOptions struct {
 	ListOptions
-	Search *string `url:"search,omitempty" json:"search,omitempty"`
+	Search     *string `url:"search,omitempty" json:"search,omitempty"`
+	Statistics *bool   `url:"statistics,omitempty" json:"statistics,omitempty"`
 }
 
 // ListGroups gets a list of groups. (As user: my groups, as admin: all groups)

--- a/groups.go
+++ b/groups.go
@@ -38,7 +38,7 @@ type Group struct {
 	Path        string            `json:"path"`
 	Description string            `json:"description"`
 	Projects    *[]Project        `json:"projects,omitempty"`
-	Statistics  ProjectStatistics `json:"statistics"`
+	Statistics  StorageStatistics `json:"statistics"`
 }
 
 // ListGroupsOptions represents the available ListGroups() options.

--- a/projects.go
+++ b/projects.go
@@ -77,7 +77,7 @@ type Project struct {
 		GroupName        string `json:"group_name"`
 		GroupAccessLevel int    `json:"group_access_level"`
 	} `json:"shared_with_groups"`
-	Statistics ProjectStatistics `json:"statistics"`
+	Statistics *ProjectStatistics `json:"statistics"`
 }
 
 // Repository represents a repository.
@@ -111,16 +111,16 @@ type ProjectNamespace struct {
 
 // StorageStatistics represents a statistics record for a group or project.
 type StorageStatistics struct {
-	StorageSize        uint64 `json:"storage_size"`
-	RepositorySize     uint64 `json:"repository_size"`
-	LfsObjectsSize     uint64 `json:"lfs_objects_size"`
-	BuildArtifactsSize uint64 `json:"build_artifacts_size"`
+	StorageSize        int64 `json:"storage_size"`
+	RepositorySize     int64 `json:"repository_size"`
+	LfsObjectsSize     int64 `json:"lfs_objects_size"`
+	BuildArtifactsSize int64 `json:"build_artifacts_size"`
 }
 
 // ProjectStatistics represents a statistics record for a project.
 type ProjectStatistics struct {
 	StorageStatistics
-	CommitCount uint64 `json:"commit_count"`
+	CommitCount int `json:"commit_count"`
 }
 
 // Permissions represents premissions.

--- a/projects.go
+++ b/projects.go
@@ -77,6 +77,7 @@ type Project struct {
 		GroupName        string `json:"group_name"`
 		GroupAccessLevel int    `json:"group_access_level"`
 	} `json:"shared_with_groups"`
+	Statistics ProjectStatistics `json:"statistics"`
 }
 
 // Repository represents a repository.
@@ -106,6 +107,20 @@ type ProjectNamespace struct {
 	OwnerID     int        `json:"owner_id"`
 	Path        string     `json:"path"`
 	UpdatedAt   *time.Time `json:"updated_at"`
+}
+
+// StorageStatistics represents a statistics record for a group or project.
+type StorageStatistics struct {
+	StorageSize        int64 `json:"storage_size"`
+	RepositorySize     int64 `json:"repository_size"`
+	LfsObjectsSize     int64 `json:"lfs_objects_size"`
+	BuildArtifactsSize int64 `json:"build_artifacts_size"`
+}
+
+// ProjectStatistics represents a statistics record for a project.
+type ProjectStatistics struct {
+	StorageStatistics
+	CommitCount int64 `json:"commit_count"`
 }
 
 // Permissions represents premissions.
@@ -141,6 +156,7 @@ type ListProjectsOptions struct {
 	Search     *string `url:"search,omitempty" json:"search,omitempty"`
 	Simple     *bool   `url:"simple,omitempty" json:"simple,omitempty"`
 	Visibility *string `url:"visibility,omitempty" json:"visibility,omitempty"`
+	Statistics *bool   `url:"statistics,omitempty" json:"statistics,omitempty"`
 }
 
 // ListProjects gets a list of projects accessible by the authenticated user.

--- a/projects.go
+++ b/projects.go
@@ -111,16 +111,16 @@ type ProjectNamespace struct {
 
 // StorageStatistics represents a statistics record for a group or project.
 type StorageStatistics struct {
-	StorageSize        int64 `json:"storage_size"`
-	RepositorySize     int64 `json:"repository_size"`
-	LfsObjectsSize     int64 `json:"lfs_objects_size"`
-	BuildArtifactsSize int64 `json:"build_artifacts_size"`
+	StorageSize        uint64 `json:"storage_size"`
+	RepositorySize     uint64 `json:"repository_size"`
+	LfsObjectsSize     uint64 `json:"lfs_objects_size"`
+	BuildArtifactsSize uint64 `json:"build_artifacts_size"`
 }
 
 // ProjectStatistics represents a statistics record for a project.
 type ProjectStatistics struct {
 	StorageStatistics
-	CommitCount int64 `json:"commit_count"`
+	CommitCount uint64 `json:"commit_count"`
 }
 
 // Permissions represents premissions.

--- a/projects_test.go
+++ b/projects_test.go
@@ -22,11 +22,12 @@ func TestListProjects(t *testing.T) {
 			"search":     "query",
 			"simple":     "true",
 			"visibility": "public",
+			"statistics": "true",
 		})
 		fmt.Fprint(w, `[{"id":1},{"id":2}]`)
 	})
 
-	opt := &ListProjectsOptions{ListOptions{2, 3}, Bool(true), String("name"), String("asc"), String("query"), Bool(true), String("public")}
+	opt := &ListProjectsOptions{ListOptions{2, 3}, Bool(true), String("name"), String("asc"), String("query"), Bool(true), String("public"), Bool(true)}
 	projects, _, err := client.Projects.ListProjects(opt)
 
 	if err != nil {
@@ -54,11 +55,12 @@ func TestListOwnedProjects(t *testing.T) {
 			"search":     "query",
 			"simple":     "true",
 			"visibility": "public",
+			"statistics": "false",
 		})
 		fmt.Fprint(w, `[{"id":1},{"id":2}]`)
 	})
 
-	opt := &ListProjectsOptions{ListOptions{2, 3}, Bool(true), String("name"), String("asc"), String("query"), Bool(true), String("public")}
+	opt := &ListProjectsOptions{ListOptions{2, 3}, Bool(true), String("name"), String("asc"), String("query"), Bool(true), String("public"), Bool(false)}
 	projects, _, err := client.Projects.ListOwnedProjects(opt)
 
 	if err != nil {
@@ -86,11 +88,12 @@ func TestListStarredProjects(t *testing.T) {
 			"search":     "query",
 			"simple":     "true",
 			"visibility": "public",
+			"statistics": "false",
 		})
 		fmt.Fprint(w, `[{"id":1},{"id":2}]`)
 	})
 
-	opt := &ListProjectsOptions{ListOptions{2, 3}, Bool(true), String("name"), String("asc"), String("query"), Bool(true), String("public")}
+	opt := &ListProjectsOptions{ListOptions{2, 3}, Bool(true), String("name"), String("asc"), String("query"), Bool(true), String("public"), Bool(false)}
 	projects, _, err := client.Projects.ListStarredProjects(opt)
 
 	if err != nil {
@@ -118,11 +121,12 @@ func TestListAllProjects(t *testing.T) {
 			"search":     "query",
 			"simple":     "true",
 			"visibility": "public",
+			"statistics": "false",
 		})
 		fmt.Fprint(w, `[{"id":1},{"id":2}]`)
 	})
 
-	opt := &ListProjectsOptions{ListOptions{2, 3}, Bool(true), String("name"), String("asc"), String("query"), Bool(true), String("public")}
+	opt := &ListProjectsOptions{ListOptions{2, 3}, Bool(true), String("name"), String("asc"), String("query"), Bool(true), String("public"), Bool(false)}
 	projects, _, err := client.Projects.ListAllProjects(opt)
 
 	if err != nil {


### PR DESCRIPTION
Gitlab returns statistics for the `projects/all`, `projects/owned`, `groups` and `groups/owned` endpoints. Unfortunately the structure of such a statistics is not very well documented on their site.

This PR implements the statistics structure as it is implemented in current Gitlab code.
