### PR TITLE
Add SnippetsService to Client

### DIFF
--- a/gitlab.go
+++ b/gitlab.go
@@ -223,6 +223,7 @@ type Client struct {
 	Services             *ServicesService
 	Session              *SessionService
 	Settings             *SettingsService
+	Snippets             *SnippetsService
 	SystemHooks          *SystemHooksService
 	Tags                 *TagsService
 	Todos                *TodosService
@@ -296,6 +297,7 @@ func newClient(httpClient *http.Client, tokenType tokenType, token string) *Clie
 	c.Services = &ServicesService{client: c}
 	c.Session = &SessionService{client: c}
 	c.Settings = &SettingsService{client: c}
+	c.Snippets = &SnippetsService{client: c}
 	c.SystemHooks = &SystemHooksService{client: c}
 	c.Tags = &TagsService{client: c}
 	c.Todos = &TodosService{client: c}


### PR DESCRIPTION
Following on to: https://github.com/xanzy/go-gitlab/pull/252

This MR exposes the SnippetsService on the client