### PR TITLE
(mr,fix) changes_count is a string not int

### DIFF
--- a/merge_requests.go
+++ b/merge_requests.go
@@ -72,7 +72,7 @@ type MergeRequest struct {
 	SHA                       string     `json:"sha"`
 	MergeCommitShaSHA         string     `json:"merge_commit_sha"`
 	UserNotesCount            int        `json:"user_notes_count"`
-	ChangesCount              int        `json:"changes_count"`
+	ChangesCount              string     `json:"changes_count"`
 	SouldRemoveSourceBranch   bool       `json:"should_remove_source_branch"`
 	ForceRemoveSourceBranch   bool       `json:"force_remove_source_branch"`
 	WebURL                    string     `json:"web_url"`


### PR DESCRIPTION
Ref: https://docs.gitlab.com/ce/api/merge_requests.html#list-project-merge-requests

> Note: the changes_count value in the response is a string, not an integer. This is because when an MR has too many changes to display and store, it will be capped at 1,000. In that case, the API will return the string "1000+" for the changes count.