### PR TITLE
Add `expires_at` option and rename `UpdateGroupMember` -> `EditGroupMember`

### DIFF
--- a/groups.go
+++ b/groups.go
@@ -237,7 +237,7 @@ func (s *GroupsService) SearchGroup(query string, options ...OptionFunc) ([]*Gro
 
 // GroupMember represents a GitLab group member.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/groups.html
+// GitLab API docs: https://docs.gitlab.com/ce/api/members.html
 type GroupMember struct {
 	ID          int              `json:"id"`
 	Username    string           `json:"username"`
@@ -252,7 +252,7 @@ type GroupMember struct {
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/groups.html#list-group-members
+// https://docs.gitlab.com/ce/api/members.html#list-all-members-of-a-group-or-project
 type ListGroupMembersOptions struct {
 	ListOptions
 }
@@ -261,7 +261,7 @@ type ListGroupMembersOptions struct {
 // user.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/groups.html#list-group-members
+// https://docs.gitlab.com/ce/api/members.html#list-all-members-of-a-group-or-project
 func (s *GroupsService) ListGroupMembers(gid interface{}, opt *ListGroupMembersOptions, options ...OptionFunc) ([]*GroupMember, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -319,16 +319,18 @@ func (s *GroupsService) ListGroupProjects(gid interface{}, opt *ListGroupProject
 
 // AddGroupMemberOptions represents the available AddGroupMember() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/groups.html#add-group-member
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/members.html#add-a-member-to-a-group-or-project
 type AddGroupMemberOptions struct {
 	UserID      *int              `url:"user_id,omitempty" json:"user_id,omitempty"`
 	AccessLevel *AccessLevelValue `url:"access_level,omitempty" json:"access_level,omitempty"`
+	ExpiresAt   *string           `url:"expires_at,omitempty" json:"expires_at"`
 }
 
 // AddGroupMember adds a user to the list of group members.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/groups.html#list-group-members
+// https://docs.gitlab.com/ce/api/members.html#add-a-member-to-a-group-or-project
 func (s *GroupsService) AddGroupMember(gid interface{}, opt *AddGroupMemberOptions, options ...OptionFunc) (*GroupMember, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -350,20 +352,21 @@ func (s *GroupsService) AddGroupMember(gid interface{}, opt *AddGroupMemberOptio
 	return g, resp, err
 }
 
-// UpdateGroupMemberOptions represents the available UpdateGroupMember()
+// EditGroupMemberOptions represents the available EditGroupMember()
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/groups.html#edit-group-team-member
-type UpdateGroupMemberOptions struct {
+// https://docs.gitlab.com/ce/api/members.html#edit-a-member-of-a-group-or-project
+type EditGroupMemberOptions struct {
 	AccessLevel *AccessLevelValue `url:"access_level,omitempty" json:"access_level,omitempty"`
+	ExpiresAt   *string           `url:"expires_at,omitempty" json:"expires_at"`
 }
 
-// UpdateGroupMember updates a group team member to a specified access level.
+// EditGroupMember updates a member of a group.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/groups.html#list-group-members
-func (s *GroupsService) UpdateGroupMember(gid interface{}, user int, opt *UpdateGroupMemberOptions, options ...OptionFunc) (*GroupMember, *Response, error) {
+// https://docs.gitlab.com/ce/api/members.html#edit-a-member-of-a-group-or-project
+func (s *GroupsService) EditGroupMember(gid interface{}, user int, opt *EditGroupMemberOptions, options ...OptionFunc) (*GroupMember, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
 		return nil, nil, err
@@ -387,7 +390,7 @@ func (s *GroupsService) UpdateGroupMember(gid interface{}, user int, opt *Update
 // RemoveGroupMember removes user from user team.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/groups.html#remove-user-from-user-team
+// https://docs.gitlab.com/ce/api/members.html#remove-a-member-from-a-group-or-project
 func (s *GroupsService) RemoveGroupMember(gid interface{}, user int, options ...OptionFunc) (*Response, error) {
 	group, err := parseID(gid)
 	if err != nil {


### PR DESCRIPTION
Fixes #205 and makes the function name inline with the docs.