### PR TITLE
Remove the OrderByValue type

### DIFF
--- a/deployments.go
+++ b/deployments.go
@@ -68,8 +68,8 @@ type Deployment struct {
 // https://docs.gitlab.com/ce/api/deployments.html#list-project-deployments
 type ListProjectDeploymentsOptions struct {
 	ListOptions
-	OrderBy *OrderByValue `url:"order_by,omitempty" json:"order_by,omitempty"`
-	Sort    *string       `url:"sort,omitempty" json:"sort,omitempty"`
+	OrderBy *string `url:"order_by,omitempty" json:"order_by,omitempty"`
+	Sort    *string `url:"sort,omitempty" json:"sort,omitempty"`
 }
 
 // ListProjectDeployments gets a list of deployments in a project.

--- a/examples/pipelines.go
+++ b/examples/pipelines.go
@@ -17,7 +17,7 @@ func pipelineExample() {
 		YamlErrors: gitlab.Bool(true),
 		Name:       gitlab.String("name"),
 		Username:   gitlab.String("username"),
-		OrderBy:    gitlab.OrderBy(gitlab.OrderByStatus),
+		OrderBy:    gitlab.String("status"),
 		Sort:       gitlab.String("asc"),
 	}
 

--- a/gitlab.go
+++ b/gitlab.go
@@ -186,19 +186,6 @@ var notificationLevelTypes = map[string]NotificationLevelValue{
 	"custom":        CustomNotificationLevel,
 }
 
-// OrderByValue represent in which order to sort the item
-type OrderByValue string
-
-// These constants represent all valid order by values.
-const (
-	OrderByCreatedAt OrderByValue = "created_at"
-	OrderByID        OrderByValue = "id"
-	OrderByIID       OrderByValue = "iid"
-	OrderByRef       OrderByValue = "ref"
-	OrderByStatus    OrderByValue = "status"
-	OrderByUserID    OrderByValue = "user_id"
-)
-
 // VisibilityValue represents a visibility level within GitLab.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/
@@ -828,14 +815,6 @@ func BuildState(v BuildStateValue) *BuildStateValue {
 // to store v and returns a pointer to it.
 func NotificationLevel(v NotificationLevelValue) *NotificationLevelValue {
 	p := new(NotificationLevelValue)
-	*p = v
-	return p
-}
-
-// OrderBy is a helper routine that allocates a new OrderByValue
-// to store v and returns a pointer to it.
-func OrderBy(v OrderByValue) *OrderByValue {
-	p := new(OrderByValue)
 	*p = v
 	return p
 }

--- a/pipelines.go
+++ b/pipelines.go
@@ -87,7 +87,7 @@ type ListProjectPipelinesOptions struct {
 	YamlErrors *bool            `url:"yaml_errors,omitempty" json:"yaml_errors,omitempty"`
 	Name       *string          `url:"name,omitempty" json:"name,omitempty"`
 	Username   *string          `url:"username,omitempty" json:"username,omitempty"`
-	OrderBy    *OrderByValue    `url:"order_by,omitempty" json:"order_by,omitempty"`
+	OrderBy    *string          `url:"order_by,omitempty" json:"order_by,omitempty"`
 	Sort       *string          `url:"sort,omitempty" json:"sort,omitempty"`
 }
 


### PR DESCRIPTION
It turns out that every API that allows you to sort, uses its own allowed values. So having a type for it doesn't really make sense and could be confusing for users of this package.