### PR TITLE
changed NotificationLevel to pointers to support null values

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -138,13 +138,13 @@ type Permissions struct {
 // ProjectAccess represents project access.
 type ProjectAccess struct {
 	AccessLevel       AccessLevelValue       `json:"access_level"`
-	NotificationLevel NotificationLevelValue `json:"notification_level"`
+	NotificationLevel *NotificationLevelValue `json:"notification_level"`
 }
 
 // GroupAccess represents group access.
 type GroupAccess struct {
 	AccessLevel       AccessLevelValue       `json:"access_level"`
-	NotificationLevel NotificationLevelValue `json:"notification_level"`
+	NotificationLevel *NotificationLevelValue `json:"notification_level"`
 }
 
 // ForkParent represents the parent project when this is a fork.


### PR DESCRIPTION
Gitlab 10.4.1 sometimes return `null` values in NotificationLevel fields. changing it to a pointer allow to support it.