### PR TITLE
Enhanced group creation and added update group support

### DIFF
--- a/groups.go
+++ b/groups.go
@@ -35,12 +35,15 @@ type GroupsService struct {
 // GitLab API docs:
 // https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/groups.md
 type Group struct {
-	ID          int                `json:"id"`
-	Name        string             `json:"name"`
-	Path        string             `json:"path"`
-	Description string             `json:"description"`
-	Projects    []*Project         `json:"projects"`
-	Statistics  *StorageStatistics `json:"statistics"`
+	ID                   int                  `json:"id"`
+	Name                 string               `json:"name"`
+	Path                 string               `json:"path"`
+	Description          string               `json:"description"`
+	VisibilityLevel      VisibilityLevelValue `json:"visibility_level"`
+	LFSEnabled           bool                 `json:"lfs_enabled"`
+	RequestAccessEnabled bool                 `json:"request_access_enabled"`
+	Projects             []*Project           `json:"projects"`
+	Statistics           *StorageStatistics   `json:"statistics"`
 }
 
 // ListGroupsOptions represents the available ListGroups() options.
@@ -102,10 +105,12 @@ func (s *GroupsService) GetGroup(gid interface{}, options ...OptionFunc) (*Group
 // GitLab API docs:
 // https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/groups.md#new-group
 type CreateGroupOptions struct {
-	Name            *string               `url:"name,omitempty" json:"name,omitempty"`
-	Path            *string               `url:"path,omitempty" json:"path,omitempty"`
-	Description     *string               `url:"description,omitempty" json:"description,omitempty"`
-	VisibilityLevel *VisibilityLevelValue `url:"visibility_level" json:"visibility_level,omitempty"`
+	Name                 *string               `url:"name,omitempty" json:"name,omitempty"`
+	Path                 *string               `url:"path,omitempty" json:"path,omitempty"`
+	Description          *string               `url:"description,omitempty" json:"description,omitempty"`
+	VisibilityLevel      *VisibilityLevelValue `url:"visibility_level" json:"visibility_level,omitempty"`
+	LFSEnabled           *bool                 `url:"lfs_enabled" json:"lfs_enabled,omitempty"`
+	RequestAccessEnabled *bool                 `url:"request_access_enabled" json:"request_access_enabled,omitempty"`
 }
 
 // CreateGroup creates a new project group. Available only for users who can


### PR DESCRIPTION
Hallo, I'm proposing a **backward compatible** enhancement to the Groups API, consisting of two items:
1. when creating a group, it is now possible to specify the values for the Group's visibility level, for Large File Support (LFS, defaulting if unspecified to "true") and for "Request Access Enabled" (defaulting if unspecified to "false").
2. a new func has been added to update an existing Group

The GitLab API seems to be quite inconsistent when it comes to handling groups, and so is the product's UI: it is impossible to provide values for Group Visibility, LFS and Request Access Enablement at creation time, so these values default to "public", "true" and "false" respectively, yet they can be changed afterwards by going to the Group settings page. The lack of this latter option in go-gitlab (no "UpdateGroup" func) made it effectively impossible to set these values programatically, to my understanding.

I'm proposing this enhancement because I consider it practical and because it is absolutely vital for proper support of GitLab Groups in provisioning tools such as [HashiCorp Terraform](https://github.com/hashicorp/terraform). I would like to see much better support of GitLab there, but it requires enhancements upstream, so here we are.

I tested both changes quite extensively; I wish there were an automated test suite to add to, maybe running againsta  docker instance... maybe we could figure one out together... OK I'll think about it...

Please feel free to ask any questions.