### PR TITLE
Updates projects and MR types to be compatible with V4 API

### DIFF
--- a/merge_requests.go
+++ b/merge_requests.go
@@ -76,14 +76,14 @@ type MergeRequest struct {
 		UpdatedAt   *time.Time `json:"updated_at"`
 		DueDate     string     `json:"due_date"`
 	} `json:"milestone"`
-	MergeWhenBuildSucceeds  bool   `json:"merge_when_build_succeeds"`
-	MergeStatus             string `json:"merge_status"`
-	SHA                     string `json:"sha"`
-	Subscribed              bool   `json:"subscribed"`
-	UserNotesCount          int    `json:"user_notes_count"`
-	SouldRemoveSourceBranch bool   `json:"should_remove_source_branch"`
-	ForceRemoveSourceBranch bool   `json:"force_remove_source_branch"`
-	Changes                 []struct {
+	MergeWhenPipelineSucceeds bool   `json:"merge_when_pipeline_succeeds"`
+	MergeStatus               string `json:"merge_status"`
+	SHA                       string `json:"sha"`
+	Subscribed                bool   `json:"subscribed"`
+	UserNotesCount            int    `json:"user_notes_count"`
+	SouldRemoveSourceBranch   bool   `json:"should_remove_source_branch"`
+	ForceRemoveSourceBranch   bool   `json:"force_remove_source_branch"`
+	Changes                   []struct {
 		OldPath     string `json:"old_path"`
 		NewPath     string `json:"new_path"`
 		AMode       string `json:"a_mode"`
@@ -302,10 +302,10 @@ func (s *MergeRequestsService) UpdateMergeRequest(pid interface{}, mergeRequest 
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/merge_requests.html#accept-mr
 type AcceptMergeRequestOptions struct {
-	MergeCommitMessage       *string `url:"merge_commit_message,omitempty" json:"merge_commit_message,omitempty"`
-	ShouldRemoveSourceBranch *bool   `url:"should_remove_source_branch,omitempty" json:"should_remove_source_branch,omitempty"`
-	MergeWhenBuildSucceeds   *bool   `url:"merge_when_build_succeeds,omitempty" json:"merge_when_build_succeeds,omitempty"`
-	Sha                      *string `url:"sha,omitempty" json:"sha,omitempty"`
+	MergeCommitMessage        *string `url:"merge_commit_message,omitempty" json:"merge_commit_message,omitempty"`
+	ShouldRemoveSourceBranch  *bool   `url:"should_remove_source_branch,omitempty" json:"should_remove_source_branch,omitempty"`
+	MergeWhenPipelineSucceeds *bool   `url:"merge_when_pipeline_succeeds,omitempty" json:"merge_when_pipeline_succeeds,omitempty"`
+	Sha                       *string `url:"sha,omitempty" json:"sha,omitempty"`
 }
 
 // AcceptMergeRequest merges changes submitted with MR using this API. If merge

--- a/projects.go
+++ b/projects.go
@@ -52,7 +52,7 @@ type Project struct {
 	OpenIssuesCount                           int               `json:"open_issues_count"`
 	MergeRequestsEnabled                      bool              `json:"merge_requests_enabled"`
 	ApprovalsBeforeMerge                      int               `json:"approvals_before_merge"`
-	BuildsEnabled                             bool              `json:"builds_enabled"`
+	JobsEnabled                               bool              `json:"jobs_enabled"`
 	WikiEnabled                               bool              `json:"wiki_enabled"`
 	SnippetsEnabled                           bool              `json:"snippets_enabled"`
 	ContainerRegistryEnabled                  bool              `json:"container_registry_enabled"`
@@ -67,8 +67,8 @@ type Project struct {
 	ForksCount                                int               `json:"forks_count"`
 	StarCount                                 int               `json:"star_count"`
 	RunnersToken                              string            `json:"runners_token"`
-	PublicBuilds                              bool              `json:"public_builds"`
-	OnlyAllowMergeIfBuildSucceeds             bool              `json:"only_allow_merge_if_build_succeeds"`
+	PublicJobs                                bool              `json:"public_jobs"`
+	OnlyAllowMergeIfPipelineSucceeds          bool              `json:"only_allow_merge_if_pipeline_succeeds"`
 	OnlyAllowMergeIfAllDiscussionsAreResolved bool              `json:"only_allow_merge_if_all_discussions_are_resolved"`
 	LFSEnabled                                bool              `json:"lfs_enabled"`
 	RequestAccessEnabled                      bool              `json:"request_access_enabled"`
@@ -112,10 +112,10 @@ type ProjectNamespace struct {
 
 // StorageStatistics represents a statistics record for a group or project.
 type StorageStatistics struct {
-	StorageSize        int64 `json:"storage_size"`
-	RepositorySize     int64 `json:"repository_size"`
-	LfsObjectsSize     int64 `json:"lfs_objects_size"`
-	BuildArtifactsSize int64 `json:"build_artifacts_size"`
+	StorageSize      int64 `json:"storage_size"`
+	RepositorySize   int64 `json:"repository_size"`
+	LfsObjectsSize   int64 `json:"lfs_objects_size"`
+	JobArtifactsSize int64 `json:"job_artifacts_size"`
 }
 
 // ProjectStatistics represents a statistics record for a project.
@@ -582,7 +582,7 @@ type ProjectHook struct {
 	MergeRequestsEvents   bool       `json:"merge_requests_events"`
 	TagPushEvents         bool       `json:"tag_push_events"`
 	NoteEvents            bool       `json:"note_events"`
-	BuildEvents           bool       `json:"build_events"`
+	JobEvents             bool       `json:"job_events"`
 	PipelineEvents        bool       `json:"pipeline_events"`
 	WikiPageEvents        bool       `json:"wiki_page_events"`
 	EnableSSLVerification bool       `json:"enable_ssl_verification"`
@@ -657,7 +657,7 @@ type AddProjectHookOptions struct {
 	MergeRequestsEvents   *bool   `url:"merge_requests_events,omitempty" json:"merge_requests_events,omitempty"`
 	TagPushEvents         *bool   `url:"tag_push_events,omitempty" json:"tag_push_events,omitempty"`
 	NoteEvents            *bool   `url:"note_events,omitempty" json:"note_events,omitempty"`
-	BuildEvents           *bool   `url:"build_events,omitempty" json:"build_events,omitempty"`
+	JobEvents             *bool   `url:"job_events,omitempty" json:"job_events,omitempty"`
 	PipelineEvents        *bool   `url:"pipeline_events,omitempty" json:"pipeline_events,omitempty"`
 	WikiPageEvents        *bool   `url:"wiki_page_events,omitempty" json:"wiki_page_events,omitempty"`
 	EnableSSLVerification *bool   `url:"enable_ssl_verification,omitempty" json:"enable_ssl_verification,omitempty"`
@@ -700,7 +700,7 @@ type EditProjectHookOptions struct {
 	MergeRequestsEvents   *bool   `url:"merge_requests_events,omitempty" json:"merge_requests_events,omitempty"`
 	TagPushEvents         *bool   `url:"tag_push_events,omitempty" json:"tag_push_events,omitempty"`
 	NoteEvents            *bool   `url:"note_events,omitempty" json:"note_events,omitempty"`
-	BuildEvents           *bool   `url:"build_events,omitempty" json:"build_events,omitempty"`
+	JobEvents             *bool   `url:"job_events,omitempty" json:"job_events,omitempty"`
 	PipelineEvents        *bool   `url:"pipeline_events,omitempty" json:"pipeline_events,omitempty"`
 	WikiPageEvents        *bool   `url:"wiki_page_events,omitempty" json:"wiki_page_events,omitempty"`
 	EnableSSLVerification *bool   `url:"enable_ssl_verification,omitempty" json:"enable_ssl_verification,omitempty"`


### PR DESCRIPTION
In Gitlab v4 API, the 'build' term is replaced with 'jobs'. This PR updates some types that still were referencing the old 'builds' term, breaking compatibility with V4.