### PR TITLE
Added function to get all users from a specific project

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -88,8 +88,8 @@ type Project struct {
 	CIConfigPath *string            `json:"ci_config_path"`
 }
 
-// Project users represents a GitLab project.
-type ProjectUsers struct {
+// ProjectUser represents a GitLab project.
+type ProjectUser struct {
 	ID        int    `json:"id"`
 	Name      string `json:"name"`
 	Username  string `json:"username"`
@@ -250,8 +250,8 @@ func (s *ProjectsService) ListUserProjects(uid interface{}, opt *ListProjectsOpt
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/projects.html#get-project-users
-func (s *ProjectsService) ListProjectsUsers(uid interface{}, opt *ListProjectsOptions, options ...OptionFunc) ([]*ProjectUsers, *Response, error) {
-	project, err := parseID(uid)
+func (s *ProjectsService) ListProjectsUsers(pid interface{}, opt *ListProjectsOptions, options ...OptionFunc) ([]*ProjectUser, *Response, error) {
+	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -262,7 +262,7 @@ func (s *ProjectsService) ListProjectsUsers(uid interface{}, opt *ListProjectsOp
 		return nil, nil, err
 	}
 
-	var p []*ProjectUsers
+	var p []*ProjectUser
 	resp, err := s.client.Do(req, &p)
 	if err != nil {
 		return nil, resp, err

--- a/projects.go
+++ b/projects.go
@@ -88,6 +88,16 @@ type Project struct {
 	CIConfigPath *string            `json:"ci_config_path"`
 }
 
+// Project users represents a GitLab project.
+type ProjectUsers struct {
+	ID        int    `json:"id"`
+	Name      string `json:"name"`
+	Username  string `json:"username"`
+	State     string `json:"state"`
+	AvatarUrl string `json:"avatar_url"`
+	WebUrl    string `json:"web_url"`
+}
+
 // Repository represents a repository.
 type Repository struct {
 	Name              string          `json:"name"`
@@ -228,6 +238,31 @@ func (s *ProjectsService) ListUserProjects(uid interface{}, opt *ListProjectsOpt
 	}
 
 	var p []*Project
+	resp, err := s.client.Do(req, &p)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return p, resp, err
+}
+
+// ListProjectsUsers gets a list of users for the given project.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/projects.html#get-project-users
+func (s *ProjectsService) ListProjectsUsers(uid interface{}, opt *ListProjectsOptions, options ...OptionFunc) ([]*ProjectUsers, *Response, error) {
+	project, err := parseID(uid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/users", project)
+
+	req, err := s.client.NewRequest("GET", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var p []*ProjectUsers
 	resp, err := s.client.Do(req, &p)
 	if err != nil {
 		return nil, resp, err

--- a/projects.go
+++ b/projects.go
@@ -203,6 +203,14 @@ type ListProjectsOptions struct {
 	WithMergeRequestsEnabled *bool            `url:"with_merge_requests_enabled,omitempty" json:"with_merge_requests_enabled,omitempty"`
 }
 
+// ListProjectUserOptions represents the available ListProjects() options.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#get-project-users
+type ListProjectUserOptions struct {
+	ListOptions
+	Search                   *string          `url:"search,omitempty" json:"search,omitempty"`
+}
+
 // ListProjects gets a list of projects accessible by the authenticated user.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#list-projects
@@ -250,7 +258,7 @@ func (s *ProjectsService) ListUserProjects(uid interface{}, opt *ListProjectsOpt
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/projects.html#get-project-users
-func (s *ProjectsService) ListProjectsUsers(pid interface{}, opt *ListProjectsOptions, options ...OptionFunc) ([]*ProjectUser, *Response, error) {
+func (s *ProjectsService) ListProjectsUsers(pid interface{}, opt *ListProjectUserOptions, options ...OptionFunc) ([]*ProjectUser, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
I needed a command that's not in the project:

/projects/<ID>/users

So I created in same format as the others in projects.go.

I saw that some minor changes in others structures was sent too, but this ones are changes in space only, sorry for that, but I saw it only after send it to my fork.