### PR TITLE
Makes SetBaseURL more robust by matching on apiVersionPath suffix and…

### DIFF
--- a/gitlab.go
+++ b/gitlab.go
@@ -36,7 +36,8 @@ import (
 )
 
 const (
-	defaultBaseURL = "https://gitlab.com/api/v4/"
+	defaultBaseURL = "https://gitlab.com/"
+	apiVersionPath = "api/v4/"
 	userAgent      = "go-gitlab"
 )
 
@@ -350,7 +351,7 @@ func NewBasicAuthClient(httpClient *http.Client, endpoint, username, password st
 	client.authType = basicAuth
 	client.username = username
 	client.password = password
-	client.SetBaseURL(endpoint + "/api/v4")
+	client.SetBaseURL(endpoint)
 
 	err := client.requestOAuthToken(context.TODO())
 	if err != nil {
@@ -473,8 +474,8 @@ func (c *Client) SetBaseURL(urlStr string) error {
 		return err
 	}
 
-	if baseURL.Path == "/" {
-		baseURL.Path = "api/v4/"
+	if !strings.HasSuffix(baseURL.Path, apiVersionPath) {
+		baseURL.Path += apiVersionPath
 	}
 
 	// Update the base URL of the client.

--- a/gitlab_test.go
+++ b/gitlab_test.go
@@ -45,12 +45,25 @@ func testMethod(t *testing.T, r *http.Request, want string) {
 
 func TestNewClient(t *testing.T) {
 	c := NewClient(nil, "")
+	expectedBaseURL := defaultBaseURL + apiVersionPath
 
-	if c.BaseURL().String() != defaultBaseURL {
-		t.Errorf("NewClient BaseURL is %s, want %s", c.BaseURL().String(), defaultBaseURL)
+	if c.BaseURL().String() != expectedBaseURL {
+		t.Errorf("NewClient BaseURL is %s, want %s", c.BaseURL().String(), expectedBaseURL)
 	}
 	if c.UserAgent != userAgent {
 		t.Errorf("NewClient UserAgent is %s, want %s", c.UserAgent, userAgent)
+	}
+}
+
+func TestSetBaseURL(t *testing.T) {
+	expectedBaseURL := "http://gitlab.local/foo/" + apiVersionPath
+	c := NewClient(nil, "")
+	err := c.SetBaseURL("http://gitlab.local/foo")
+	if err != nil {
+		t.Fatalf("Failed to SetBaseURL: %v", err)
+	}
+	if c.BaseURL().String() != expectedBaseURL {
+		t.Errorf("BaseURL is %s, want %s", c.BaseURL().String(), expectedBaseURL)
 	}
 }
 


### PR DESCRIPTION
… adds unit test

Can I suggest matching on apiVersionPath instead of / ?