### PR TITLE
Fix typo

### DIFF
--- a/pages_domains.go
+++ b/pages_domains.go
@@ -33,7 +33,7 @@ type PagesDomain struct {
 // ListPagesDomainsOptions represents the available ListPagesDomains() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/pages_domais.html#list-pages-domains
+// https://docs.gitlab.com/ce/api/pages_domains.html#list-pages-domains
 type ListPagesDomainsOptions ListOptions
 
 // ListPagesDomains gets a list of project pages domains.

--- a/validate.go
+++ b/validate.go
@@ -16,7 +16,7 @@ type LintResult struct {
 	Errors []string `json:"errors"`
 }
 
-// Lint validates .gitlab-ci content.
+// Lint validates .gitlab-ci.yml content.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/lint.html
 func (s *ValidateService) Lint(content string, options ...OptionFunc) (*LintResult, *Response, error) {


### PR DESCRIPTION
**Note:** The GitLab API links in [build_variables.go](https://github.com/xanzy/go-gitlab/blob/4c7442d86102f147b5e934ad68bffd14ca56d790/build_variables.go#L11) are still left broken because Project-level Variables and Group-level Variables in [README.md](go-gitlab/README.md) are marked as undone.