### PR TITLE
Handle tokens with no expiration

### DIFF
--- a/gitlab.go
+++ b/gitlab.go
@@ -357,6 +357,9 @@ func NewBasicAuthClient(httpClient *http.Client, endpoint, username, password st
 		for {
 			client.token = t.AccessToken
 
+			if t.ExpiresIn == 0 {
+				return // Token does not expire
+			}
 			if t.ExpiresIn > 60 {
 				t.ExpiresIn -= 60
 			}


### PR DESCRIPTION
My GitLab instance returns tokens with no expiration. Without this check, the package spams GitLab with requests for new tokens.