### PR TITLE
Add SkipReconfirmation field for ModifyUserOptions

### DIFF
--- a/users.go
+++ b/users.go
@@ -174,23 +174,24 @@ func (s *UsersService) CreateUser(opt *CreateUserOptions, options ...OptionFunc)
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/users.html#user-modification
 type ModifyUserOptions struct {
-	Email          *string `url:"email,omitempty" json:"email,omitempty"`
-	Password       *string `url:"password,omitempty" json:"password,omitempty"`
-	Username       *string `url:"username,omitempty" json:"username,omitempty"`
-	Name           *string `url:"name,omitempty" json:"name,omitempty"`
-	Skype          *string `url:"skype,omitempty" json:"skype,omitempty"`
-	Linkedin       *string `url:"linkedin,omitempty" json:"linkedin,omitempty"`
-	Twitter        *string `url:"twitter,omitempty" json:"twitter,omitempty"`
-	WebsiteURL     *string `url:"website_url,omitempty" json:"website_url,omitempty"`
-	Organization   *string `url:"organization,omitempty" json:"organization,omitempty"`
-	ProjectsLimit  *int    `url:"projects_limit,omitempty" json:"projects_limit,omitempty"`
-	ExternUID      *string `url:"extern_uid,omitempty" json:"extern_uid,omitempty"`
-	Provider       *string `url:"provider,omitempty" json:"provider,omitempty"`
-	Bio            *string `url:"bio,omitempty" json:"bio,omitempty"`
-	Location       *string `url:"location,omitempty" json:"location,omitempty"`
-	Admin          *bool   `url:"admin,omitempty" json:"admin,omitempty"`
-	CanCreateGroup *bool   `url:"can_create_group,omitempty" json:"can_create_group,omitempty"`
-	External       *bool   `url:"external,omitempty" json:"external,omitempty"`
+	Email              *string `url:"email,omitempty" json:"email,omitempty"`
+	Password           *string `url:"password,omitempty" json:"password,omitempty"`
+	Username           *string `url:"username,omitempty" json:"username,omitempty"`
+	Name               *string `url:"name,omitempty" json:"name,omitempty"`
+	Skype              *string `url:"skype,omitempty" json:"skype,omitempty"`
+	Linkedin           *string `url:"linkedin,omitempty" json:"linkedin,omitempty"`
+	Twitter            *string `url:"twitter,omitempty" json:"twitter,omitempty"`
+	WebsiteURL         *string `url:"website_url,omitempty" json:"website_url,omitempty"`
+	Organization       *string `url:"organization,omitempty" json:"organization,omitempty"`
+	ProjectsLimit      *int    `url:"projects_limit,omitempty" json:"projects_limit,omitempty"`
+	ExternUID          *string `url:"extern_uid,omitempty" json:"extern_uid,omitempty"`
+	Provider           *string `url:"provider,omitempty" json:"provider,omitempty"`
+	Bio                *string `url:"bio,omitempty" json:"bio,omitempty"`
+	Location           *string `url:"location,omitempty" json:"location,omitempty"`
+	Admin              *bool   `url:"admin,omitempty" json:"admin,omitempty"`
+	CanCreateGroup     *bool   `url:"can_create_group,omitempty" json:"can_create_group,omitempty"`
+	SkipReconfirmation *bool   `url:"skip_reconfirmation,omitempty" json:"skip_reconfirmation,omitempty"`
+	External           *bool   `url:"external,omitempty" json:"external,omitempty"`
 }
 
 // ModifyUser modifies an existing user. Only administrators can change attributes


### PR DESCRIPTION
The latest documentation for user modification has a `skip_reconfirmation` field.

Reference: https://docs.gitlab.com/ce/api/users.html#user-modification
