### PR TITLE
Added ForkParent struct to show details of a project if it is a fork.

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -74,6 +74,7 @@ type Project struct {
 	OnlyAllowMergeIfAllDiscussionsAreResolved bool                 `json:"only_allow_merge_if_all_discussions_are_resolved"`
 	LFSEnabled                                bool                 `json:"lfs_enabled"`
 	RequestAccessEnabled                      bool                 `json:"request_access_enabled"`
+	ForkedFromProject                         *ForkParent          `json:"forked_from_project"`
 	SharedWithGroups                          []struct {
 		GroupID          int    `json:"group_id"`
 		GroupName        string `json:"group_name"`
@@ -141,6 +142,17 @@ type ProjectAccess struct {
 type GroupAccess struct {
 	AccessLevel       AccessLevelValue       `json:"access_level"`
 	NotificationLevel NotificationLevelValue `json:"notification_level"`
+}
+
+// ForkParent represents the parent project when this is a fork.
+type ForkParent struct {
+	HTTPURLToRepo     string `json:"http_url_to_repo"`
+	ID                int    `json:"id"`
+	Name              string `json:"name"`
+	NameWithNamespace string `json:"name_with_namespace"`
+	Path              string `json:"path"`
+	PathWithNamespace string `json:"path_with_namespace"`
+	WebURL            string `json:"web_url"`
 }
 
 func (s Project) String() string {


### PR DESCRIPTION
If a project is a fork it will show the details of the project that it was forked from.

If a project isn't a fork the setting will be null.

Here is the relevant output for a project that is  not a fork (project id on gitlab.com 1031285):

```
  "request_access_enabled": true,
  "forked_from_project": null,
  "shared_with_groups": [],
  "statistics": null
```

This is the output from a fork (project id on gitlab.com 243827):

```
  "request_access_enabled": true,
  "forked_from_project": {
    "http_url_to_repo": "https://gitlab.com/gitlab-org/gitlab-ce.git",
    "id": 13083,
    "name": "GitLab Community Edition",
    "name_with_namespace": "GitLab.org / GitLab Community Edition",
    "path": "gitlab-ce",
    "path_with_namespace": "gitlab-org/gitlab-ce",
    "web_url": "https://gitlab.com/gitlab-org/gitlab-ce"
  },
  "shared_with_groups": [],
  "statistics": null
```

The API documentation doesn't list these fields but they have existed for the last 2 years that I've been using them with an api from another language that I want to move away from.

Only query I have is if the naming could be improved, I've no preference just picked something to get it working.