### PR TITLE
Add support for GET /users?blocked=true #241

### DIFF
--- a/users.go
+++ b/users.go
@@ -72,6 +72,7 @@ type UserIdentity struct {
 type ListUsersOptions struct {
 	ListOptions
 	Active   *bool   `url:"active,omitempty" json:"active,omitempty"`
+	Blocked  *bool   `url:"blocked,omitempty" json:"blocked,omitempty"`
 	Search   *string `url:"search,omitempty" json:"search,omitempty"`
 	Username *string `url:"username,omitempty" json:"username,omitempty"`
 }


### PR DESCRIPTION
As documented in #241 this PR adds support for `GET /users?blocked=true`