### PR TITLE
Implement DownloadSingleArtifactsFile

### DIFF
--- a/jobs.go
+++ b/jobs.go
@@ -212,7 +212,7 @@ func (s *JobsService) DownloadSingleArtifactsFile(pid interface{}, jobID int, ar
 
 	u := fmt.Sprintf(
 		"projects/%s/jobs/%d/artifacts/%s",
-		url.PathEscape(project),
+		url.QueryEscape(project),
 		jobID
 		url.PathEscape(artifactPath),
 	)

--- a/jobs.go
+++ b/jobs.go
@@ -213,7 +213,7 @@ func (s *JobsService) DownloadSingleArtifactsFile(pid interface{}, jobID int, ar
 	u := fmt.Sprintf(
 		"projects/%s/jobs/%d/artifacts/%s",
 		url.QueryEscape(project),
-		jobID
+		jobID,
 		artifactPath,
 	)
 

--- a/jobs.go
+++ b/jobs.go
@@ -214,7 +214,7 @@ func (s *JobsService) DownloadSingleArtifactsFile(pid interface{}, jobID int, ar
 		"projects/%s/jobs/%d/artifacts/%s",
 		url.QueryEscape(project),
 		jobID
-		url.PathEscape(artifactPath),
+		artifactPath,
 	)
 
 	req, err := s.client.NewRequest("GET", u, nil, options)

--- a/jobs.go
+++ b/jobs.go
@@ -199,10 +199,11 @@ func (s *JobsService) DownloadArtifactsFile(pid interface{}, refName string, job
 
 // DownloadSingleArtifactsFile download a file from the artifacts from the
 // given reference name and job provided the job finished successfully.
-// Only a single file is going to be extracted from the archive and streamed to a client.
+// Only a single file is going to be extracted from the archive and streamed
+// to a client.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/jobs.html#download-the-artifacts-file
+// https://docs.gitlab.com/ce/api/jobs.html#download-a-single-artifact-file
 func (s *JobsService) DownloadSingleArtifactsFile(pid interface{}, jid interface{}, artifactPath string, options ...OptionFunc) (io.Reader, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/jobs.go
+++ b/jobs.go
@@ -203,7 +203,7 @@ func (s *JobsService) DownloadArtifactsFile(pid interface{}, refName string, job
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/jobs.html#download-the-artifacts-file
-func (s *JobsService) DownloadSingleArtifactsFile(pid interface{}, jid interface{}, artifact_path string, options ...OptionFunc) (io.Reader, *Response, error) {
+func (s *JobsService) DownloadSingleArtifactsFile(pid interface{}, jid interface{}, artifactPath string, options ...OptionFunc) (io.Reader, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
@@ -218,7 +218,7 @@ func (s *JobsService) DownloadSingleArtifactsFile(pid interface{}, jid interface
 		"projects/%s/jobs/%s/artifacts/%s",
 		url.PathEscape(project),
 		url.PathEscape(job),
-		url.PathEscape(artifact_path),
+		url.PathEscape(artifactPath),
 	)
 
 	req, err := s.client.NewRequest("GET", u, nil, options)

--- a/jobs.go
+++ b/jobs.go
@@ -197,6 +197,44 @@ func (s *JobsService) DownloadArtifactsFile(pid interface{}, refName string, job
 	return artifactsBuf, resp, err
 }
 
+// DownloadSingleArtifactsFile download a file from the artifacts from the
+// given reference name and job provided the job finished successfully.
+// Only a single file is going to be extracted from the archive and streamed to a client.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/jobs.html#download-the-artifacts-file
+func (s *JobsService) DownloadSingleArtifactsFile(pid interface{}, jid interface{}, artifact_path string, options ...OptionFunc) (io.Reader, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	job, err := parseID(jid)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	u := fmt.Sprintf(
+		"projects/%s/jobs/%s/artifacts/%s",
+		url.PathEscape(project),
+		url.PathEscape(job),
+		url.PathEscape(artifact_path),
+	)
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	artifactBuf := new(bytes.Buffer)
+	resp, err := s.client.Do(req, artifactBuf)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return artifactBuf, resp, err
+}
+
 // GetTraceFile gets a trace of a specific job of a project
 //
 // GitLab API docs:

--- a/jobs.go
+++ b/jobs.go
@@ -204,21 +204,16 @@ func (s *JobsService) DownloadArtifactsFile(pid interface{}, refName string, job
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/jobs.html#download-a-single-artifact-file
-func (s *JobsService) DownloadSingleArtifactsFile(pid interface{}, jid interface{}, artifactPath string, options ...OptionFunc) (io.Reader, *Response, error) {
+func (s *JobsService) DownloadSingleArtifactsFile(pid interface{}, jobID int, artifactPath string, options ...OptionFunc) (io.Reader, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	job, err := parseID(jid)
-	if err != nil {
-		return nil, nil, err
-	}
-
 	u := fmt.Sprintf(
-		"projects/%s/jobs/%s/artifacts/%s",
+		"projects/%s/jobs/%d/artifacts/%s",
 		url.PathEscape(project),
-		url.PathEscape(job),
+		jobID
 		url.PathEscape(artifactPath),
 	)
 


### PR DESCRIPTION
I've missed the possibility to download a single file from a jobs artifacts archive, as I need it in another tool.

P.S.: I've checked the `DownloadArtifactsFile` while implementing this and I think that all variables should be escaped before building the url. Also `project` is currently escaped using `url.QueryEscape`, but as it is part of the url path `url.PathEscape` should be used.
```
u := fmt.Sprintf(
  "projects/%s/jobs/artifacts/%s/download?job=%s",
  url.PathEscape(project),
  url.PathEscape(refName),
  url.QueryEscape(job),
)
```