### PR TITLE
Fix groupvisibility and add sharewithgroup component 

### DIFF
--- a/events.go
+++ b/events.go
@@ -47,7 +47,7 @@ type PushEvent struct {
 		SSHURL            string               `json:"ssh_url"`
 		HTTPURL           string               `json:"http_url"`
 		WebURL            string               `json:"web_url"`
-		VisibilityLevel   VisibilityLevelValue `json:"visibility_level"`
+		VisibilityLevel   VisibilityLevelValue `json:"visibility"`
 	} `json:"project"`
 	Repository        *Repository `json:"repository"`
 	Commits           []*Commit   `json:"commits"`
@@ -82,7 +82,7 @@ type TagEvent struct {
 		SSHURL            string               `json:"ssh_url"`
 		HTTPURL           string               `json:"http_url"`
 		WebURL            string               `json:"web_url"`
-		VisibilityLevel   VisibilityLevelValue `json:"visibility_level"`
+		VisibilityLevel   VisibilityLevelValue `json:"visibility"`
 	} `json:"project"`
 	Repository        *Repository `json:"repository"`
 	Commits           []*Commit   `json:"commits"`
@@ -110,7 +110,7 @@ type IssueEvent struct {
 		SSHURL            string               `json:"ssh_url"`
 		HTTPURL           string               `json:"http_url"`
 		WebURL            string               `json:"web_url"`
-		VisibilityLevel   VisibilityLevelValue `json:"visibility_level"`
+		VisibilityLevel   VisibilityLevelValue `json:"visibility"`
 	} `json:"project"`
 	Repository       *Repository `json:"repository"`
 	ObjectAttributes struct {
@@ -159,7 +159,7 @@ type CommitCommentEvent struct {
 		SSHURL            string               `json:"ssh_url"`
 		HTTPURL           string               `json:"http_url"`
 		WebURL            string               `json:"web_url"`
-		VisibilityLevel   VisibilityLevelValue `json:"visibility_level"`
+		VisibilityLevel   VisibilityLevelValue `json:"visibility"`
 	} `json:"project"`
 	Repository       *Repository `json:"repository"`
 	ObjectAttributes struct {
@@ -211,7 +211,7 @@ type MergeCommentEvent struct {
 		SSHURL            string               `json:"ssh_url"`
 		HTTPURL           string               `json:"http_url"`
 		WebURL            string               `json:"web_url"`
-		VisibilityLevel   VisibilityLevelValue `json:"visibility_level"`
+		VisibilityLevel   VisibilityLevelValue `json:"visibility"`
 	} `json:"project"`
 	Repository       *Repository `json:"repository"`
 	ObjectAttributes struct {
@@ -255,7 +255,7 @@ type IssueCommentEvent struct {
 		SSHURL            string               `json:"ssh_url"`
 		HTTPURL           string               `json:"http_url"`
 		WebURL            string               `json:"web_url"`
-		VisibilityLevel   VisibilityLevelValue `json:"visibility_level"`
+		VisibilityLevel   VisibilityLevelValue `json:"visibility"`
 	} `json:"project"`
 	Repository       *Repository `json:"repository"`
 	ObjectAttributes struct {
@@ -299,7 +299,7 @@ type SnippetCommentEvent struct {
 		SSHURL            string               `json:"ssh_url"`
 		HTTPURL           string               `json:"http_url"`
 		WebURL            string               `json:"web_url"`
-		VisibilityLevel   VisibilityLevelValue `json:"visibility_level"`
+		VisibilityLevel   VisibilityLevelValue `json:"visibility"`
 	} `json:"project"`
 	Repository       *Repository `json:"repository"`
 	ObjectAttributes struct {
@@ -342,7 +342,7 @@ type MergeEvent struct {
 		SSHURL            string               `json:"ssh_url"`
 		HTTPURL           string               `json:"http_url"`
 		WebURL            string               `json:"web_url"`
-		VisibilityLevel   VisibilityLevelValue `json:"visibility_level"`
+		VisibilityLevel   VisibilityLevelValue `json:"visibility"`
 	} `json:"project"`
 	ObjectAttributes struct {
 		ID              int       `json:"id"`
@@ -425,7 +425,7 @@ type WikiPageEvent struct {
 		SSHURL            string               `json:"ssh_url"`
 		HTTPURL           string               `json:"http_url"`
 		WebURL            string               `json:"web_url"`
-		VisibilityLevel   VisibilityLevelValue `json:"visibility_level"`
+		VisibilityLevel   VisibilityLevelValue `json:"visibility"`
 	} `json:"project"`
 	Wiki struct {
 		WebURL            string `json:"web_url"`
@@ -482,7 +482,7 @@ type PipelineEvent struct {
 		SSHURL            string               `json:"ssh_url"`
 		HTTPURL           string               `json:"http_url"`
 		WebURL            string               `json:"web_url"`
-		VisibilityLevel   VisibilityLevelValue `json:"visibility_level"`
+		VisibilityLevel   VisibilityLevelValue `json:"visibility"`
 	} `json:"project"`
 	Commit struct {
 		ID        string    `json:"id"`

--- a/events_test.go
+++ b/events_test.go
@@ -25,7 +25,7 @@ func TestPushEventUnmarshal(t *testing.T) {
     "git_ssh_url":"git@example.com:mike/diaspora.git",
     "git_http_url":"http://example.com/mike/diaspora.git",
     "namespace":"Mike",
-    "visibility_level":0,
+    "visibility":"public",
     "path_with_namespace":"mike/diaspora",
     "default_branch":"master",
     "homepage":"http://example.com/mike/diaspora",
@@ -40,7 +40,7 @@ func TestPushEventUnmarshal(t *testing.T) {
     "homepage": "http://example.com/mike/diaspora",
     "git_http_url":"http://example.com/mike/diaspora.git",
     "git_ssh_url":"git@example.com:mike/diaspora.git",
-    "visibility_level":0
+    "visibility":"public"
   },
   "commits": [
     {
@@ -124,7 +124,7 @@ func TestMergeEventUnmarshal(t *testing.T) {
       "git_ssh_url":"git@example.com:awesome_space/awesome_project.git",
       "git_http_url":"http://example.com/awesome_space/awesome_project.git",
       "namespace":"Awesome Space",
-      "visibility_level":20,
+      "visibility":"private",
       "path_with_namespace":"awesome_space/awesome_project",
       "default_branch":"master",
       "homepage":"http://example.com/awesome_space/awesome_project",
@@ -140,7 +140,7 @@ func TestMergeEventUnmarshal(t *testing.T) {
       "git_ssh_url":"git@example.com:awesome_space/awesome_project.git",
       "git_http_url":"http://example.com/awesome_space/awesome_project.git",
       "namespace":"Awesome Space",
-      "visibility_level":20,
+      "visibility":"private",
       "path_with_namespace":"awesome_space/awesome_project",
       "default_branch":"master",
       "homepage":"http://example.com/awesome_space/awesome_project",
@@ -233,7 +233,7 @@ func TestPipelineEventUnmarshal(t *testing.T) {
       "git_ssh_url": "git@192.168.64.1:gitlab-org/gitlab-test.git",
       "git_http_url": "http://192.168.64.1:3005/gitlab-org/gitlab-test.git",
       "namespace": "Gitlab Org",
-      "visibility_level": 20,
+      "visibility": "private",
       "path_with_namespace": "gitlab-org/gitlab-test",
       "default_branch": "master"
    },
@@ -413,7 +413,7 @@ func TestBuildEventUnmarshal(t *testing.T) {
     "homepage": "http://192.168.64.1:3005/gitlab-org/gitlab-test",
     "git_ssh_url": "git@192.168.64.1:gitlab-org/gitlab-test.git",
     "git_http_url": "http://192.168.64.1:3005/gitlab-org/gitlab-test.git",
-    "visibility_level": 20
+    "visibility": "private"
   }
 }`
 	var event *BuildEvent
@@ -449,7 +449,7 @@ func TestMergeEventUnmarshalFromGroup(t *testing.T) {
 		"git_ssh_url": "git@example.com:exm-namespace/example-project.git",
 		"git_http_url": "http://example.com/exm-namespace/example-project.git",
 		"namespace": "exm-namespace",
-		"visibility_level": 0,
+		"visibility": "public",
 		"path_with_namespace": "exm-namespace/example-project",
 		"default_branch": "master",
 		"homepage": "http://example.com/exm-namespace/example-project",
@@ -497,7 +497,7 @@ func TestMergeEventUnmarshalFromGroup(t *testing.T) {
 			"git_ssh_url": "git@example.com:exm-namespace/example-project.git",
 			"git_http_url": "http://example.com/exm-namespace/example-project.git",
 			"namespace": "exm-namespace",
-			"visibility_level": 0,
+			"visibility": "public",
 			"path_with_namespace": "exm-namespace/example-project",
 			"default_branch": "master",
 			"homepage": "http://example.com/exm-namespace/example-project",
@@ -513,7 +513,7 @@ func TestMergeEventUnmarshalFromGroup(t *testing.T) {
 			"git_ssh_url": "git@example.com:exm-namespace/example-project.git",
 			"git_http_url": "http://example.com/exm-namespace/example-project.git",
 			"namespace": "exm-namespace",
-			"visibility_level": 0,
+			"visibility": "public",
 			"path_with_namespace": "exm-namespace/example-project",
 			"default_branch": "master",
 			"homepage": "http://example.com/exm-namespace/example-project",

--- a/gitlab.go
+++ b/gitlab.go
@@ -130,15 +130,15 @@ var notificationLevelTypes = map[string]NotificationLevelValue{
 // VisibilityLevelValue represents a visibility level within GitLab.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/
-type VisibilityLevelValue int
+type VisibilityLevelValue string
 
 // List of available visibility levels
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/
 const (
-	PrivateVisibility  VisibilityLevelValue = 0
-	InternalVisibility VisibilityLevelValue = 10
-	PublicVisibility   VisibilityLevelValue = 20
+	PrivateVisibility  VisibilityLevelValue = "private"
+	InternalVisibility VisibilityLevelValue = "internal"
+	PublicVisibility   VisibilityLevelValue = "public"
 )
 
 // A Client manages communication with the GitLab API.

--- a/groups.go
+++ b/groups.go
@@ -21,22 +21,6 @@ import (
 	"time"
 )
 
-// defines visibility level for groups
-type GroupVisibilityLevelValue string
-
-const (
-	PrivateGroupVisibility  GroupVisibilityLevelValue = "private"
-	PublicGroupVisibility   GroupVisibilityLevelValue = "public"
-	InternalGroupVisibility GroupVisibilityLevelValue = "internal"
-)
-
-// GroupVisibilityLevel as helper for setting visibility in options, same as like VisibilityLevel
-func GroupVisibilityLevel(v GroupVisibilityLevelValue) *GroupVisibilityLevelValue {
-	p := new(GroupVisibilityLevelValue)
-	*p = v
-	return p
-}
-
 // GroupsService handles communication with the group related methods of
 // the GitLab API.
 //
@@ -113,10 +97,10 @@ func (s *GroupsService) GetGroup(gid interface{}, options ...OptionFunc) (*Group
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/groups.html#new-group
 type CreateGroupOptions struct {
-	Name                 *string                    `url:"name,omitempty" json:"name,omitempty"`
-	Path                 *string                    `url:"path,omitempty" json:"path,omitempty"`
-	Description          *string                    `url:"description,omitempty" json:"description,omitempty"`
-	GroupVisibilityLevel *GroupVisibilityLevelValue `url:"visibility" json:"visibility,omitempty"`
+	Name            *string               `url:"name,omitempty" json:"name,omitempty"`
+	Path            *string               `url:"path,omitempty" json:"path,omitempty"`
+	Description     *string               `url:"description,omitempty" json:"description,omitempty"`
+	VisibilityLevel *VisibilityLevelValue `url:"visibility" json:"visibility,omitempty"`
 }
 
 // CreateGroup creates a new project group. Available only for users who can

--- a/groups.go
+++ b/groups.go
@@ -21,6 +21,22 @@ import (
 	"time"
 )
 
+// defines visibility level for groups
+type GroupVisibilityLevelValue string
+
+const (
+	PrivateGroupVisibility  GroupVisibilityLevelValue = "private"
+	PublicGroupVisibility   GroupVisibilityLevelValue = "public"
+	InternalGroupVisibility GroupVisibilityLevelValue = "internal"
+)
+
+// GroupVisibilityLevel as helper for setting visibility in options, same as like VisibilityLevel
+func GroupVisibilityLevel(v GroupVisibilityLevelValue) *GroupVisibilityLevelValue {
+	p := new(GroupVisibilityLevelValue)
+	*p = v
+	return p
+}
+
 // GroupsService handles communication with the group related methods of
 // the GitLab API.
 //
@@ -97,10 +113,10 @@ func (s *GroupsService) GetGroup(gid interface{}, options ...OptionFunc) (*Group
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/groups.html#new-group
 type CreateGroupOptions struct {
-	Name            *string               `url:"name,omitempty" json:"name,omitempty"`
-	Path            *string               `url:"path,omitempty" json:"path,omitempty"`
-	Description     *string               `url:"description,omitempty" json:"description,omitempty"`
-	VisibilityLevel *VisibilityLevelValue `url:"visibility_level" json:"visibility_level,omitempty"`
+	Name                 *string                    `url:"name,omitempty" json:"name,omitempty"`
+	Path                 *string                    `url:"path,omitempty" json:"path,omitempty"`
+	Description          *string                    `url:"description,omitempty" json:"description,omitempty"`
+	GroupVisibilityLevel *GroupVisibilityLevelValue `url:"visibility" json:"visibility,omitempty"`
 }
 
 // CreateGroup creates a new project group. Available only for users who can

--- a/project_snippets.go
+++ b/project_snippets.go
@@ -118,7 +118,7 @@ type CreateSnippetOptions struct {
 	Title           *string               `url:"title,omitempty" json:"title,omitempty"`
 	FileName        *string               `url:"file_name,omitempty" json:"file_name,omitempty"`
 	Code            *string               `url:"code,omitempty" json:"code,omitempty"`
-	VisibilityLevel *VisibilityLevelValue `url:"visibility_level,omitempty" json:"visibility_level,omitempty"`
+	VisibilityLevel *VisibilityLevelValue `url:"visibility,omitempty" json:"visibility,omitempty"`
 }
 
 // CreateSnippet creates a new project snippet. The user must have permission
@@ -155,7 +155,7 @@ type UpdateSnippetOptions struct {
 	Title           *string               `url:"title,omitempty" json:"title,omitempty"`
 	FileName        *string               `url:"file_name,omitempty" json:"file_name,omitempty"`
 	Code            *string               `url:"code,omitempty" json:"code,omitempty"`
-	VisibilityLevel *VisibilityLevelValue `url:"visibility_level,omitempty" json:"visibility_level,omitempty"`
+	VisibilityLevel *VisibilityLevelValue `url:"visibility,omitempty" json:"visibility,omitempty"`
 }
 
 // UpdateSnippet updates an existing project snippet. The user must have

--- a/projects.go
+++ b/projects.go
@@ -367,6 +367,28 @@ func (s *ProjectsService) CreateProject(opt *CreateProjectOptions, options ...Op
 	return p, resp, err
 }
 
+// ShareWithGroupOptions represents the available CreateProjects() options.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#create-project
+type ShareWithGroupOptions struct {
+	ID          *int              `url:"id" json:"id"`
+	GroupID     *int              `url:"group_id" json:"group_id"`
+	GroupAccess *AccessLevelValue `url:"group_access" json:"group_access"`
+	ExpiresAt   *string           `url:"expires_at" json:"expires_at"`
+}
+
+func (s *ProjectsService) ShareProjectWithGroup(opt *ShareWithGroupOptions, options ...OptionFunc) (*Response, error) {
+	u := fmt.Sprintf("projects/%d/share", *opt.ID)
+
+	req, err := s.client.NewRequest("POST", u, opt, options)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.Do(req, nil)
+	return resp, err
+}
+
 // CreateProjectForUserOptions represents the available CreateProjectForUser()
 // options.
 //

--- a/projects.go
+++ b/projects.go
@@ -367,9 +367,8 @@ func (s *ProjectsService) CreateProject(opt *CreateProjectOptions, options ...Op
 	return p, resp, err
 }
 
-// ShareWithGroupOptions represents the available CreateProjects() options.
+// ShareWithGroupOptions represents options to share project with groups
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#create-project
 type ShareWithGroupOptions struct {
 	ID          *int              `url:"id" json:"id"`
 	GroupID     *int              `url:"group_id" json:"group_id"`

--- a/projects.go
+++ b/projects.go
@@ -38,7 +38,7 @@ type Project struct {
 	Description                               string               `json:"description"`
 	DefaultBranch                             string               `json:"default_branch"`
 	Public                                    bool                 `json:"public"`
-	VisibilityLevel                           VisibilityLevelValue `json:"visibility_level"`
+	VisibilityLevel                           VisibilityLevelValue `json:"visibility"`
 	SSHURLToRepo                              string               `json:"ssh_url_to_repo"`
 	HTTPURLToRepo                             string               `json:"http_url_to_repo"`
 	WebURL                                    string               `json:"web_url"`
@@ -150,13 +150,13 @@ func (s Project) String() string {
 // GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#list-projects
 type ListProjectsOptions struct {
 	ListOptions
-	Archived   *bool   `url:"archived,omitempty" json:"archived,omitempty"`
-	OrderBy    *string `url:"order_by,omitempty" json:"order_by,omitempty"`
-	Sort       *string `url:"sort,omitempty" json:"sort,omitempty"`
-	Search     *string `url:"search,omitempty" json:"search,omitempty"`
-	Simple     *bool   `url:"simple,omitempty" json:"simple,omitempty"`
-	Visibility *string `url:"visibility,omitempty" json:"visibility,omitempty"`
-	Statistics *bool   `url:"statistics,omitempty" json:"statistics,omitempty"`
+	Archived   *bool                `url:"archived,omitempty" json:"archived,omitempty"`
+	OrderBy    *string              `url:"order_by,omitempty" json:"order_by,omitempty"`
+	Sort       *string              `url:"sort,omitempty" json:"sort,omitempty"`
+	Search     *string              `url:"search,omitempty" json:"search,omitempty"`
+	Simple     *bool                `url:"simple,omitempty" json:"simple,omitempty"`
+	Visibility VisibilityLevelValue `url:"visibility,omitempty" json:"visibility,omitempty"`
+	Statistics *bool                `url:"statistics,omitempty" json:"statistics,omitempty"`
 }
 
 // ListProjects gets a list of projects accessible by the authenticated user.
@@ -341,7 +341,7 @@ type CreateProjectOptions struct {
 	ContainerRegistryEnabled      *bool                 `url:"container_registry_enabled,omitempty" json:"container_registry_enabled,omitempty"`
 	SharedRunnersEnabled          *bool                 `url:"shared_runners_enabled,omitempty" json:"shared_runners_enabled,omitempty"`
 	Public                        *bool                 `url:"public,omitempty" json:"public,omitempty"`
-	VisibilityLevel               *VisibilityLevelValue `url:"visibility_level,omitempty" json:"visibility_level,omitempty"`
+	VisibilityLevel               *VisibilityLevelValue `url:"visibility,omitempty" json:"visibility,omitempty"`
 	ImportURL                     *string               `url:"import_url,omitempty" json:"import_url,omitempty"`
 	PublicBuilds                  *bool                 `url:"public_builds,omitempty" json:"public_builds,omitempty"`
 	OnlyAllowMergeIfBuildSucceeds *bool                 `url:"only_allow_merge_if_build_succeeds,omitempty" json:"only_allow_merge_if_build_succeeds,omitempty"`
@@ -369,23 +369,29 @@ func (s *ProjectsService) CreateProject(opt *CreateProjectOptions, options ...Op
 
 // ShareWithGroupOptions represents options to share project with groups
 //
+// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#share-project-with-group
 type ShareWithGroupOptions struct {
-	ID          *int              `url:"id" json:"id"`
 	GroupID     *int              `url:"group_id" json:"group_id"`
 	GroupAccess *AccessLevelValue `url:"group_access" json:"group_access"`
 	ExpiresAt   *string           `url:"expires_at" json:"expires_at"`
 }
 
-func (s *ProjectsService) ShareProjectWithGroup(opt *ShareWithGroupOptions, options ...OptionFunc) (*Response, error) {
-	u := fmt.Sprintf("projects/%d/share", *opt.ID)
+// ShareProjectWithGroup allows to share a project with a group.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#share-project-with-group
+func (s *ProjectsService) ShareProjectWithGroup(pid interface{}, opt *ShareWithGroupOptions, options ...OptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/share", url.QueryEscape(project))
 
 	req, err := s.client.NewRequest("POST", u, opt, options)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(req, nil)
-	return resp, err
+	return s.client.Do(req, nil)
 }
 
 // CreateProjectForUserOptions represents the available CreateProjectForUser()
@@ -402,7 +408,7 @@ type CreateProjectForUserOptions struct {
 	WikiEnabled          *bool                 `url:"wiki_enabled,omitempty" json:"wiki_enabled,omitempty"`
 	SnippetsEnabled      *bool                 `url:"snippets_enabled,omitempty" json:"snippets_enabled,omitempty"`
 	Public               *bool                 `url:"public,omitempty" json:"public,omitempty"`
-	VisibilityLevel      *VisibilityLevelValue `url:"visibility_level,omitempty" json:"visibility_level,omitempty"`
+	VisibilityLevel      *VisibilityLevelValue `url:"visibility,omitempty" json:"visibility,omitempty"`
 	ImportURL            *string               `url:"import_url,omitempty" json:"import_url,omitempty"`
 }
 

--- a/projects.go
+++ b/projects.go
@@ -82,20 +82,20 @@ type Project struct {
 
 // Repository represents a repository.
 type Repository struct {
-	Name              string `json:"name"`
-	Description       string `json:"description"`
-	WebURL            string `json:"web_url"`
-	AvatarURL         string `json:"avatar_url"`
-	GitSSHURL         string `json:"git_ssh_url"`
-	GitHTTPURL        string `json:"git_http_url"`
-	Namespace         string `json:"namespace"`
-	VisibilityLevel   int    `json:"visibility_level"`
-	PathWithNamespace string `json:"path_with_namespace"`
-	DefaultBranch     string `json:"default_branch"`
-	Homepage          string `json:"homepage"`
-	URL               string `json:"url"`
-	SSHURL            string `json:"ssh_url"`
-	HTTPURL           string `json:"http_url"`
+	Name              string                `json:"name"`
+	Description       string                `json:"description"`
+	WebURL            string                `json:"web_url"`
+	AvatarURL         string                `json:"avatar_url"`
+	GitSSHURL         string                `json:"git_ssh_url"`
+	GitHTTPURL        string                `json:"git_http_url"`
+	Namespace         string                `json:"namespace"`
+	VisibilityLevel   *VisibilityLevelValue `json:"visibility"`
+	PathWithNamespace string                `json:"path_with_namespace"`
+	DefaultBranch     string                `json:"default_branch"`
+	Homepage          string                `json:"homepage"`
+	URL               string                `json:"url"`
+	SSHURL            string                `json:"ssh_url"`
+	HTTPURL           string                `json:"http_url"`
 }
 
 // ProjectNamespace represents a project namespace.
@@ -150,13 +150,13 @@ func (s Project) String() string {
 // GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#list-projects
 type ListProjectsOptions struct {
 	ListOptions
-	Archived   *bool                `url:"archived,omitempty" json:"archived,omitempty"`
-	OrderBy    *string              `url:"order_by,omitempty" json:"order_by,omitempty"`
-	Sort       *string              `url:"sort,omitempty" json:"sort,omitempty"`
-	Search     *string              `url:"search,omitempty" json:"search,omitempty"`
-	Simple     *bool                `url:"simple,omitempty" json:"simple,omitempty"`
-	Visibility VisibilityLevelValue `url:"visibility,omitempty" json:"visibility,omitempty"`
-	Statistics *bool                `url:"statistics,omitempty" json:"statistics,omitempty"`
+	Archived   *bool                 `url:"archived,omitempty" json:"archived,omitempty"`
+	OrderBy    *string               `url:"order_by,omitempty" json:"order_by,omitempty"`
+	Sort       *string               `url:"sort,omitempty" json:"sort,omitempty"`
+	Search     *string               `url:"search,omitempty" json:"search,omitempty"`
+	Simple     *bool                 `url:"simple,omitempty" json:"simple,omitempty"`
+	Visibility *VisibilityLevelValue `url:"visibility,omitempty" json:"visibility,omitempty"`
+	Statistics *bool                 `url:"statistics,omitempty" json:"statistics,omitempty"`
 }
 
 // ListProjects gets a list of projects accessible by the authenticated user.

--- a/projects.go
+++ b/projects.go
@@ -82,20 +82,20 @@ type Project struct {
 
 // Repository represents a repository.
 type Repository struct {
-	Name              string                `json:"name"`
-	Description       string                `json:"description"`
-	WebURL            string                `json:"web_url"`
-	AvatarURL         string                `json:"avatar_url"`
-	GitSSHURL         string                `json:"git_ssh_url"`
-	GitHTTPURL        string                `json:"git_http_url"`
-	Namespace         string                `json:"namespace"`
-	VisibilityLevel   *VisibilityLevelValue `json:"visibility"`
-	PathWithNamespace string                `json:"path_with_namespace"`
-	DefaultBranch     string                `json:"default_branch"`
-	Homepage          string                `json:"homepage"`
-	URL               string                `json:"url"`
-	SSHURL            string                `json:"ssh_url"`
-	HTTPURL           string                `json:"http_url"`
+	Name              string               `json:"name"`
+	Description       string               `json:"description"`
+	WebURL            string               `json:"web_url"`
+	AvatarURL         string               `json:"avatar_url"`
+	GitSSHURL         string               `json:"git_ssh_url"`
+	GitHTTPURL        string               `json:"git_http_url"`
+	Namespace         string               `json:"namespace"`
+	VisibilityLevel   VisibilityLevelValue `json:"visibility"`
+	PathWithNamespace string               `json:"path_with_namespace"`
+	DefaultBranch     string               `json:"default_branch"`
+	Homepage          string               `json:"homepage"`
+	URL               string               `json:"url"`
+	SSHURL            string               `json:"ssh_url"`
+	HTTPURL           string               `json:"http_url"`
 }
 
 // ProjectNamespace represents a project namespace.

--- a/projects.go
+++ b/projects.go
@@ -451,7 +451,7 @@ type EditProjectOptions struct {
 	ContainerRegistryEnabled                  *bool                 `url:"container_registry_enabled,omitempty" json:"container_registry_enabled,omitempty"`
 	SharedRunnersEnabled                      *bool                 `url:"shared_runners_enabled,omitempty" json:"shared_runners_enabled,omitempty"`
 	Public                                    *bool                 `url:"public,omitempty" json:"public,omitempty"`
-	VisibilityLevel                           *VisibilityLevelValue `url:"visibility_level,omitempty" json:"visibility_level,omitempty"`
+	VisibilityLevel                           *VisibilityLevelValue `url:"visibility,omitempty" json:"visibility,omitempty"`
 	ImportURL                                 *bool                 `url:"import_url,omitempty" json:"import_url,omitempty"`
 	PublicBuilds                              *bool                 `url:"public_builds,omitempty" json:"public_builds,omitempty"`
 	OnlyAllowMergeIfBuildSucceeds             *bool                 `url:"only_allow_merge_if_build_succeeds,omitempty" json:"only_allow_merge_if_build_succeeds,omitempty"`

--- a/projects_test.go
+++ b/projects_test.go
@@ -27,7 +27,7 @@ func TestListProjects(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1},{"id":2}]`)
 	})
 
-	opt := &ListProjectsOptions{ListOptions{2, 3}, Bool(true), String("name"), String("asc"), String("query"), Bool(true), String("public"), Bool(true)}
+	opt := &ListProjectsOptions{ListOptions{2, 3}, Bool(true), String("name"), String("asc"), String("query"), Bool(true), VisibilityLevel(PublicVisibility), Bool(true)}
 	projects, _, err := client.Projects.ListProjects(opt)
 
 	if err != nil {
@@ -60,7 +60,7 @@ func TestListOwnedProjects(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1},{"id":2}]`)
 	})
 
-	opt := &ListProjectsOptions{ListOptions{2, 3}, Bool(true), String("name"), String("asc"), String("query"), Bool(true), String("public"), Bool(false)}
+	opt := &ListProjectsOptions{ListOptions{2, 3}, Bool(true), String("name"), String("asc"), String("query"), Bool(true), VisibilityLevel(PublicVisibility), Bool(false)}
 	projects, _, err := client.Projects.ListOwnedProjects(opt)
 
 	if err != nil {
@@ -93,7 +93,7 @@ func TestListStarredProjects(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1},{"id":2}]`)
 	})
 
-	opt := &ListProjectsOptions{ListOptions{2, 3}, Bool(true), String("name"), String("asc"), String("query"), Bool(true), String("public"), Bool(false)}
+	opt := &ListProjectsOptions{ListOptions{2, 3}, Bool(true), String("name"), String("asc"), String("query"), Bool(true), VisibilityLevel(PublicVisibility), Bool(false)}
 	projects, _, err := client.Projects.ListStarredProjects(opt)
 
 	if err != nil {
@@ -126,7 +126,7 @@ func TestListAllProjects(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1},{"id":2}]`)
 	})
 
-	opt := &ListProjectsOptions{ListOptions{2, 3}, Bool(true), String("name"), String("asc"), String("query"), Bool(true), String("public"), Bool(false)}
+	opt := &ListProjectsOptions{ListOptions{2, 3}, Bool(true), String("name"), String("asc"), String("query"), Bool(true), VisibilityLevel(PublicVisibility), Bool(false)}
 	projects, _, err := client.Projects.ListAllProjects(opt)
 
 	if err != nil {


### PR DESCRIPTION
I fixed the api call for group visibility. it has not the same scheme like the project visibility in version 9. furthermore I added the project share with groups option. 