### PR TITLE
Bring List Repository Tree in line with current API docs

### DIFF
--- a/repositories.go
+++ b/repositories.go
@@ -39,6 +39,7 @@ type TreeNode struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
 	Type string `json:"type"`
+	Path string `json:"path"`
 	Mode string `json:"mode"`
 }
 
@@ -51,8 +52,9 @@ func (t TreeNode) String() string {
 // GitLab API docs:
 // https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/repositories.md#list-repository-tree
 type ListTreeOptions struct {
-	Path    *string `url:"path,omitempty" json:"path,omitempty"`
-	RefName *string `url:"ref_name,omitempty" json:"ref_name,omitempty"`
+	Path      *string `url:"path,omitempty" json:"path,omitempty"`
+	RefName   *string `url:"ref_name,omitempty" json:"ref_name,omitempty"`
+	Recursive *bool   `url:"recursive,omitempty" json:"recursive,omitempty"`
 }
 
 // ListTree gets a list of repository files and directories in a project.


### PR DESCRIPTION
Heya,

Noticed a couple parameters missing from the ListTree API.

Also noticed the efforts for v4, this should translate over 1:1 with the exception of `RefName` having been renamed to `Ref`. I'm absolutely willing to update that branch as well but I kinda needed this functionality now. :smile: