### PR TITLE
Added RequestAccessEnabled, AvatarURL and WebURL to Group struct (GetGroup)

### DIFF
--- a/groups.go
+++ b/groups.go
@@ -36,14 +36,17 @@ type GroupsService struct {
 // GitLab API docs:
 // https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/groups.md
 type Group struct {
-	ID              int                  `json:"id"`
-	Name            string               `json:"name"`
-	Path            string               `json:"path"`
-	Description     string               `json:"description"`
-	LFSEnabled      bool                 `json:"lfs_enabled"`
-	Projects        []*Project           `json:"projects"`
-	Statistics      *StorageStatistics   `json:"statistics"`
-	VisibilityLevel VisibilityLevelValue `json:"visibility_level"`
+	ID                   int                  `json:"id"`
+	Name                 string               `json:"name"`
+	Path                 string               `json:"path"`
+	Description          string               `json:"description"`
+	VisibilityLevel      VisibilityLevelValue `json:"visibility_level"`
+	AvatarURL            string               `json:"avatar_url"`
+	WebURL               string               `json:"web_url"`
+	RequestAccessEnabled bool                 `json:"request_access_enabled"`
+	LFSEnabled           bool                 `json:"lfs_enabled"`
+	Projects             []*Project           `json:"projects"`
+	Statistics           *StorageStatistics   `json:"statistics"`
 }
 
 // ListGroupsOptions represents the available ListGroups() options.


### PR DESCRIPTION
The Group struct misses three values returned by the GetGroup details API, namely RequestAccessEnabled, AvatarURL and WebURL:
`
$> curl --header "PRIVATE-TOKEN: <my token>" http://mygitlab/api/v3/groups/57
`
returns
`
{
  "id":57,
  "name":"first-group",
  "path":"first-group",
  "description":"",
  "visibility_level":10,
  "lfs_enabled":true,
  "avatar_url":"http://mygitlab/uploads/group/avatar/57/home-icon.png",
  "web_url":"http://mygitlab/groups/first-group",
  "request_access_enabled":true,
  "full_name":"first-group",
  "full_path":"first-group",
  "parent_id":null,
  "projects":[],
  "shared_projects":[]
}
`