### PR TITLE
Add unshare project from group

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -648,7 +648,7 @@ func (s *ProjectsService) ShareProjectWithGroup(pid interface{}, opt *ShareWithG
 
 // UnshareProjectFromGroup allows to unshare a project from a group.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/projects.html#delete-a-shared-project-link-within-a-group
+// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#delete-a-shared-project-link-within-a-group
 func (s *ProjectsService) UnshareProjectFromGroup(pid interface{}, groupID int, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/projects.go
+++ b/projects.go
@@ -646,10 +646,10 @@ func (s *ProjectsService) ShareProjectWithGroup(pid interface{}, opt *ShareWithG
 	return s.client.Do(req, nil)
 }
 
-// UnshareProjectFromGroup allows to unshare a project from a group.
+// DeleteSharedProjectFromGroup allows to unshare a project from a group.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#delete-a-shared-project-link-within-a-group
-func (s *ProjectsService) UnshareProjectFromGroup(pid interface{}, groupID int, options ...OptionFunc) (*Response, error) {
+func (s *ProjectsService) DeleteSharedProjectFromGroup(pid interface{}, groupID int, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, err

--- a/projects.go
+++ b/projects.go
@@ -646,6 +646,24 @@ func (s *ProjectsService) ShareProjectWithGroup(pid interface{}, opt *ShareWithG
 	return s.client.Do(req, nil)
 }
 
+// UnshareProjectFromGroup allows to unshare a project from a group.
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/projects.html#delete-a-shared-project-link-within-a-group
+func (s *ProjectsService) UnshareProjectFromGroup(pid interface{}, groupID int, options ...OptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/share/%d", url.QueryEscape(project), groupID)
+
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
 // ProjectMember represents a project member.
 //
 // GitLab API docs:

--- a/projects_test.go
+++ b/projects_test.go
@@ -338,7 +338,7 @@ func TestShareProjectWithGroup(t *testing.T) {
 	}
 }
 
-func TestUnshareProjectFromGroup(t *testing.T) {
+func TestDeleteSharedProjectFromGroup(t *testing.T) {
 	mux, server, client := setup()
 	defer teardown(server)
 
@@ -346,8 +346,8 @@ func TestUnshareProjectFromGroup(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Projects.UnshareProjectFromGroup(1, 2)
+	_, err := client.Projects.DeleteSharedProjectFromGroup(1, 2)
 	if err != nil {
-		t.Errorf("Projects.UnshareProjectFromGroup returned error: %v", err)
+		t.Errorf("Projects.DeleteSharedProjectFromGroup returned error: %v", err)
 	}
 }

--- a/projects_test.go
+++ b/projects_test.go
@@ -318,3 +318,36 @@ func TestListProjectForks(t *testing.T) {
 		t.Errorf("Projects.ListProjects returned %+v, want %+v", projects, want)
 	}
 }
+
+func TestShareProjectWithGroup(t *testing.T) {
+	mux, server, client := setup()
+	defer teardown(server)
+
+	mux.HandleFunc("/projects/1/share", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+	})
+
+	opt := &ShareWithGroupOptions{
+		GroupID:     Int(1),
+		GroupAccess: AccessLevel(AccessLevelValue(50)),
+	}
+
+	_, err := client.Projects.ShareProjectWithGroup(1, opt)
+	if err != nil {
+		t.Errorf("Projects.ShareProjectWithGroup returned error: %v", err)
+	}
+}
+
+func TestUnshareProjectFromGroup(t *testing.T) {
+	mux, server, client := setup()
+	defer teardown(server)
+
+	mux.HandleFunc("/projects/1/share/2", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+	})
+
+	_, err := client.Projects.UnshareProjectFromGroup(1, 2)
+	if err != nil {
+		t.Errorf("Projects.UnshareProjectFromGroup returned error: %v", err)
+	}
+}


### PR DESCRIPTION
Add possibility to stop sharing a project with a group as described in [Gitlab API Doc](https://docs.gitlab.com/ee/api/projects.html#delete-a-shared-project-link-within-a-group).