### PR TITLE
Fix Namespace struct

### DIFF
--- a/namespaces.go
+++ b/namespaces.go
@@ -37,7 +37,7 @@ type Namespace struct {
 	Path                        string `json:"path"`
 	Kind                        string `json:"kind"`
 	FullPath                    string `json:"full_path"`
-	ParentID                    string `json:"parent_id"`
+	ParentID                    int    `json:"parent_id"`
 	MembersCountWithDescendants int    `json:"members_count_with_descendants"`
 }
 


### PR DESCRIPTION
Currently execution of `Client.Namespaces.GetNamespace()` is failing with:

```
json: cannot unmarshal number into Go struct field Namespace.parent_id of type string
```

It's that because `parent_id` is sent as JSON integer, not string. This PR updates `Namespace` struct to reflect this.

