### PR TITLE
Fixes #230: get users by username

### DIFF
--- a/users.go
+++ b/users.go
@@ -118,6 +118,39 @@ func (s *UsersService) GetUser(user int, options ...OptionFunc) (*User, *Respons
 	return usr, resp, err
 }
 
+// GetUsersAsAdminOptions represents the search options for GetUsersAsAdmin
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/users.html#for-admins
+type GetUsersAsAdminOptions struct {
+	Username     *string    `json:"username,omitempty" url:"username,omitempty"`
+	ExternalUID  *string    `json:"extern_uid,omitempty" url:"extern_uid,omitempty"`
+	Provider     *string    `json:"provider,omitempty" url:"provider,omitempty"`
+	External     *bool      `json:"external,omitempty" url:"external,omitempty"`
+	CratedBefore *time.Time `json:"created_before,omitempty" url:"created_before,omitempty"`
+	CreatedAfter *time.Time `json:"created_after,omitempty" url:"created_after,omitempty"`
+}
+
+// GetUsersAsAdmin looks up users by multiple search options
+// (for admins only)
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/users.html#for-admins
+func (s *UsersService) GetUsersAsAdmin(opt *GetUsersAsAdminOptions, options ...OptionFunc) ([]*User, *Response, error) {
+	req, err := s.client.NewRequest("GET", "users", opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var usr []*User
+	resp, err := s.client.Do(req, &usr)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return usr, resp, err
+}
+
 // CreateUserOptions represents the available CreateUser() options.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/users.html#user-creation


### PR DESCRIPTION
This PR fixes #230 

Not sure though, whether we could provide a more "generic" method that handles external users as well... on the other hand, adding `/users?extern_uid=:extern_uid&provider=:provider` and `/users?external=true` would be no big deal.