### PR TITLE
fix expected return code for block / unblock user

### DIFF
--- a/users.go
+++ b/users.go
@@ -407,7 +407,7 @@ func (s *UsersService) BlockUser(user int, options ...OptionFunc) error {
 	}
 
 	switch resp.StatusCode {
-	case 200:
+	case 201:
 		return nil
 	case 403:
 		return errors.New("Cannot block a user that is already blocked by LDAP synchronization")
@@ -435,7 +435,7 @@ func (s *UsersService) UnblockUser(user int, options ...OptionFunc) error {
 	}
 
 	switch resp.StatusCode {
-	case 200:
+	case 201:
 		return nil
 	case 403:
 		return errors.New("Cannot unblock a user that is blocked by LDAP synchronization")


### PR DESCRIPTION
According to the API documentation, a `201 OK` will be returned
upon success for the block / unblock user call.

See https://docs.gitlab.com/ce/api/users.html#block-user