### PR TITLE
Added Version API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ includes all calls to the following services:
 - [x] Namespaces
 - [x] Settings
 - [x] Pipelines
+- [x] Version
 
 ## Usage
 

--- a/gitlab.go
+++ b/gitlab.go
@@ -192,6 +192,7 @@ type Client struct {
 	Tags                 *TagsService
 	TimeStats            *TimeStatsService
 	Users                *UsersService
+	Version              *VersionService
 }
 
 // ListOptions specifies the optional parameters to various List methods that
@@ -254,6 +255,7 @@ func newClient(httpClient *http.Client, tokenType tokenType, token string) *Clie
 	c.Tags = &TagsService{client: c}
 	c.TimeStats = &TimeStatsService{client: c}
 	c.Users = &UsersService{client: c}
+	c.Version = &VersionService{client: c}
 
 	return c
 }

--- a/version.go
+++ b/version.go
@@ -20,7 +20,7 @@ package gitlab
 // retrieve its version information via the GitLab API.
 //
 // GitLab API docs:
-// https://gitlab.com/gitlab-org/gitlab-ce/blob/v9.1.4/doc/api/version.md
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/version.md
 type VersionService struct {
 	client *Client
 }
@@ -28,7 +28,7 @@ type VersionService struct {
 // Version represents a GitLab instance version.
 //
 // GitLab API docs:
-// https://gitlab.com/gitlab-org/gitlab-ce/blob/v9.1.4/doc/api/version.md
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/version.md
 type Version struct {
 	Version  string `json:"version"`
 	Revision string `json:"revision"`
@@ -38,12 +38,12 @@ func (s Version) String() string {
 	return Stringify(s)
 }
 
-// GetVersion gets a GitLab server instance version; it is only available to authemticated users.
+// GetVersion gets a GitLab server instance version; it is only available to
+// authenticated users.
 //
 // GitLab API docs:
-// https://gitlab.com/gitlab-org/gitlab-ce/blob/v9.1.4/doc/api/version.md
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/version.md
 func (s *VersionService) GetVersion() (*Version, *Response, error) {
-
 	req, err := s.client.NewRequest("GET", "version", nil, nil)
 	if err != nil {
 		return nil, nil, err

--- a/version.go
+++ b/version.go
@@ -1,0 +1,59 @@
+//
+// Copyright 2017, Andrea Funto'
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package gitlab
+
+// VersionService handles communication with the GitLab server instance to
+// retrieve its version information via the GitLab API.
+//
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/v9.1.4/doc/api/version.md
+type VersionService struct {
+	client *Client
+}
+
+// Version represents a GitLab instance version.
+//
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/v9.1.4/doc/api/version.md
+type Version struct {
+	Version  string `json:"version"`
+	Revision string `json:"revision"`
+}
+
+func (s Version) String() string {
+	return Stringify(s)
+}
+
+// GetVersion gets a GitLab server instance version; it is only available to authemticated users.
+//
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/v9.1.4/doc/api/version.md
+func (s *VersionService) GetVersion() (*Version, *Response, error) {
+
+	req, err := s.client.NewRequest("GET", "version", nil, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	v := new(Version)
+	resp, err := s.client.Do(req, v)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return v, resp, err
+}


### PR DESCRIPTION
Hallo, I'm submitting a proposal for the addition of the Version API; I followed your style quite closely and tested my code against a 9.1.3 instance (gitlab/gitlab-ce:latest on dockerhub). The API has been there since 8.13, though.