### PR TITLE
 BREAKING: add support for `from` in `GetUserActivities`

### DIFF
--- a/commits.go
+++ b/commits.go
@@ -150,6 +150,7 @@ func (s *CommitsService) GetCommit(pid interface{}, sha string, options ...Optio
 type CreateCommitOptions struct {
 	Branch        *string         `url:"branch" json:"branch"`
 	CommitMessage *string         `url:"commit_message" json:"commit_message"`
+	StartBranch   *string         `url:"start_branch,omitempty" json:"start_branch,omitempty"`
 	Actions       []*CommitAction `url:"actions" json:"actions"`
 	AuthorEmail   *string         `url:"author_email,omitempty" json:"author_email,omitempty"`
 	AuthorName    *string         `url:"author_name,omitempty" json:"author_name,omitempty"`

--- a/namespaces.go
+++ b/namespaces.go
@@ -16,6 +16,10 @@
 
 package gitlab
 
+import (
+	"fmt"
+)
+
 // NamespacesService handles communication with the namespace related methods
 // of the GitLab API.
 //
@@ -33,7 +37,7 @@ type Namespace struct {
 	Path                        string `json:"path"`
 	Kind                        string `json:"kind"`
 	FullPath                    string `json:"full_path"`
-	ParentID                    int    `json:"parent_id"`
+	ParentID                    string `json:"parent_id"`
 	MembersCountWithDescendants int    `json:"members_count_with_descendants"`
 }
 
@@ -85,6 +89,31 @@ func (s *NamespacesService) SearchNamespace(query string, options ...OptionFunc)
 
 	var n []*Namespace
 	resp, err := s.client.Do(req, &n)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return n, resp, err
+}
+
+// GetNamespace gets a namespace by id.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/namespaces.html#get-namespace-by-id
+func (s *NamespacesService) GetNamespace(id interface{}, options ...OptionFunc) (*Namespace, *Response, error) {
+	namespace, err := parseID(id)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("namespaces/%s", namespace)
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	n := new(Namespace)
+	resp, err := s.client.Do(req, n)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/namespaces.go
+++ b/namespaces.go
@@ -28,9 +28,13 @@ type NamespacesService struct {
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/namespaces.html
 type Namespace struct {
-	ID   int    `json:"id"`
-	Path string `json:"path"`
-	Kind string `json:"kind"`
+	ID                          int    `json:"id"`
+	Name                        string `json:"name"`
+	Path                        string `json:"path"`
+	Kind                        string `json:"kind"`
+	FullPath                    string `json:"full_path"`
+	ParentID                    int    `json:"parent_id"`
+	MembersCountWithDescendants int    `json:"members_count_with_descendants"`
 }
 
 func (n Namespace) String() string {

--- a/users.go
+++ b/users.go
@@ -715,12 +715,20 @@ type UserActivity struct {
 	LastActivityOn *ISOTime `json:"last_activity_on"`
 }
 
+// GetUserActivitiesOptions represents the options for GetUserActivities
+//
+// GitLap API docs:
+// https://docs.gitlab.com/ce/api/users.html#get-user-activities-admin-only
+type GetUserActivitiesOptions struct {
+	From *ISOTime `url:"from,omitempty" json:"from,omitempty"`
+}
+
 // GetUserActivities retrieves user activities (admin only)
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/users.html#get-user-activities-admin-only
-func (s *UsersService) GetUserActivities(options ...OptionFunc) ([]*UserActivity, *Response, error) {
-	req, err := s.client.NewRequest("GET", "user/activities", nil, options)
+func (s *UsersService) GetUserActivities(opt *GetUserActivitiesOptions, options ...OptionFunc) ([]*UserActivity, *Response, error) {
+	req, err := s.client.NewRequest("GET", "user/activities", opt, options)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Adds support for the `from` parameter in the `GetUserActivities` method.

This is a breaking change, since the interface of `UsersService.GetUserActivities()` changes.

See https://docs.gitlab.com/ce/api/users.html#get-user-activities-admin-only

Based on #291 and #290 