### PR TITLE
added _links property support in projects api

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -63,6 +63,7 @@ type Project struct {
 	ContainerRegistryEnabled                  bool              `json:"container_registry_enabled"`
 	CreatedAt                                 *time.Time        `json:"created_at,omitempty"`
 	LastActivityAt                            *time.Time        `json:"last_activity_at,omitempty"`
+	Links                                     *Links            `json:"_links,omitempty"`
 	CreatorID                                 int               `json:"creator_id"`
 	Namespace                                 *ProjectNamespace `json:"namespace"`
 	Permissions                               *Permissions      `json:"permissions"`
@@ -156,6 +157,16 @@ type ForkParent struct {
 	Path              string `json:"path"`
 	PathWithNamespace string `json:"path_with_namespace"`
 	WebURL            string `json:"web_url"`
+}
+
+type Links struct {
+	Self          string `json:"self"`
+	Issues        string `json:"issues"`
+	MergeRequests string `json:"merge_requests"`
+	RepoBranches  string `json:"repo_branches"`
+	Labels        string `json:"labels"`
+	Events        string `json:"events"`
+	Members       string `json:"members"`
 }
 
 func (s Project) String() string {

--- a/projects.go
+++ b/projects.go
@@ -63,7 +63,6 @@ type Project struct {
 	ContainerRegistryEnabled                  bool              `json:"container_registry_enabled"`
 	CreatedAt                                 *time.Time        `json:"created_at,omitempty"`
 	LastActivityAt                            *time.Time        `json:"last_activity_at,omitempty"`
-	Links                                     *Links            `json:"_links,omitempty"`
 	CreatorID                                 int               `json:"creator_id"`
 	Namespace                                 *ProjectNamespace `json:"namespace"`
 	Permissions                               *Permissions      `json:"permissions"`
@@ -85,6 +84,7 @@ type Project struct {
 		GroupAccessLevel int    `json:"group_access_level"`
 	} `json:"shared_with_groups"`
 	Statistics *ProjectStatistics `json:"statistics"`
+	Links                                     *Links            `json:"_links,omitempty"`
 }
 
 // Repository represents a repository.
@@ -159,6 +159,7 @@ type ForkParent struct {
 	WebURL            string `json:"web_url"`
 }
 
+// Links represents a project web liks for self, issues, merge_requests, repo_branches, labels, events, members.
 type Links struct {
 	Self          string `json:"self"`
 	Issues        string `json:"issues"`


### PR DESCRIPTION
`_links` added projects API, below is the example for API response

`
 "_links": {
        "self": "http://gitlab.com/api/v4/projects/153",
        "issues": "http://gitlab.com/api/v4/projects/153/issues",
        "merge_requests": "http://gitlab.com/api/v4/projects/153/merge_requests",
        "repo_branches": "http://gitlab.com/api/v4/projects/153/repository/branches",
        "labels": "http://gitlab.com/api/v4/projects/153/labels",
        "events": "http://gitlab.com/api/v4/projects/153/events",
        "members": "http://gitlab.com/api/v4/projects/153/members"
    },
`