### PR TITLE
add `organization`, `location` and `external` to user structs - fixes #256

### DIFF
--- a/users.go
+++ b/users.go
@@ -41,10 +41,12 @@ type User struct {
 	State            string          `json:"state"`
 	CreatedAt        *time.Time      `json:"created_at"`
 	Bio              string          `json:"bio"`
+	Location         string          `json:"location"`
 	Skype            string          `json:"skype"`
 	Linkedin         string          `json:"linkedin"`
 	Twitter          string          `json:"twitter"`
 	WebsiteURL       string          `json:"website_url"`
+	Organization     string          `json:"organization"`
 	ExternUID        string          `json:"extern_uid"`
 	Provider         string          `json:"provider"`
 	ThemeID          int             `json:"theme_id"`
@@ -58,6 +60,7 @@ type User struct {
 	LastSignInAt     *time.Time      `json:"last_sign_in_at"`
 	TwoFactorEnabled bool            `json:"two_factor_enabled"`
 	Identities       []*UserIdentity `json:"identities"`
+	External         bool            `json:"external"`
 }
 
 // UserIdentity represents a user identity
@@ -127,13 +130,16 @@ type CreateUserOptions struct {
 	Linkedin         *string `url:"linkedin,omitempty" json:"linkedin,omitempty"`
 	Twitter          *string `url:"twitter,omitempty" json:"twitter,omitempty"`
 	WebsiteURL       *string `url:"website_url,omitempty" json:"website_url,omitempty"`
+	Organization     *string `url:"organization,omitempty" json:"organization,omitempty"`
 	ProjectsLimit    *int    `url:"projects_limit,omitempty" json:"projects_limit,omitempty"`
 	ExternUID        *string `url:"extern_uid,omitempty" json:"extern_uid,omitempty"`
 	Provider         *string `url:"provider,omitempty" json:"provider,omitempty"`
 	Bio              *string `url:"bio,omitempty" json:"bio,omitempty"`
+	Location         *string `url:"location,omitempty" json:"location,omitempty"`
 	Admin            *bool   `url:"admin,omitempty" json:"admin,omitempty"`
 	CanCreateGroup   *bool   `url:"can_create_group,omitempty" json:"can_create_group,omitempty"`
 	SkipConfirmation *bool   `url:"skip_confirmation,omitempty" json:"skip_confirmation,omitempty"`
+	External         *bool   `url:"external,omitempty" json:"external,omitempty"`
 }
 
 // CreateUser creates a new user. Note only administrators can create new users.
@@ -166,12 +172,15 @@ type ModifyUserOptions struct {
 	Linkedin       *string `url:"linkedin,omitempty" json:"linkedin,omitempty"`
 	Twitter        *string `url:"twitter,omitempty" json:"twitter,omitempty"`
 	WebsiteURL     *string `url:"website_url,omitempty" json:"website_url,omitempty"`
+	Organization   *string `url:"organization,omitempty" json:"organization,omitempty"`
 	ProjectsLimit  *int    `url:"projects_limit,omitempty" json:"projects_limit,omitempty"`
 	ExternUID      *string `url:"extern_uid,omitempty" json:"extern_uid,omitempty"`
 	Provider       *string `url:"provider,omitempty" json:"provider,omitempty"`
 	Bio            *string `url:"bio,omitempty" json:"bio,omitempty"`
+	Location       *string `url:"location,omitempty" json:"location,omitempty"`
 	Admin          *bool   `url:"admin,omitempty" json:"admin,omitempty"`
 	CanCreateGroup *bool   `url:"can_create_group,omitempty" json:"can_create_group,omitempty"`
+	External       *bool   `url:"external,omitempty" json:"external,omitempty"`
 }
 
 // ModifyUser modifies an existing user. Only administrators can change attributes


### PR DESCRIPTION
This PR adds missing fields to user related structs:

* `Organization`
* `Location`
* `External`

see https://docs.gitlab.com/ce/api/users.html#user-creation for details