### PR TITLE
Add the Path filter and All option to the ListCommits API

### DIFF
--- a/commits.go
+++ b/commits.go
@@ -71,6 +71,7 @@ type ListCommitsOptions struct {
 	RefName *string   `url:"ref_name,omitempty" json:"ref_name,omitempty"`
 	Since   time.Time `url:"since,omitempty" json:"since,omitempty"`
 	Until   time.Time `url:"until,omitempty" json:"until,omitempty"`
+	Path    *string   `url:"path,omitempty" json:"path,omitempty"`
 }
 
 // ListCommits gets a list of repository commits in a project.

--- a/commits.go
+++ b/commits.go
@@ -72,6 +72,7 @@ type ListCommitsOptions struct {
 	Since   time.Time `url:"since,omitempty" json:"since,omitempty"`
 	Until   time.Time `url:"until,omitempty" json:"until,omitempty"`
 	Path    *string   `url:"path,omitempty" json:"path,omitempty"`
+	All     bool     `url:"all,omitempty" json:"all,omitempty"`
 }
 
 // ListCommits gets a list of repository commits in a project.


### PR DESCRIPTION
This supports restricting listed commits to a given tree in the repository.

GitLab ref: https://docs.gitlab.com/ce/api/commits.html#list-repository-commits