### PR TITLE
Add missing last_activity_on value for a user

### DIFF
--- a/gitlab.go
+++ b/gitlab.go
@@ -117,6 +117,11 @@ func (t *ISOTime) UnmarshalJSON(data []byte) error {
 	return err
 }
 
+// String implements the Stringer interface
+func (t ISOTime) String() string {
+	return time.Time(t).Format(iso8601)
+}
+
 // NotificationLevelValue represents a notification level.
 type NotificationLevelValue int
 

--- a/users.go
+++ b/users.go
@@ -50,6 +50,7 @@ type User struct {
 	ExternUID        string          `json:"extern_uid"`
 	Provider         string          `json:"provider"`
 	ThemeID          int             `json:"theme_id"`
+	LastActivityOn   *ISOTime        `json:"last_activity_on"`
 	ColorSchemeID    int             `json:"color_scheme_id"`
 	IsAdmin          bool            `json:"is_admin"`
 	AvatarURL        string          `json:"avatar_url"`


### PR DESCRIPTION
The user object is missing the "last_activity_on" field that is available for admins and when requesting the CurrentUser().

The documentation, https://gitlab.com/help/api/users.md#for-normal-users-1, shows that it has the format "YYYY-MM-DD" which time.Time doesn't appear to handle by default so I had to add a new type and marshal functions for it.   I had a quick fix to get something working that just used a string, but I think it is probably better handled this way.