### PR TITLE
 Add GetProjectLanguages to get languages from a project 

### DIFF
--- a/examples/languages.go
+++ b/examples/languages.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"log"
+
+	"github.com/topochan/go-gitlab"
+)
+
+func main() {
+	git := gitlab.NewClient(nil, "yourtokengoeshere")
+	git.SetBaseURL("https://gitlab.com/api/v4")
+
+	languages, _, err := git.Projects.GetProjectLanguages("2743054")
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("Found languages: %v", languages)
+}

--- a/examples/languages.go
+++ b/examples/languages.go
@@ -6,7 +6,7 @@ import (
 	"github.com/topochan/go-gitlab"
 )
 
-func main() {
+func languagesExample() {
 	git := gitlab.NewClient(nil, "yourtokengoeshere")
 	git.SetBaseURL("https://gitlab.com/api/v4")
 

--- a/projects.go
+++ b/projects.go
@@ -282,6 +282,35 @@ func (s *ProjectsService) ListProjectsUsers(pid interface{}, opt *ListProjectUse
 	return p, resp, err
 }
 
+// ProjectLanguages is a map of strings because the response is arbitrary
+// Gitlab API docs with example: https://docs.gitlab.com/ce/api/projects.html#languages
+type ProjectLanguages map[string]interface{}
+
+// GetProjectLanguages gets a list of languages of the project ID
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/projects.html#languages
+func (s *ProjectsService) GetProjectLanguages(pid interface{}, options ...OptionFunc) (*ProjectLanguages, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/languages", url.QueryEscape(project))
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	p := new(ProjectLanguages)
+	resp, err := s.client.Do(req, p)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return p, resp, err
+}
+
 // GetProject gets a specific project, identified by project ID or
 // NAMESPACE/PROJECT_NAME, which is owned by the authenticated user.
 //

--- a/projects.go
+++ b/projects.go
@@ -283,13 +283,13 @@ func (s *ProjectsService) ListProjectsUsers(pid interface{}, opt *ListProjectUse
 }
 
 // ProjectLanguages is a map of strings because the response is arbitrary
-// Gitlab API docs with example: https://docs.gitlab.com/ce/api/projects.html#languages
-type ProjectLanguages map[string]interface{}
-
-// GetProjectLanguages gets a list of languages of the project ID
 //
-// GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#languages
+// Gitlab API docs: https://docs.gitlab.com/ce/api/projects.html#languages
+type ProjectLanguages map[string]float32
+
+// GetProjectLanguages gets a list of languages used by the project
+//
+// GitLab API docs:  https://docs.gitlab.com/ce/api/projects.html#languages
 func (s *ProjectsService) GetProjectLanguages(pid interface{}, options ...OptionFunc) (*ProjectLanguages, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {


### PR DESCRIPTION
Implements the languages project API https://docs.gitlab.com/ce/api/projects.html#languages

Small detail: 
* Defines ProjectLanguages as map of string interfaces because the response is not structured and will have a list of languages with percentage.

* Includes an example 