### PR TITLE
Create a basic client with username/password

### DIFF
--- a/examples/basic_auth.go
+++ b/examples/basic_auth.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"log"
+
+	"github.com/xanzy/go-gitlab"
+)
+
+// This example shows how to create a client with username and password.
+func basicAuthExample() {
+	git, err := gitlab.NewBasicAuthClient(nil, "https://gitlab.company.com", "svanharmelen", "password")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// List all projects
+	projects, _, err := git.Projects.ListProjects(nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Printf("Found %d projects", len(projects))
+}

--- a/gitlab.go
+++ b/gitlab.go
@@ -35,9 +35,8 @@ import (
 )
 
 const (
-	libraryVersion = "0.2.0"
 	defaultBaseURL = "https://gitlab.com/api/v4/"
-	userAgent      = "go-gitlab/" + libraryVersion
+	userAgent      = "go-gitlab"
 )
 
 // authType represents an authentication type within GitLab.


### PR DESCRIPTION
This client will retrieve an oAuth token using: https://docs.gitlab.com/ce/api/oauth2.html#1-requesting-access-token (fixes #385).

It also removes the `libraryVersion` (closes #387). 