### PR TITLE
Update ListUsersOptions: add missing parameters

### DIFF
--- a/users.go
+++ b/users.go
@@ -82,7 +82,9 @@ type ListUsersOptions struct {
 	Search        *string    `url:"search,omitempty" json:"search,omitempty"`
 	Username      *string    `url:"username,omitempty" json:"username,omitempty"`
 	ExternalUID   *string    `url:"extern_uid,omitempty" json:"extern_uid,omitempty"`
+	Provider      *string    `url:"provider,omitempty" json:"provider,omitempty"`
 	CreatedBefore *time.Time `url:"created_before,omitempty" json:"created_before,omitempty" `
+	CreatedAfter  *time.Time `url:"created_after,omitempty" json:"created_after,omitempty" `
 }
 
 // ListUsers gets a list of users.

--- a/users.go
+++ b/users.go
@@ -83,8 +83,10 @@ type ListUsersOptions struct {
 	Username      *string    `url:"username,omitempty" json:"username,omitempty"`
 	ExternalUID   *string    `url:"extern_uid,omitempty" json:"extern_uid,omitempty"`
 	Provider      *string    `url:"provider,omitempty" json:"provider,omitempty"`
-	CreatedBefore *time.Time `url:"created_before,omitempty" json:"created_before,omitempty" `
-	CreatedAfter  *time.Time `url:"created_after,omitempty" json:"created_after,omitempty" `
+	CreatedBefore *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
+	CreatedAfter  *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
+	OrderBy       *string    `url:"order_by,omitempty" json:"order_by,omitempty"`
+	Sort          *string    `url:"sort,omitempty" json:"sort,omitempty"`
 }
 
 // ListUsers gets a list of users.


### PR DESCRIPTION
Hi there!

I'd like to add 4 options for listing users ([docs](https://docs.gitlab.com/ce/api/users.html#for-admins)) which seem to be missing:
- `provider`: which makes `extern_uid` unusable since they need to be used together
- `created_after`
- `order_by`
- `sort`

Thanks!
