### PR TITLE
Add missing options in ListIssues and related APIs

### DIFF
--- a/issues.go
+++ b/issues.go
@@ -108,17 +108,17 @@ func (l *Labels) MarshalJSON() ([]byte, error) {
 // GitLab API docs: https://docs.gitlab.com/ce/api/issues.html#list-issues
 type ListIssuesOptions struct {
 	ListOptions
-	State           *string `url:"state,omitempty" json:"state,omitempty"`
-	Labels          Labels  `url:"labels,comma,omitempty" json:"labels,omitempty"`
-	Milestone       *string `url:"milestone,omitempty" json:"milestone,omitempty"`
-	Scope           *string `url:"scope,omitempty" json:"scope,omitempty"`
-	AuthorID        *int    `url:"author_id,omitempty" json:"author_id,omitempty"`
-	AssigneeID      *int    `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
-	MyReactionEmoji *string `url:"my_reaction_emoji,omitempty" json:"my_reaction_emoji,omitempty"`
-	IIDs            []int   `url:"iids[],omitempty" json:"iids,omitempty"`
-	OrderBy         *string `url:"order_by,omitempty" json:"order_by,omitempty"`
-	Sort            *string `url:"sort,omitempty" json:"sort,omitempty"`
-	Search          *string `url:"search,omitempty" json:"search,omitempty"`
+	State           *string    `url:"state,omitempty" json:"state,omitempty"`
+	Labels          Labels     `url:"labels,comma,omitempty" json:"labels,omitempty"`
+	Milestone       *string    `url:"milestone,omitempty" json:"milestone,omitempty"`
+	Scope           *string    `url:"scope,omitempty" json:"scope,omitempty"`
+	AuthorID        *int       `url:"author_id,omitempty" json:"author_id,omitempty"`
+	AssigneeID      *int       `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
+	MyReactionEmoji *string    `url:"my_reaction_emoji,omitempty" json:"my_reaction_emoji,omitempty"`
+	IIDs            []int      `url:"iids[],omitempty" json:"iids,omitempty"`
+	OrderBy         *string    `url:"order_by,omitempty" json:"order_by,omitempty"`
+	Sort            *string    `url:"sort,omitempty" json:"sort,omitempty"`
+	Search          *string    `url:"search,omitempty" json:"search,omitempty"`
 	CreatedAfter    *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
 	CreatedBefore   *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
 	UpdatedAfter    *time.Time `url:"updated_after,omitempty" json:"updated_after,omitempty"`
@@ -149,17 +149,17 @@ func (s *IssuesService) ListIssues(opt *ListIssuesOptions, options ...OptionFunc
 // GitLab API docs: https://docs.gitlab.com/ce/api/issues.html#list-group-issues
 type ListGroupIssuesOptions struct {
 	ListOptions
-	State           *string `url:"state,omitempty" json:"state,omitempty"`
-	Labels          Labels  `url:"labels,comma,omitempty" json:"labels,omitempty"`
-	IIDs            []int   `url:"iids[],omitempty" json:"iids,omitempty"`
-	Milestone       *string `url:"milestone,omitempty" json:"milestone,omitempty"`
-	Scope           *string `url:"scope,omitempty" json:"scope,omitempty"`
-	AuthorID        *int    `url:"author_id,omitempty" json:"author_id,omitempty"`
-	AssigneeID      *int    `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
-	MyReactionEmoji *string `url:"my_reaction_emoji,omitempty" json:"my_reaction_emoji,omitempty"`
-	OrderBy         *string `url:"order_by,omitempty" json:"order_by,omitempty"`
-	Sort            *string `url:"sort,omitempty" json:"sort,omitempty"`
-	Search          *string `url:"search,omitempty" json:"search,omitempty"`
+	State           *string    `url:"state,omitempty" json:"state,omitempty"`
+	Labels          Labels     `url:"labels,comma,omitempty" json:"labels,omitempty"`
+	IIDs            []int      `url:"iids[],omitempty" json:"iids,omitempty"`
+	Milestone       *string    `url:"milestone,omitempty" json:"milestone,omitempty"`
+	Scope           *string    `url:"scope,omitempty" json:"scope,omitempty"`
+	AuthorID        *int       `url:"author_id,omitempty" json:"author_id,omitempty"`
+	AssigneeID      *int       `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
+	MyReactionEmoji *string    `url:"my_reaction_emoji,omitempty" json:"my_reaction_emoji,omitempty"`
+	OrderBy         *string    `url:"order_by,omitempty" json:"order_by,omitempty"`
+	Sort            *string    `url:"sort,omitempty" json:"sort,omitempty"`
+	Search          *string    `url:"search,omitempty" json:"search,omitempty"`
 	CreatedAfter    *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
 	CreatedBefore   *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
 	UpdatedAfter    *time.Time `url:"updated_after,omitempty" json:"updated_after,omitempty"`

--- a/issues.go
+++ b/issues.go
@@ -119,6 +119,10 @@ type ListIssuesOptions struct {
 	OrderBy         *string `url:"order_by,omitempty" json:"order_by,omitempty"`
 	Sort            *string `url:"sort,omitempty" json:"sort,omitempty"`
 	Search          *string `url:"search,omitempty" json:"search,omitempty"`
+	CreatedAfter    *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
+	CreatedBefore   *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
+	UpdatedAfter    *time.Time `url:"updated_after,omitempty" json:"updated_after,omitempty"`
+	UpdatedBefore   *time.Time `url:"updated_before,omitempty" json:"updated_before,omitempty"`
 }
 
 // ListIssues gets all issues created by authenticated user. This function
@@ -156,6 +160,10 @@ type ListGroupIssuesOptions struct {
 	OrderBy         *string `url:"order_by,omitempty" json:"order_by,omitempty"`
 	Sort            *string `url:"sort,omitempty" json:"sort,omitempty"`
 	Search          *string `url:"search,omitempty" json:"search,omitempty"`
+	CreatedAfter    *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
+	CreatedBefore   *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
+	UpdatedAfter    *time.Time `url:"updated_after,omitempty" json:"updated_after,omitempty"`
+	UpdatedBefore   *time.Time `url:"updated_before,omitempty" json:"updated_before,omitempty"`
 }
 
 // ListGroupIssues gets a list of group issues. This function accepts
@@ -201,6 +209,8 @@ type ListProjectIssuesOptions struct {
 	Search          *string    `url:"search,omitempty" json:"search,omitempty"`
 	CreatedAfter    *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
 	CreatedBefore   *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
+	UpdatedAfter    *time.Time `url:"updated_after,omitempty" json:"updated_after,omitempty"`
+	UpdatedBefore   *time.Time `url:"updated_before,omitempty" json:"updated_before,omitempty"`
 }
 
 // ListProjectIssues gets a list of project issues. This function accepts


### PR DESCRIPTION
I have added several fields because they seem supported in API according to the document.

* `ListIssuesOptions` struct
    * added field: `CreatedAfter`, `CreatedBefore`, `UpdatedAfter`, `UpdatedBefore`
    * [document](https://docs.gitlab.com/ce/api/issues.html#list-issues)
* `ListGroupIssuesOptions` struct
    * added field: `CreatedAfter`, `CreatedBefore`, `UpdatedAfter`, `UpdatedBefore`
    * [document](https://docs.gitlab.com/ce/api/issues.html#list-group-issues)
* `ListProjectIssuesOptions` struct
    * added field: `UpdatedAfter`, `UpdatedBefore`
        * `CreatedAfter` and `CreatedBefore` have been already implemented
    * [document](https://docs.gitlab.com/ce/api/issues.html#list-project-issues)

I checked the behavior by using simple code like the following.

```
package main

import (
	"fmt"
	"time"

	"github.com/ntoofu/go-gitlab"
)

func main() {
	client := gitlab.NewClient(nil, "<YOUR_TOKEN>")
	client.SetBaseURL("https://gitlab.com/api/v4")
	t2 := time.Now()
	t1 := t2.Add(time.Hour * -24)
	// var issueOpt gitlab.ListIssuesOptions
	var issueOpt gitlab.ListProjectIssuesOptions
	issueOpt.UpdatedAfter = &t1
	issueOpt.UpdatedBefore = &t2
	// gitlabIssues, _, err := client.Issues.ListIssues(&issueOpt)
	gitlabIssues, _, err := client.Issues.ListProjectIssues("gitlab-org/release/tasks", &issueOpt)
	if err != nil {
		fmt.Printf("error: %v", err)
	} else {
		for _, issue := range gitlabIssues {
			fmt.Printf("#%d: %s (%s)\n", issue.IID, issue.Title, issue.UpdatedAt)
		}
	}
}
```