### PR TITLE
Add Build Trigger endpoints

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -915,13 +915,13 @@ func (s *ProjectsService) ListBuildTriggers(pid interface{}, opt *ListBuildTrigg
 		return nil, nil, err
 	}
 
-	var ph []*BuildTrigger
-	resp, err := s.client.Do(req, &ph)
+	var bt []*BuildTrigger
+	resp, err := s.client.Do(req, &bt)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return ph, resp, err
+	return bt, resp, err
 }
 
 // GetBuildTrigger gets a specific build trigger for a project.
@@ -940,13 +940,13 @@ func (s *ProjectsService) GetBuildTrigger(pid interface{}, token string, options
 		return nil, nil, err
 	}
 
-	ph := new(BuildTrigger)
-	resp, err := s.client.Do(req, ph)
+	bt := new(BuildTrigger)
+	resp, err := s.client.Do(req, bt)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return ph, resp, err
+	return bt, resp, err
 }
 
 // AddBuildTrigger adds a build trigger to a specified project.
@@ -965,13 +965,13 @@ func (s *ProjectsService) AddBuildTrigger(pid interface{}, options ...OptionFunc
 		return nil, nil, err
 	}
 
-	ph := new(BuildTrigger)
-	resp, err := s.client.Do(req, ph)
+	bt := new(BuildTrigger)
+	resp, err := s.client.Do(req, bt)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return ph, resp, err
+	return bt, resp, err
 }
 
 // DeleteBuildTrigger removes a trigger from a project.

--- a/projects.go
+++ b/projects.go
@@ -879,6 +879,120 @@ func (s *ProjectsService) DeleteProjectHook(pid interface{}, hook int, options .
 	return s.client.Do(req, nil)
 }
 
+// BuildTrigger represents a project build trigger.
+//
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/build_triggers.md#build-triggers
+type BuildTrigger struct {
+	CreatedAt *time.Time `json:"created_at"`
+	DeletedAt *time.Time `json:"deleted_at"`
+	LastUsed  *time.Time `json:"last_used"`
+	Token     string     `json:"token"`
+	UpdatedAt *time.Time `json:"updated_at"`
+}
+
+// ListBuildTriggersOptions represents the available ListBuildTriggers() options.
+//
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/build_triggers.md#list-project-triggers
+type ListBuildTriggersOptions struct {
+	ListOptions
+}
+
+// ListBuildTriggers gets a list of project triggers.
+//
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/build_triggers.md#list-project-triggers
+func (s *ProjectsService) ListBuildTriggers(pid interface{}, opt *ListBuildTriggersOptions, options ...OptionFunc) ([]*BuildTrigger, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/triggers", url.QueryEscape(project))
+
+	req, err := s.client.NewRequest("GET", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var ph []*BuildTrigger
+	resp, err := s.client.Do(req, &ph)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return ph, resp, err
+}
+
+// GetBuildTrigger gets a specific build trigger for a project.
+//
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/build_triggers.md#get-trigger-details
+func (s *ProjectsService) GetBuildTrigger(pid interface{}, token string, options ...OptionFunc) (*BuildTrigger, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/triggers/%v", url.QueryEscape(project), token)
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ph := new(BuildTrigger)
+	resp, err := s.client.Do(req, ph)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return ph, resp, err
+}
+
+// AddBuildTrigger adds a build trigger to a specified project.
+//
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/build_triggers.md#create-a-project-trigger
+func (s *ProjectsService) AddBuildTrigger(pid interface{}, options ...OptionFunc) (*BuildTrigger, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/triggers", url.QueryEscape(project))
+
+	req, err := s.client.NewRequest("POST", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ph := new(BuildTrigger)
+	resp, err := s.client.Do(req, ph)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return ph, resp, err
+}
+
+// DeleteBuildTrigger removes a trigger from a project.
+//
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/build_triggers.md#remove-a-project-trigger
+func (s *ProjectsService) DeleteBuildTrigger(pid interface{}, token string, options ...OptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/triggers/%s", url.QueryEscape(project), token)
+
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
 // ProjectForkRelation represents a project fork relationship.
 //
 // GitLab API docs:


### PR DESCRIPTION
Fixes #148.

This implements build triggers for API v3, with the comments linking to relevant v3 API documents.