### PR TITLE
Update BranchesService Methods to Conform to v3 API

### DIFF
--- a/branches.go
+++ b/branches.go
@@ -24,37 +24,48 @@ import (
 // BranchesService handles communication with the branch related methods
 // of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/branches.html
+// GitLab API docs: https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/branches.md
 type BranchesService struct {
 	client *Client
 }
 
 // Branch represents a GitLab branch.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/branches.html
+// GitLab API docs: https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/branches.md
 type Branch struct {
-	Commit    *Commit `json:"commit"`
-	Name      string  `json:"name"`
-	Protected bool    `json:"protected"`
+	Commit             *Commit `json:"commit"`
+	Name               string  `json:"name"`
+	Protected          bool    `json:"protected"`
+	Merged             bool    `json:"merged"`
+	DevelopersCanPush  bool    `json:"developers_can_push"`
+	DevelopersCanMerge bool    `json:"developers_can_merge"`
 }
 
 func (b Branch) String() string {
 	return Stringify(b)
 }
 
+// ListBranchesOptions represents the available ListBranches() options.
+//
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/branches.md#list-repository-branches
+type ListBranchesOptions struct {
+	ListOptions
+}
+
 // ListBranches gets a list of repository branches from a project, sorted by
 // name alphabetically.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/branches.html#list-repository-branches
-func (s *BranchesService) ListBranches(pid interface{}, options ...OptionFunc) ([]*Branch, *Response, error) {
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/branches.md#list-repository-branches
+func (s *BranchesService) ListBranches(pid interface{}, opts *ListBranchesOptions, options ...OptionFunc) ([]*Branch, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/repository/branches", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("GET", u, nil, options)
+	req, err := s.client.NewRequest("GET", u, opts, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -71,7 +82,7 @@ func (s *BranchesService) ListBranches(pid interface{}, options ...OptionFunc) (
 // GetBranch gets a single project repository branch.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/branches.html#get-single-repository-branch
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/branches.md#get-single-repository-branch
 func (s *BranchesService) GetBranch(pid interface{}, branch string, options ...OptionFunc) (*Branch, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -93,20 +104,29 @@ func (s *BranchesService) GetBranch(pid interface{}, branch string, options ...O
 	return b, resp, err
 }
 
+// ProtectBranchOptions represents the available ProtectBranch() options.
+//
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/branches.md#protect-repository-branch
+type ProtectBranchOptions struct {
+	DevelopersCanPush  *bool `url:"developers_can_push,omitempty" json:"developers_can_push,omitempty"`
+	DevelopersCanMerge *bool `url:"developers_can_merge,omitempty" json:"developers_can_merge,omitempty"`
+}
+
 // ProtectBranch protects a single project repository branch. This is an
 // idempotent function, protecting an already protected repository branch
 // still returns a 200 OK status code.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/branches.html#protect-repository-branch
-func (s *BranchesService) ProtectBranch(pid interface{}, branch string, options ...OptionFunc) (*Branch, *Response, error) {
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/branches.md#protect-repository-branch
+func (s *BranchesService) ProtectBranch(pid interface{}, branch string, opts *ProtectBranchOptions, options ...OptionFunc) (*Branch, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/repository/branches/%s/protect", url.QueryEscape(project), branch)
 
-	req, err := s.client.NewRequest("PUT", u, nil, options)
+	req, err := s.client.NewRequest("PUT", u, opts, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -125,7 +145,7 @@ func (s *BranchesService) ProtectBranch(pid interface{}, branch string, options 
 // still returns a 200 OK status code.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/branches.html#unprotect-repository-branch
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/branches.md#unprotect-repository-branch
 func (s *BranchesService) UnprotectBranch(pid interface{}, branch string, options ...OptionFunc) (*Branch, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -150,7 +170,7 @@ func (s *BranchesService) UnprotectBranch(pid interface{}, branch string, option
 // CreateBranchOptions represents the available CreateBranch() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/branches.html#create-repository-branch
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/branches.md#create-repository-branch
 type CreateBranchOptions struct {
 	BranchName *string `url:"branch_name,omitempty" json:"branch_name,omitempty"`
 	Ref        *string `url:"ref,omitempty" json:"ref,omitempty"`
@@ -159,7 +179,7 @@ type CreateBranchOptions struct {
 // CreateBranch creates branch from commit SHA or existing branch.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/branches.html#create-repository-branch
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/branches.md#create-repository-branch
 func (s *BranchesService) CreateBranch(pid interface{}, opt *CreateBranchOptions, options ...OptionFunc) (*Branch, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -184,13 +204,32 @@ func (s *BranchesService) CreateBranch(pid interface{}, opt *CreateBranchOptions
 // DeleteBranch deletes an existing branch.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/branches.html#delete-repository-branch
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/branches.md#delete-repository-branch
 func (s *BranchesService) DeleteBranch(pid interface{}, branch string, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, err
 	}
 	u := fmt.Sprintf("projects/%s/repository/branches/%s", url.QueryEscape(project), branch)
+
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// DeleteMergedBranches deletes all branches that are merged into the project's default branch.
+//
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/branches.md#delete-merged-branches
+func (s *BranchesService) DeleteMergedBranches(pid interface{}, options ...OptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/repository/merged_branches", url.QueryEscape(project))
 
 	req, err := s.client.NewRequest("DELETE", u, nil, options)
 	if err != nil {


### PR DESCRIPTION
This change breaks backwards compatibility.

The `BranchesService` methods were almost all inconsistent with other Services and not supplying all available options. Also updated all documentation links.

The Branch struct now includes all properties exported by the v3 API.
`ListBranches` takes a new `ListBranchesOptions` struct for pagination.
Added the ability to configure the branch protection in line with API documentation.
Added a new `DeleteMergedBranches` which is part of the branches page.