### PR TITLE
Rename Iid fields to IID to match golang convention

### DIFF
--- a/events.go
+++ b/events.go
@@ -126,7 +126,7 @@ type IssueEvent struct {
 		Description string `json:"description"`
 		MilestoneID int    `json:"milestone_id"`
 		State       string `json:"state"`
-		Iid         int    `json:"iid"`
+		IID         int    `json:"iid"`
 		URL         string `json:"url"`
 		Action      string `json:"action"`
 	} `json:"object_attributes"`
@@ -360,7 +360,7 @@ type MergeEvent struct {
 		State           string    `json:"state"`
 		MergeStatus     string    `json:"merge_status"`
 		TargetProjectID int       `json:"target_project_id"`
-		Iid             int       `json:"iid"`
+		IID             int       `json:"iid"`
 		Description     string    `json:"description"`
 		Position        int       `json:"position"`
 		LockedAt        string    `json:"locked_at"`

--- a/events.go
+++ b/events.go
@@ -246,7 +246,7 @@ type MergeCommentEvent struct {
 		State           string    `json:"state"`
 		MergeStatus     string    `json:"merge_status"`
 		TargetProjectID int       `json:"target_project_id"`
-		Iid             int       `json:"iid"`
+		IID             int       `json:"iid"`
 		Description     string    `json:"description"`
 		Position        int       `json:"position"`
 		LockedAt        string    `json:"locked_at"`

--- a/events.go
+++ b/events.go
@@ -230,7 +230,58 @@ type MergeCommentEvent struct {
 		StDiff       *Diff  `json:"st_diff"`
 		URL          string `json:"url"`
 	} `json:"object_attributes"`
-	MergeRequest *MergeRequest `json:"merge_request"`
+	MergeRequest struct {
+		ID              int       `json:"id"`
+		TargetBranch    string    `json:"target_branch"`
+		SourceBranch    string    `json:"source_branch"`
+		SourceProjectID int       `json:"source_project_id"`
+		AuthorID        int       `json:"author_id"`
+		AssigneeID      int       `json:"assignee_id"`
+		Title           string    `json:"title"`
+		CreatedAt       string    `json:"created_at"` // Should be *time.Time (see Gitlab issue #21468)
+		UpdatedAt       string    `json:"updated_at"` // Should be *time.Time (see Gitlab issue #21468)
+		StCommits       []*Commit `json:"st_commits"`
+		StDiffs         []*Diff   `json:"st_diffs"`
+		MilestoneID     int       `json:"milestone_id"`
+		State           string    `json:"state"`
+		MergeStatus     string    `json:"merge_status"`
+		TargetProjectID int       `json:"target_project_id"`
+		Iid             int       `json:"iid"`
+		Description     string    `json:"description"`
+		Position        int       `json:"position"`
+		LockedAt        string    `json:"locked_at"`
+		UpdatedByID     int       `json:"updated_by_id"`
+		MergeError      string    `json:"merge_error"`
+		MergeParams     struct {
+			ForceRemoveSourceBranch string `json:"force_remove_source_branch"`
+		} `json:"merge_params"`
+		MergeWhenBuildSucceeds   bool        `json:"merge_when_build_succeeds"`
+		MergeUserID              int         `json:"merge_user_id"`
+		MergeCommitSha           string      `json:"merge_commit_sha"`
+		DeletedAt                string      `json:"deleted_at"`
+		ApprovalsBeforeMerge     string      `json:"approvals_before_merge"`
+		RebaseCommitSha          string      `json:"rebase_commit_sha"`
+		InProgressMergeCommitSha string      `json:"in_progress_merge_commit_sha"`
+		LockVersion              int         `json:"lock_version"`
+		TimeEstimate             int         `json:"time_estimate"`
+		Source                   *Repository `json:"source"`
+		Target                   *Repository `json:"target"`
+		LastCommit               struct {
+			ID        string     `json:"id"`
+			Message   string     `json:"message"`
+			Timestamp *time.Time `json:"timestamp"`
+			URL       string     `json:"url"`
+			Author    *Author    `json:"author"`
+		} `json:"last_commit"`
+		WorkInProgress bool   `json:"work_in_progress"`
+		URL            string `json:"url"`
+		Action         string `json:"action"`
+		Assignee       struct {
+			Name      string `json:"name"`
+			Username  string `json:"username"`
+			AvatarURL string `json:"avatar_url"`
+		} `json:"assignee"`
+	} `json:"merge_request"`
 }
 
 // IssueCommentEvent represents a comment on an issue event.

--- a/merge_requests.go
+++ b/merge_requests.go
@@ -67,7 +67,7 @@ type MergeRequest struct {
 	Labels          []string `json:"labels"`
 	Milestone       struct {
 		ID          int        `json:"id"`
-		Iid         int        `json:"iid"`
+		IID         int        `json:"iid"`
 		ProjectID   int        `json:"project_id"`
 		Title       string     `json:"title"`
 		Description string     `json:"description"`

--- a/milestones.go
+++ b/milestones.go
@@ -35,7 +35,7 @@ type MilestonesService struct {
 // GitLab API docs: https://docs.gitlab.com/ce/api/milestones.html
 type Milestone struct {
 	ID          int        `json:"id"`
-	Iid         int        `json:"iid"`
+	IID         int        `json:"iid"`
 	ProjectID   int        `json:"project_id"`
 	Title       string     `json:"title"`
 	Description string     `json:"description"`


### PR DESCRIPTION
This is inconsistent right now, there are some fields that are named `IID` correctly.

> Words in names that are initialisms or acronyms (e.g. "URL" or "NATO") have a consistent case. ? > For example, "URL" should appear as "URL" or "url" (as in "urlPony", or "URLPony"), never as "Url". Here's an example: ServeHTTP not ServeHttp.

From https://github.com/golang/go/wiki/CodeReviewComments#initialisms