### PR TITLE
Add group milestones methods

### DIFF
--- a/gitlab.go
+++ b/gitlab.go
@@ -280,6 +280,7 @@ type Client struct {
 	GitIgnoreTemplates   *GitIgnoreTemplatesService
 	Groups               *GroupsService
 	GroupMembers         *GroupMembersService
+	GroupMilestones      *GroupMilestonesService
 	Issues               *IssuesService
 	IssueLinks           *IssueLinksService
 	Jobs                 *JobsService
@@ -368,6 +369,7 @@ func newClient(httpClient *http.Client, tokenType tokenType, token string) *Clie
 	c.GitIgnoreTemplates = &GitIgnoreTemplatesService{client: c}
 	c.Groups = &GroupsService{client: c}
 	c.GroupMembers = &GroupMembersService{client: c}
+	c.GroupMilestones = &GroupMilestonesService{client: c}
 	c.Issues = &IssuesService{client: c, timeStats: timeStats}
 	c.IssueLinks = &IssueLinksService{client: c}
 	c.Jobs = &JobsService{client: c}

--- a/group_milestones.go
+++ b/group_milestones.go
@@ -1,0 +1,250 @@
+//
+// Copyright 2018, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package gitlab
+
+import (
+	"fmt"
+	"net/url"
+	"time"
+)
+
+// GroupMilestonesService handles communication with the milestone related
+// methods of the GitLab API.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/group_milestones.html
+type GroupMilestonesService struct {
+	client *Client
+}
+
+// GroupMilestone represents a GitLab milestone.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/group_milestones.html
+type GroupMilestone struct {
+	ID          int        `json:"id"`
+	IID         int        `json:"iid"`
+	GroupID     int        `json:"group_id"`
+	Title       string     `json:"title"`
+	Description string     `json:"description"`
+	StartDate   *ISOTime   `json:"start_date"`
+	DueDate     *ISOTime   `json:"due_date"`
+	State       string     `json:"state"`
+	UpdatedAt   *time.Time `json:"updated_at"`
+	CreatedAt   *time.Time `json:"created_at"`
+}
+
+func (m GroupMilestone) String() string {
+	return Stringify(m)
+}
+
+// ListGroupMilestonesOptions represents the available
+// ListGroupMilestones() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/group_milestones.html#list-group-milestones
+type ListGroupMilestonesOptions struct {
+	ListOptions
+	IIDs   []int  `url:"iids,omitempty" json:"iids,omitempty"`
+	State  string `url:"state,omitempty" json:"state,omitempty"`
+	Search string `url:"search,omitempty" json:"search,omitempty"`
+}
+
+// ListGroupMilestones returns a list of group milestones.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/group_milestones.html#list-group-milestones
+func (s *GroupMilestonesService) ListGroupMilestones(gid interface{}, opt *ListGroupMilestonesOptions, options ...OptionFunc) ([]*GroupMilestone, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/milestones", url.QueryEscape(group))
+
+	req, err := s.client.NewRequest("GET", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var m []*GroupMilestone
+	resp, err := s.client.Do(req, &m)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return m, resp, err
+}
+
+// GetGroupMilestone gets a single group milestone.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/group_milestones.html#get-single-milestone
+func (s *GroupMilestonesService) GetGroupMilestone(gid interface{}, milestone int, options ...OptionFunc) (*GroupMilestone, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/milestones/%d", url.QueryEscape(group), milestone)
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	m := new(GroupMilestone)
+	resp, err := s.client.Do(req, m)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return m, resp, err
+}
+
+// CreateGroupMilestoneOptions represents the available CreateGroupMilestone() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/group_milestones.html#create-new-milestone
+type CreateGroupMilestoneOptions struct {
+	Title       *string  `url:"title,omitempty" json:"title,omitempty"`
+	Description *string  `url:"description,omitempty" json:"description,omitempty"`
+	StartDate   *ISOTime `url:"start_date,omitempty" json:"start_date,omitempty"`
+	DueDate     *ISOTime `url:"due_date,omitempty" json:"due_date,omitempty"`
+}
+
+// CreateGroupMilestone creates a new group milestone.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/group_milestones.html#create-new-milestone
+func (s *GroupMilestonesService) CreateGroupMilestone(gid interface{}, opt *CreateGroupMilestoneOptions, options ...OptionFunc) (*GroupMilestone, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/milestones", url.QueryEscape(group))
+
+	req, err := s.client.NewRequest("POST", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	m := new(GroupMilestone)
+	resp, err := s.client.Do(req, m)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return m, resp, err
+}
+
+// UpdateGroupMilestoneOptions represents the available UpdateGroupMilestone() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/group_milestones.html#edit-milestone
+type UpdateGroupMilestoneOptions struct {
+	Title       *string  `url:"title,omitempty" json:"title,omitempty"`
+	Description *string  `url:"description,omitempty" json:"description,omitempty"`
+	StartDate   *ISOTime `url:"start_date,omitempty" json:"start_date,omitempty"`
+	DueDate     *ISOTime `url:"due_date,omitempty" json:"due_date,omitempty"`
+	StateEvent  *string  `url:"state_event,omitempty" json:"state_event,omitempty"`
+}
+
+// UpdateGroupMilestone updates an existing group milestone.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/group_milestones.html#edit-milestone
+func (s *GroupMilestonesService) UpdateGroupMilestone(gid interface{}, milestone int, opt *UpdateGroupMilestoneOptions, options ...OptionFunc) (*GroupMilestone, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/milestones/%d", url.QueryEscape(group), milestone)
+
+	req, err := s.client.NewRequest("PUT", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	m := new(GroupMilestone)
+	resp, err := s.client.Do(req, m)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return m, resp, err
+}
+
+// GetGroupMilestoneIssuesOptions represents the available GetGroupMilestoneIssues() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/group_milestones.html#get-all-issues-assigned-to-a-single-milestone
+type GetGroupMilestoneIssuesOptions ListOptions
+
+// GetGroupMilestoneIssues gets all issues assigned to a single group milestone.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/group_milestones.html#get-all-issues-assigned-to-a-single-milestone
+func (s *GroupMilestonesService) GetGroupMilestoneIssues(gid interface{}, milestone int, opt *GetGroupMilestoneIssuesOptions, options ...OptionFunc) ([]*Issue, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/milestones/%d/issues", url.QueryEscape(group), milestone)
+
+	req, err := s.client.NewRequest("GET", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var i []*Issue
+	resp, err := s.client.Do(req, &i)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return i, resp, err
+}
+
+// GetGroupMilestoneMergeRequestsOptions represents the available
+// GetGroupMilestoneMergeRequests() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/group_milestones.html#get-all-merge-requests-assigned-to-a-single-milestone
+type GetGroupMilestoneMergeRequestsOptions ListOptions
+
+// GetGroupMilestoneMergeRequests gets all merge requests assigned to a
+// single group milestone.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/group_milestones.html#get-all-merge-requests-assigned-to-a-single-milestone
+func (s *GroupMilestonesService) GetGroupMilestoneMergeRequests(gid interface{}, milestone int, opt *GetGroupMilestoneMergeRequestsOptions, options ...OptionFunc) ([]*MergeRequest, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/milestones/%d/merge_requests", url.QueryEscape(group), milestone)
+
+	req, err := s.client.NewRequest("GET", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var mr []*MergeRequest
+	resp, err := s.client.Do(req, &mr)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return mr, resp, err
+}

--- a/milestones.go
+++ b/milestones.go
@@ -39,8 +39,8 @@ type Milestone struct {
 	ProjectID   int        `json:"project_id"`
 	Title       string     `json:"title"`
 	Description string     `json:"description"`
-	StartDate   string     `json:"start_date"`
-	DueDate     string     `json:"due_date"`
+	StartDate   *ISOTime   `json:"start_date"`
+	DueDate     *ISOTime   `json:"due_date"`
 	State       string     `json:"state"`
 	UpdatedAt   *time.Time `json:"updated_at"`
 	CreatedAt   *time.Time `json:"created_at"`
@@ -56,7 +56,9 @@ func (m Milestone) String() string {
 // https://docs.gitlab.com/ce/api/milestones.html#list-project-milestones
 type ListMilestonesOptions struct {
 	ListOptions
-	IIDs []int `url:"iids,omitempty" json:"iids,omitempty"`
+	IIDs   []int  `url:"iids,omitempty" json:"iids,omitempty"`
+	State  string `url:"state,omitempty" json:"state,omitempty"`
+	Search string `url:"search,omitempty" json:"search,omitempty"`
 }
 
 // ListMilestones returns a list of project milestones.
@@ -114,10 +116,10 @@ func (s *MilestonesService) GetMilestone(pid interface{}, milestone int, options
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/milestones.html#create-new-milestone
 type CreateMilestoneOptions struct {
-	Title       *string `url:"title,omitempty" json:"title,omitempty"`
-	Description *string `url:"description,omitempty" json:"description,omitempty"`
-	StartDate   *string `url:"start_date,omitempty" json:"start_date,omitempty"`
-	DueDate     *string `url:"due_date,omitempty" json:"due_date,omitempty"`
+	Title       *string  `url:"title,omitempty" json:"title,omitempty"`
+	Description *string  `url:"description,omitempty" json:"description,omitempty"`
+	StartDate   *ISOTime `url:"start_date,omitempty" json:"start_date,omitempty"`
+	DueDate     *ISOTime `url:"due_date,omitempty" json:"due_date,omitempty"`
 }
 
 // CreateMilestone creates a new project milestone.
@@ -150,11 +152,11 @@ func (s *MilestonesService) CreateMilestone(pid interface{}, opt *CreateMileston
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/milestones.html#edit-milestone
 type UpdateMilestoneOptions struct {
-	Title       *string `url:"title,omitempty" json:"title,omitempty"`
-	Description *string `url:"description,omitempty" json:"description,omitempty"`
-	StartDate   *string `url:"start_date,omitempty" json:"start_date,omitempty"`
-	DueDate     *string `url:"due_date,omitempty" json:"due_date,omitempty"`
-	StateEvent  *string `url:"state_event,omitempty" json:"state_event,omitempty"`
+	Title       *string  `url:"title,omitempty" json:"title,omitempty"`
+	Description *string  `url:"description,omitempty" json:"description,omitempty"`
+	StartDate   *ISOTime `url:"start_date,omitempty" json:"start_date,omitempty"`
+	DueDate     *ISOTime `url:"due_date,omitempty" json:"due_date,omitempty"`
+	StateEvent  *string  `url:"state_event,omitempty" json:"state_event,omitempty"`
 }
 
 // UpdateMilestone updates an existing project milestone.


### PR DESCRIPTION
This is built on top of #368. Tested against gitlab.com:

```go
package main

import (
	"fmt"

	"github.com/xanzy/go-gitlab"
)

const token = "REDACTED"

func main() {
	c := gitlab.NewClient(nil, token)

	// gitlab-org
	groupID := "9970"
	// 11.0
	milestoneID := 362887

	fmt.Println(c.GroupMilestones.ListGroupMilestones(groupID, nil))
	fmt.Println(c.GroupMilestones.GetGroupMilestone(groupID, milestoneID, nil))
	fmt.Println(c.GroupMilestones.GetGroupMilestoneIssues(groupID, milestoneID, nil))
	fmt.Println(c.GroupMilestones.GetGroupMilestoneMergeRequests(groupID, milestoneID, nil))
}
```

Fixes #367 