### PR TITLE
Add go 1.9.x to travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,4 @@ language: go
 go:
   - 1.7.x
   - 1.8.x
+  - 1.9.x


### PR DESCRIPTION
I'm using 1.9.x at home, maybe you would like to support that version too?