### PR TITLE
Add Issue Links API

### DIFF
--- a/gitlab.go
+++ b/gitlab.go
@@ -210,6 +210,7 @@ type Client struct {
 	Groups               *GroupsService
 	GroupMembers         *GroupMembersService
 	Issues               *IssuesService
+	IssueLinks           *IssueLinksService
 	Jobs                 *JobsService
 	Labels               *LabelsService
 	MergeRequests        *MergeRequestsService
@@ -288,6 +289,7 @@ func newClient(httpClient *http.Client, tokenType tokenType, token string) *Clie
 	c.Groups = &GroupsService{client: c}
 	c.GroupMembers = &GroupMembersService{client: c}
 	c.Issues = &IssuesService{client: c, timeStats: timeStats}
+	c.IssueLinks = &IssueLinksService{client: c}
 	c.Jobs = &JobsService{client: c}
 	c.Labels = &LabelsService{client: c}
 	c.MergeRequests = &MergeRequestsService{client: c, timeStats: timeStats}

--- a/issue_links.go
+++ b/issue_links.go
@@ -1,0 +1,122 @@
+//
+// Copyright 2017, Arkbriar
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package gitlab
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// IssueLinksService handles communication with the issue relations related methods
+// of the GitLab API.
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/issue_links.html
+type IssueLinksService struct {
+	client *Client
+}
+
+type IssueLink struct {
+	SourceIssue *Issue `json:"source_issue"`
+	TargetIssue *Issue `json:"target_issue"`
+}
+
+// ListIssueRelations gets a list of related issues of a given issue,
+// sorted by the relationship creation datetime (ascending).
+//
+// Issues will be filtered according to the user authorizations.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/issue_links.html#list-issue-relations
+func (s *IssueLinksService) ListIssueRelations(pid interface{}, issueIID int, options ...OptionFunc) ([]*Issue, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/issues/%d/links", url.QueryEscape(project), issueIID)
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var is []*Issue
+	resp, err := s.client.Do(req, &is)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return is, resp, err
+}
+
+type CreateIssueLinkOptions struct {
+	TargetProjectID *string `json:"target_project_id"`
+	TargetIssueIID  *string `json:"target_issue_iid"`
+}
+
+// CreateIssueLink creates a two-way relation between two issues.
+// User must be allowed to update both issues in order to succeed.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/issue_links.html#create-an-issue-link
+func (s *IssueLinksService) CreateIssueLink(pid interface{}, issueIID int, opt *CreateIssueLinkOptions, options ...OptionFunc) (*IssueLink, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/issues/%d/links", url.QueryEscape(project), issueIID)
+
+	req, err := s.client.NewRequest("POST", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	i := new(IssueLink)
+	resp, err := s.client.Do(req, &i)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return i, resp, err
+}
+
+// DeleteIssueLink deletes an issue link, thus removes the two-way relationship.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/issue_links.html#delete-an-issue-link
+func (s *IssueLinksService) DeleteIssueLink(pid interface{}, issueIID, issueLinkID int, options ...OptionFunc) (*IssueLink, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/issues/%d/links/%d",
+		url.QueryEscape(project),
+		issueIID,
+		issueLinkID)
+
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	i := new(IssueLink)
+	resp, err := s.client.Do(req, &i)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return i, resp, err
+}

--- a/issues.go
+++ b/issues.go
@@ -59,6 +59,16 @@ type Issue struct {
 		State     string     `json:"state"`
 		CreatedAt *time.Time `json:"created_at"`
 	} `json:"assignees"`
+	Assignee struct {
+		ID        int    `json:"id"`
+		Name      string `json:"name"`
+		Username  string `json:"username"`
+		State     string `json:"state"`
+		AvatarURL string `json:"avatar_url"`
+		WebURL    string `json:"web_url"`
+	} `json:"assignee"`
+	Upvotes          int        `json:"upvotes"`
+	Downvotes        int        `json:"downvotes"`
 	Labels           []string   `json:"labels"`
 	Title            string     `json:"title"`
 	UpdatedAt        *time.Time `json:"updated_at"`
@@ -70,7 +80,15 @@ type Issue struct {
 	WebURL           string     `json:"web_url"`
 	TimeStats        *TimeStats `json:"time_stats"`
 	Confidential     bool       `json:"confidential"`
+	Weight           int        `json:"weight"`
 	DiscussionLocked bool       `json:"discussion_locked"`
+	Links            struct {
+		Self       string `json:"self"`
+		Notes      string `json:"notes"`
+		AwardEmoji string `json:"award_emoji"`
+		Project    string `json:"project"`
+	} `json:"_links"`
+	IssueLinkID int `json:"issue_link_id"`
 }
 
 func (i Issue) String() string {


### PR DESCRIPTION
I'm not too sure about the `IssueLinksResult` struct name, if you have better I would gladly change it.

When you look at the documentation, it's outdated... When I actually do the calls on my side there are a lot more properties inside the response.

That's why `IssueLinks` has more fields than the documentation.

Fixes : #315 