### PR TITLE
Auto update libraryVersion when creating releases/tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: go
 
+# use containers which run faster and have cache
+sudo: false
+
 go:
   - 1.8.x
   - 1.9.x
@@ -9,10 +12,13 @@ go:
 stages:
   - lint
   - test
+  - name: deploy
+    if: tag IS present
 
 jobs:
   include:
     - stage: lint
+      go: 1.10.x
       script:
         - go get github.com/golang/lint/golint
         - golint
@@ -20,6 +26,18 @@ jobs:
     - stage: test
       script:
         - go test -v
+    - stage: deploy
+      go: 1.10.x
+      script:
+        - sed -i "s|libraryVersion =.\+$|libraryVersion = \"$(echo ${TRAVIS_TAG} | tr -d 'v')\"|" gitlab.go
+        - git config --global user.email "travis@travis-ci.org"
+        - git config --global user.name "Travis CI"
+        - git remote add origin-https https://${GITHUB_TOKEN}@github.com/xanzy/go-gitlab.git
+        - git fetch origin-https
+        - git checkout master
+        - git add gitlab.go
+        - git commit -m "(libraryVersion) ${TRAVIS_TAG}"
+        - git push origin-https master
 
 matrix:
   allow_failures:


### PR DESCRIPTION
If you'd like, this is is travis job that will auto update the `libraryVersion`
variable when you publish tags/releases on github.

You'll need to setup a secure environment variable with travis:
https://docs.travis-ci.com/user/environment-variables/#Defining-encrypted-variables-in-.travis.yml

You can see a sample run of this job here: https://travis-ci.org/zaquestion/go-gitlab/jobs/374748652
Note: the push fails because env vars are actually tied to the repo (I learned)
and I tried to copy the one I use for lab