### PR TITLE
When deleting a repository file, the API returns a 204

### DIFF
--- a/examples/repository_files.go
+++ b/examples/repository_files.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/base64"
 	"log"
 
 	"github.com/xanzy/go-gitlab"
@@ -13,7 +12,6 @@ func repositoryFileExample() {
 	// Create a new repository file
 	cf := &gitlab.CreateFileOptions{
 		Branch:        gitlab.String("master"),
-		Encoding:      gitlab.String("text"),
 		Content:       gitlab.String("My file contents"),
 		CommitMessage: gitlab.String("Adding a test file"),
 	}
@@ -25,7 +23,6 @@ func repositoryFileExample() {
 	// Update a repository file
 	uf := &gitlab.UpdateFileOptions{
 		Branch:        gitlab.String("master"),
-		Encoding:      gitlab.String("text"),
 		Content:       gitlab.String("My file content"),
 		CommitMessage: gitlab.String("Fixing typo"),
 	}
@@ -42,14 +39,5 @@ func repositoryFileExample() {
 		log.Fatal(err)
 	}
 
-	if f.Encoding == "base64" {
-		content, err := base64.StdEncoding.DecodeString(f.Content)
-		if err != nil {
-			log.Fatal(err)
-		}
-		log.Printf("File contains: %s", string(content))
-
-	} else {
-		log.Printf("File contains: %s", f.Content)
-	}
+	log.Printf("File contains: %s", f.Content)
 }

--- a/repository_files.go
+++ b/repository_files.go
@@ -218,23 +218,17 @@ type DeleteFileOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/repository_files.html#delete-existing-file-in-repository
-func (s *RepositoryFilesService) DeleteFile(pid interface{}, fileName string, opt *DeleteFileOptions, options ...OptionFunc) (*FileInfo, *Response, error) {
+func (s *RepositoryFilesService) DeleteFile(pid interface{}, fileName string, opt *DeleteFileOptions, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	u := fmt.Sprintf("projects/%s/repository/files/%s", url.QueryEscape(project), url.QueryEscape(fileName))
 
 	req, err := s.client.NewRequest("DELETE", u, opt, options)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	f := new(FileInfo)
-	resp, err := s.client.Do(req, f)
-	if err != nil {
-		return nil, resp, err
-	}
-
-	return f, resp, err
+	return s.client.Do(req, nil)
 }


### PR DESCRIPTION
This means that in contrast with the API docs, no response data is given. To fix this I had to make a small backwards incompatible change for the `RepositoryFiles.DeleteFile()` method. Sorry about that...

Fixes #195