### PR TITLE
Snippet: add Explore API call

### DIFF
--- a/snippets.go
+++ b/snippets.go
@@ -49,6 +49,7 @@ type Snippet struct {
 	UpdatedAt *time.Time `json:"updated_at"`
 	CreatedAt *time.Time `json:"created_at"`
 	WebURL    string     `json:"web_url"`
+	RawURL    string     `json:"raw_url"`
 }
 
 func (s Snippet) String() string {

--- a/snippets.go
+++ b/snippets.go
@@ -204,3 +204,22 @@ func (s *SnippetsService) SnippetContent(snippet int, options ...OptionFunc) ([]
 
 	return b.Bytes(), resp, err
 }
+
+// Explore gets the list of public snippets.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/snippets.html#explore-all-public-snippets
+func (s *SnippetsService) Explore(opt *ListSnippetsOptions, options ...OptionFunc) ([]*Snippet, *Response, error) {
+	req, err := s.client.NewRequest("GET", "snippets/public", nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var ps []*Snippet
+	resp, err := s.client.Do(req, &ps)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return ps, resp, err
+}

--- a/snippets.go
+++ b/snippets.go
@@ -206,11 +206,18 @@ func (s *SnippetsService) SnippetContent(snippet int, options ...OptionFunc) ([]
 	return b.Bytes(), resp, err
 }
 
-// Explore gets the list of public snippets.
+// ExploreSnippetsOptions represents the available ExploreSnippets() options.
+//
+// https://docs.gitlab.com/ce/api/snippets.html#explore-all-public-snippets
+type ExploreSnippetsOptions struct {
+	ListOptions
+}
+
+// ExploreSnippets gets the list of public snippets.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/snippets.html#explore-all-public-snippets
-func (s *SnippetsService) Explore(opt *ListSnippetsOptions, options ...OptionFunc) ([]*Snippet, *Response, error) {
+func (s *SnippetsService) ExploreSnippets(opt *ExploreSnippetsOptions, options ...OptionFunc) ([]*Snippet, *Response, error) {
 	req, err := s.client.NewRequest("GET", "snippets/public", nil, options)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
Hey there, from what I saw, this API call is missing. 
See https://docs.gitlab.com/ce/api/snippets.html#explore-all-public-snippets

I've also added the `Snipper.RawURL` property.

Thanks for this lib!