### PR TITLE
Fix panic when []OptionFunc contains nil

### DIFF
--- a/gitlab.go
+++ b/gitlab.go
@@ -356,6 +356,10 @@ func (c *Client) NewRequest(method, path string, opt interface{}, options []Opti
 	}
 
 	for _, fn := range options {
+		if fn == nil {
+			continue
+		}
+
 		if err := fn(req); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
From commit 42c4e6d:
```
NewRequest() can potentially be called with a
nil value present in []OptionFunc. For example
this code would trigger a panic prior to this
commit:

  _, _, err := git.Users.ModifyUser(event.UserId, options, nil)
```

Technically speaking the above is user error but I figured someone else could make the same mistake down the line. The correct way to call the above function and avoid the panic is:
```golang
  _, _, err := git.Users.ModifyUser(event.UserId, options)
```
