### PR TITLE
Adds NewSelfHostedClient helper function 

### DIFF
--- a/gitlab.go
+++ b/gitlab.go
@@ -342,6 +342,31 @@ func NewClient(httpClient *http.Client, token string) *Client {
 	return client
 }
 
+// NewSelfHostedClient returns a new GitLab API client with provided baseURL.
+// If baseURL does not have a trailing slash, one is added automatically.
+// If a nil httpClient is provided, http.DefaultClient will be used.
+// To use API methods which require authentication, provide a valid private
+// or personal token.
+//
+// Note that NewSelfHostedClient is a convenience helper only;
+// its behavior is equivalent to using NewClient, followed by setting
+// the baseURL field.
+func NewSelfHostedClient(httpClient *http.Client, token, baseURL string) (*Client, error) {
+	baseEndpoint, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, err
+	}
+	if !strings.HasSuffix(baseEndpoint.Path, "/") {
+		baseEndpoint.Path += "/"
+	}
+	baseEndpoint.Path += "api/v4"
+	client := NewClient(httpClient, token)
+	if err := client.SetBaseURL(baseEndpoint.String()); err != nil {
+		return nil, err
+	}
+	return client, nil
+}
+
 // NewBasicAuthClient returns a new GitLab API client. If a nil httpClient is
 // provided, http.DefaultClient will be used. To use API methods which require
 // authentication, provide a valid username and password.

--- a/gitlab_test.go
+++ b/gitlab_test.go
@@ -54,6 +54,17 @@ func TestNewClient(t *testing.T) {
 	}
 }
 
+func TestNewSelfHostedClient(t *testing.T) {
+	expectedBaseURL := "http://gitlab.local/api/v4/"
+	c, err := NewSelfHostedClient(nil, "", "http://gitlab.local")
+	if err != nil {
+		t.Fatalf("Failed to create NewSelfHostedClient: %v", err)
+	}
+	if c.BaseURL().String() != expectedBaseURL {
+		t.Errorf("NewSelfHostedClient BaseURL is %s, want %s", c.BaseURL().String(), expectedBaseURL)
+	}
+}
+
 func TestCheckResponse(t *testing.T) {
 	req, err := NewClient(nil, "").NewRequest("GET", "test", nil, nil)
 	if err != nil {


### PR DESCRIPTION
This helper function is created so that a new token based client can be created with a self hosted base url supplied.

Hoping that it will be used in https://github.com/jenkins-x/jx