### PR TITLE
Add ListOptions for paging GetCommitStatuses

### DIFF
--- a/commits.go
+++ b/commits.go
@@ -329,6 +329,7 @@ func (s *CommitsService) PostCommitComment(pid interface{}, sha string, opt *Pos
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/commits.html#get-the-status-of-a-commit
 type GetCommitStatusesOptions struct {
+	ListOptions
 	Ref   *string `url:"ref,omitempty" json:"ref,omitempty"`
 	Stage *string `url:"stage,omitempty" json:"stage,omitempty"`
 	Name  *string `url:"name,omitempty" json:"name,omitempty"`

--- a/commits_test.go
+++ b/commits_test.go
@@ -16,7 +16,7 @@ func TestGetCommitStatuses(t *testing.T) {
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
 
-	opt := &GetCommitStatusesOptions{String("master"), String("test"), String("ci/jenkins"), Bool(true)}
+	opt := &GetCommitStatusesOptions{Ref: String("master"), Stage: String("test"), Name: String("ci/jenkins"), All: Bool(true)}
 	statuses, _, err := client.Commits.GetCommitStatuses("1", "b0b3a907f41409829b307a28b82fdbd552ee5a27", opt)
 
 	if err != nil {
@@ -38,7 +38,7 @@ func TestSetCommitStatus(t *testing.T) {
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
-	opt := &SetCommitStatusOptions{Running, String("master"), String("ci/jenkins"), String(""), String("http://abc"), String("build")}
+	opt := &SetCommitStatusOptions{State: Running, Ref: String("master"), Name: String("ci/jenkins"), Context: String(""), TargetURL: String("http://abc"), Description: String("build")}
 	status, _, err := client.Commits.SetCommitStatus("1", "b0b3a907f41409829b307a28b82fdbd552ee5a27", opt)
 
 	if err != nil {


### PR DESCRIPTION
The commit status API is paginated, but `ListOptions` were not included in `GetCommitStatusesOptions`