### PR TITLE
Make ListTagsOptions work correctly with ListOptions

### DIFF
--- a/tags.go
+++ b/tags.go
@@ -49,7 +49,7 @@ func (t Tag) String() string {
 // ListTagsOptions represents the available ListTags() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/branches.html#list-repository-tags
+// https://docs.gitlab.com/ce/api/tags.html#list-project-repository-tags
 type ListTagsOptions ListOptions
 
 // ListTags gets a list of tags from a project, sorted by name in reverse

--- a/tags_test.go
+++ b/tags_test.go
@@ -1,0 +1,30 @@
+package gitlab
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestListTags(t *testing.T) {
+	mux, server, client := setup()
+	defer teardown(server)
+
+	mux.HandleFunc("/projects/1/repository/tags", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `[{"name": "1.0.0"},{"name": "1.0.1"}]`)
+	})
+
+	opt := &ListTagsOptions{Page: 2, PerPage: 3}
+
+	tags, _, err := client.Tags.ListTags(1, opt)
+	if err != nil {
+		t.Errorf("Tags.ListTags returned error: %v", err)
+	}
+
+	want := []*Tag{{Name: "1.0.0"}, {Name: "1.0.1"}}
+	if !reflect.DeepEqual(want, tags) {
+		t.Errorf("Tags.ListTags returned %+v, want %+v", tags, want)
+	}
+}


### PR DESCRIPTION
The ListTagsOptions was not defined correctly with an invalid documentation reference. Fixed this and added a test suite for tags (like the product test)