### PR TITLE
PipelineEvent fixes

### DIFF
--- a/events.go
+++ b/events.go
@@ -509,10 +509,15 @@ type PipelineEvent struct {
 			Username  string `json:"username"`
 			AvatarURL string `json:"avatar_url"`
 		} `json:"user"`
-		Runner        string `json:"runner"`
+		Runner struct {
+			Id          int    `json:"id"`
+			Description string `json:"description"`
+			Active      bool   `json:"active"`
+			IsShared    bool   `json:"is_shared"`
+		} `json:"runner"`
 		ArtifactsFile struct {
 			Filename string `json:"filename"`
-			Size     string `json:"size"`
+			Size     int    `json:"size"`
 		} `json:"artifacts_file"`
 	} `json:"builds"`
 }

--- a/events.go
+++ b/events.go
@@ -510,7 +510,7 @@ type PipelineEvent struct {
 			AvatarURL string `json:"avatar_url"`
 		} `json:"user"`
 		Runner struct {
-			Id          int    `json:"id"`
+			ID          int    `json:"id"`
 			Description string `json:"description"`
 			Active      bool   `json:"active"`
 			IsShared    bool   `json:"is_shared"`

--- a/events_test.go
+++ b/events_test.go
@@ -285,11 +285,11 @@ func TestPipelineEventUnmarshal(t *testing.T) {
             "avatar_url": "http://www.gravatar.com/avatar/e32bd13e2add097461cb96824b7a829c?s=80\u0026d=identicon"
          },
          "runner": {
-		    "id": 6,
-			"description": "Kubernetes Runner",
-			"active": true,
-			"is_shared": true
-		 },
+            "id": 6,
+            "description": "Kubernetes Runner",
+            "active": true,
+            "is_shared": true
+         },
          "artifacts_file":{
             "filename": "artifacts.zip",
             "size": 1319148

--- a/events_test.go
+++ b/events_test.go
@@ -284,10 +284,15 @@ func TestPipelineEventUnmarshal(t *testing.T) {
             "username": "root",
             "avatar_url": "http://www.gravatar.com/avatar/e32bd13e2add097461cb96824b7a829c?s=80\u0026d=identicon"
          },
-         "runner": null,
+         "runner": {
+		    "id": 6,
+			"description": "Kubernetes Runner",
+			"active": true,
+			"is_shared": true
+		 },
          "artifacts_file":{
-            "filename": null,
-            "size": null
+            "filename": "artifacts.zip",
+            "size": 1319148
          }
       },
       {


### PR DESCRIPTION
Tested on GitLab CE 9.5.1

Correct type for "size" field in .builds[].artifacts_file.size and support for the "runner" object in .builds[].runner

Please see excerpt (item from .builds[] array) from the JSON posted by Gitlab below:

```
{
    "id": 11185,
    "stage": "build",
    "name": "content",
    "status": "success",
    "created_at": "2017-08-31 08:00:45 UTC",
    "started_at": "2017-08-31 08:02:13 UTC",
    "finished_at": "2017-08-31 08:02:22 UTC",
    "when": "on_success",
    "manual": false,
    "user": {
        "name": "Emil Flink",
        "username": "emil.flink",
        "avatar_url": "http://example.com/uploads/-/system/user/avatar/14/avatar.png"
    },
    "runner": {
        "id": 6,
        "description": "Kubernetes Runner",
        "active": true,
        "is_shared": true
    },
    "artifacts_file": {
        "filename": "artifacts.zip",
        "size": 1319148
    }
}
```