### PR TITLE
WIP: Make subscription API more RESTful

### DIFF
--- a/issues.go
+++ b/issues.go
@@ -302,3 +302,35 @@ func (s *IssuesService) DeleteIssue(pid interface{}, issue int, options ...Optio
 
 	return s.client.Do(req, nil)
 }
+
+// MoveIssueOptions represents the available MoveIssue() options.
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/issues.html#move-an-issue
+type MoveIssueOptions struct {
+	IssueIID    *int `url:"issue_iid" json:"issue_iid"`
+	ToProjectID *int `url:"to_project_id" json:"to_project_id"`
+}
+
+// MoveIssue moves an issue to a different project
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/issues.html#move-an-issue
+func (s *IssuesService) MoveIssue(pid interface{}, issueIID int, opt *MoveIssueOptions, options ...OptionFunc) (*Issue, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	u := fmt.Sprintf("projects/%s/issues/%d/move", url.QueryEscape(project), issueIID)
+	req, err := s.client.NewRequest("POST", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	i := new(Issue)
+	resp, err := s.client.Do(req, i)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return i, resp, err
+}

--- a/issues.go
+++ b/issues.go
@@ -334,3 +334,35 @@ func (s *IssuesService) MoveIssue(pid interface{}, issueIID int, opt *MoveIssueO
 
 	return i, resp, err
 }
+
+// SubscribeIssueOptions represents the available SubscribeIssue() options.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/issues.html#subscribe-to-an-issue
+type SubscribeIssueOptions struct {
+	ID       int  `url:"id,omitempty" json:"id,omitempty"`
+	IssueIID *int `url:"issue_iid" json:"issue_iid"`
+}
+
+// SubscribeIssue subscribe the authenticated user to an issue to receive notifications
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/issues.html#subscribe-to-an-issue
+func (s *IssuesService) SubscribeIssue(pid interface{}, issueIID int, opt *SubscribeIssueOptions, options ...OptionFunc) (*Issue, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	u := fmt.Sprintf("projects/%s/issues/%d/subscribe", url.QueryEscape(project), issueIID)
+	req, err := s.client.NewRequest("POST", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	i := new(Issue)
+	resp, err := s.client.Do(req, i)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return i, resp, err
+}

--- a/issues.go
+++ b/issues.go
@@ -44,20 +44,20 @@ type Issue struct {
 	Labels      []string   `json:"labels"`
 	Milestone   *Milestone `json:"milestone"`
 	Assignee    struct {
-		ID        int        `json:"id"`
-		Username  string     `json:"username"`
-		Email     string     `json:"email"`
-		Name      string     `json:"name"`
-		State     string     `json:"state"`
-		CreatedAt *time.Time `json:"created_at"`
+		ID        int    `json:"id"`
+		Username  string `json:"username"`
+		AvatarURL string `json:"avatar_url,omitempty"`
+		WebURL    string `json:"web_url"`
+		Name      string `json:"name"`
+		State     string `json:"state"`
 	} `json:"assignee"`
 	Author struct {
-		ID        int        `json:"id"`
-		Username  string     `json:"username"`
-		Email     string     `json:"email"`
-		Name      string     `json:"name"`
-		State     string     `json:"state"`
-		CreatedAt *time.Time `json:"created_at"`
+		ID        int    `json:"id"`
+		Username  string `json:"username"`
+		AvatarURL string `json:"avatar_url,omitempty"`
+		WebURL    string `json:"web_url"`
+		Name      string `json:"name"`
+		State     string `json:"state"`
 	} `json:"author"`
 	State          string     `json:"state"`
 	UpdatedAt      *time.Time `json:"updated_at"`

--- a/issues.go
+++ b/issues.go
@@ -307,6 +307,7 @@ func (s *IssuesService) DeleteIssue(pid interface{}, issue int, options ...Optio
 //
 // GitLab API docs: https://docs.gitlab.com/ee/api/issues.html#move-an-issue
 type MoveIssueOptions struct {
+	ID          *int `url:"id" json:"id"`
 	IssueIID    *int `url:"issue_iid" json:"issue_iid"`
 	ToProjectID *int `url:"to_project_id" json:"to_project_id"`
 }
@@ -339,11 +340,11 @@ func (s *IssuesService) MoveIssue(pid interface{}, issueIID int, opt *MoveIssueO
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/issues.html#subscribe-to-an-issue
 type SubscribeIssueOptions struct {
-	ID       int  `url:"id,omitempty" json:"id,omitempty"`
+	ID       *int `url:"id" json:"id"`
 	IssueIID *int `url:"issue_iid" json:"issue_iid"`
 }
 
-// SubscribeIssue subscribe the authenticated user to an issue to receive notifications
+// SubscribeIssue subscribe the authenticated user to an issue to receive notifications.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/issues.html#subscribe-to-an-issue
 func (s *IssuesService) SubscribeIssue(pid interface{}, issueIID int, opt *SubscribeIssueOptions, options ...OptionFunc) (*Issue, *Response, error) {
@@ -353,6 +354,38 @@ func (s *IssuesService) SubscribeIssue(pid interface{}, issueIID int, opt *Subsc
 	}
 
 	u := fmt.Sprintf("projects/%s/issues/%d/subscribe", url.QueryEscape(project), issueIID)
+	req, err := s.client.NewRequest("POST", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	i := new(Issue)
+	resp, err := s.client.Do(req, i)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return i, resp, err
+}
+
+// UnsubscribeIssueOptions represents the available UnsubscribeIssue() options.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/issues.html#unsubscribe-from-an-issue
+type UnsubscribeIssueOptions struct {
+	ID       *int `url:"id" json:"id"`
+	IssueIID *int `url:"issue_iid" json:"issue_iid"`
+}
+
+// UnsubscribeIssue unsubscribes the authenticated user from the issue to not receive notifications from it.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/issues.html#unsubscribe-from-an-issue
+func (s *IssuesService) UnsubscribeIssue(pid interface{}, issueIID int, opt *UnsubscribeIssueOptions, options ...OptionFunc) (*Issue, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	u := fmt.Sprintf("projects/%s/issues/%d/unsubscribe", url.QueryEscape(project), issueIID)
 	req, err := s.client.NewRequest("POST", u, opt, options)
 	if err != nil {
 		return nil, nil, err

--- a/issues_test.go
+++ b/issues_test.go
@@ -16,9 +16,8 @@ func TestMoveIssue(t *testing.T) {
 		fmt.Fprint(w, `{"iid":1, "project_id":2}`)
 	})
 
-	opt := &MoveIssueOptions{IssueIID: Int(1), ToProjectID: Int(2)}
+	opt := &MoveIssueOptions{ID: Int(1), IssueIID: Int(1), ToProjectID: Int(2)}
 	issue, _, err := client.Issues.MoveIssue(1, 1, opt)
-
 	if err != nil {
 		t.Errorf("Issues.MoveIssue returned error: %v", err)
 	}
@@ -26,5 +25,47 @@ func TestMoveIssue(t *testing.T) {
 	want := &Issue{IID: 1, ProjectID: 2}
 	if !reflect.DeepEqual(want, issue) {
 		t.Errorf("Issues.MoveIssue returned %+v, want %+v", issue, want)
+	}
+}
+
+func TestSubscribeIssue(t *testing.T) {
+	mux, server, client := setup()
+	defer teardown(server)
+
+	mux.HandleFunc("/projects/1/issues/1/subscribe", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		fmt.Fprint(w, `{"id":1, "project_id":1}`)
+	})
+
+	opt := &SubscribeIssueOptions{ID: Int(1), IssueIID: Int(1)}
+	issue, _, err := client.Issues.SubscribeIssue(1, 1, opt)
+	if err != nil {
+		t.Errorf("Issues.SubscribeIssue returned error: %v", err)
+	}
+
+	want := &Issue{ID: 1, ProjectID: 1}
+	if !reflect.DeepEqual(want, issue) {
+		t.Errorf("Issues.SubscribeIssue returned %+v, want %+v", issue, want)
+	}
+}
+
+func TestUnsubscribeIssue(t *testing.T) {
+	mux, server, client := setup()
+	defer teardown(server)
+
+	mux.HandleFunc("/projects/1/issues/1/unsubscribe", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		fmt.Fprint(w, `{"id":1, "project_id":1}`)
+	})
+
+	opt := &UnsubscribeIssueOptions{ID: Int(1), IssueIID: Int(1)}
+	issue, _, err := client.Issues.UnsubscribeIssue(1, 1, opt)
+	if err != nil {
+		t.Errorf("Issues.UnsubscribeIssue returned error: %v", err)
+	}
+
+	want := &Issue{ID: 1, ProjectID: 1}
+	if !reflect.DeepEqual(want, issue) {
+		t.Errorf("Issues.UnsubscribeIssue returned %+v, want %+v", issue, want)
 	}
 }

--- a/issues_test.go
+++ b/issues_test.go
@@ -1,0 +1,30 @@
+package gitlab
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestMoveIssue(t *testing.T) {
+	mux, server, client := setup()
+	defer teardown(server)
+
+	mux.HandleFunc("/projects/1/issues/1/move", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		fmt.Fprint(w, `{"iid":1, "project_id":2}`)
+	})
+
+	opt := &MoveIssueOptions{IssueIID: Int(1), ToProjectID: Int(2)}
+	issue, _, err := client.Issues.MoveIssue(1, 1, opt)
+
+	if err != nil {
+		t.Errorf("Issues.MoveIssue returned error: %v", err)
+	}
+
+	want := &Issue{IID: 1, ProjectID: 2}
+	if !reflect.DeepEqual(want, issue) {
+		t.Errorf("Issues.MoveIssue returned %+v, want %+v", issue, want)
+	}
+}


### PR DESCRIPTION
Make subscription API more RESTful. Use POST /projects/:id/:subscribable_type/:subscribable_id/subscribe to subscribe and POST /projects/:id/:subscribable_type/:subscribable_id/unsubscribe to unsubscribe from a resource. [!9325](https://gitlab.com/gitlab-org/gitlab-ce/merge_requests/9325)