### PR TITLE
Add Discussions API implementation

### DIFF
--- a/discussions.go
+++ b/discussions.go
@@ -19,7 +19,6 @@ package gitlab
 import (
 	"fmt"
 	"net/url"
-	"time"
 )
 
 // DiscussionsService handles communication with the discussions related methods
@@ -34,41 +33,9 @@ type DiscussionsService struct {
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/discussions.html
 type Discussion struct {
-	ID         int    `json:"id"`
-	Body       string `json:"body"`
-	Attachment string `json:"attachment"`
-	Type       string `json:"type,omitempty"`
-	Title      string `json:"title"`
-	FileName   string `json:"file_name"`
-	Author     struct {
-		ID        int        `json:"id"`
-		Username  string     `json:"username"`
-		Email     string     `json:"email"`
-		Name      string     `json:"name"`
-		State     string     `json:"state"`
-		CreatedAt *time.Time `json:"created_at"`
-		AvatarURL string     `json:"avatar_url"`
-		WebURL    string     `json:"web_url"`
-	} `json:"author"`
-	System       bool       `json:"system"`
-	ExpiresAt    *time.Time `json:"expires_at"`
-	UpdatedAt    *time.Time `json:"updated_at"`
-	CreatedAt    *time.Time `json:"created_at"`
-	NoteableID   int        `json:"noteable_id"`
-	NoteableType string     `json:"noteable_type"`
-	Resolvable   bool       `json:"resolvable"`
-	Resolved     bool       `json:"resolved"`
-	ResolvedBy   struct {
-		ID        int        `json:"id"`
-		Username  string     `json:"username"`
-		Email     string     `json:"email"`
-		Name      string     `json:"name"`
-		State     string     `json:"state"`
-		CreatedAt *time.Time `json:"created_at"`
-		AvatarURL string     `json:"avatar_url"`
-		WebURL    string     `json:"web_url"`
-	} `json:"resolved_by"`
-	NoteableIID int `json:"noteable_iid"`
+	ID             string `json:"id"`
+	IndividualNote bool   `json:"individual_note"`
+	Notes          []Note `json:"notes"`
 }
 
 func (n Discussion) String() string {

--- a/discussions.go
+++ b/discussions.go
@@ -19,6 +19,7 @@ package gitlab
 import (
 	"fmt"
 	"net/url"
+	"time"
 )
 
 // DiscussionsService handles communication with the discussions related methods
@@ -393,7 +394,9 @@ func (s *DiscussionsService) GetMergeRequestDiscussion(pid interface{}, mergeReq
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/discussions.html#create-new-merge-request-discussion
 type CreateMergeRequestDiscussionOptions struct {
-	Body *string `url:"body,omitempty" json:"body,omitempty"`
+	Body      *string      `url:"body,omitempty" json:"body,omitempty"`
+	CreatedAt time.Time    `url:"created_at,omitempty"`
+	Position  NotePosition `json:"position,omitempty"`
 }
 
 // CreateMergeRequestDiscussion creates a new discussion for a single merge request.

--- a/discussions.go
+++ b/discussions.go
@@ -43,8 +43,8 @@ func (d Discussion) String() string {
 	return Stringify(d)
 }
 
-// ListProjectIssueDiscussionsOptions represents the available ListIssueDiscussions()
-// options.
+// ListProjectIssueDiscussionsOptions represents the available
+// ListIssueDiscussions() options.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/discussions.html#list-project-issue-discussions
@@ -158,7 +158,8 @@ func (s *DiscussionsService) AddIssueDiscussionNote(pid interface{}, issue int, 
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/issues/%d/discussions/%s/notes", url.QueryEscape(project), issue, discussion)
+	u := fmt.Sprintf("projects/%s/issues/%d/discussions/%s/notes", url.QueryEscape(project), issue,
+		discussion)
 
 	req, err := s.client.NewRequest("POST", u, opt, options)
 	if err != nil {
@@ -174,8 +175,8 @@ func (s *DiscussionsService) AddIssueDiscussionNote(pid interface{}, issue int, 
 	return d, resp, err
 }
 
-// UpdateIssueDiscussionNoteOptions represents the available UpdateIssueDiscussion()
-// options.
+// UpdateIssueDiscussionNoteOptions represents the available
+// UpdateIssueDiscussion() options.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/discussions.html#modify-existing-issue-discussion-note
@@ -192,7 +193,8 @@ func (s *DiscussionsService) UpdateIssueDiscussionNote(pid interface{}, issue in
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/issues/%d/discussions/%s/notes/%d", url.QueryEscape(project), issue, discussion, note)
+	u := fmt.Sprintf("projects/%s/issues/%d/discussions/%s/notes/%d", url.QueryEscape(project),
+		issue, discussion, note)
 
 	req, err := s.client.NewRequest("PUT", u, opt, options)
 	if err != nil {
@@ -210,13 +212,15 @@ func (s *DiscussionsService) UpdateIssueDiscussionNote(pid interface{}, issue in
 
 // DeleteIssueDiscussionNote deletes an existing discussion of an issue.
 //
+// GitLab API docs:
 // https://docs.gitlab.com/ce/api/discussions.html#delete-an-issue-discussion-note
 func (s *DiscussionsService) DeleteIssueDiscussionNote(pid interface{}, issue int, discussion string, note int, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/issues/%d/discussions/%s/notes/%d", url.QueryEscape(project), issue, discussion, note)
+	u := fmt.Sprintf("projects/%s/issues/%d/discussions/%s/notes/%d", url.QueryEscape(project),
+		issue, discussion, note)
 
 	req, err := s.client.NewRequest("DELETE", u, nil, options)
 	if err != nil {
@@ -268,7 +272,8 @@ func (s *DiscussionsService) GetSnippetDiscussion(pid interface{}, snippet int, 
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/snippets/%d/discussions/%s", url.QueryEscape(project), snippet, discussion)
+	u := fmt.Sprintf("projects/%s/snippets/%d/discussions/%s", url.QueryEscape(project), snippet,
+		discussion)
 
 	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
@@ -284,8 +289,8 @@ func (s *DiscussionsService) GetSnippetDiscussion(pid interface{}, snippet int, 
 	return d, resp, err
 }
 
-// CreateSnippetDiscussionOptions represents the available CreateSnippetDiscussion()
-// options.
+// CreateSnippetDiscussionOptions represents the available
+// CreateSnippetDiscussion() options.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/discussions.html#create-new-snippet-discussion
@@ -294,8 +299,8 @@ type CreateSnippetDiscussionOptions struct {
 	CreatedAt *time.Time `url:"created_at,omitempty"`
 }
 
-// CreateSnippetDiscussion creates a new discussion for a single snippet. Snippet discussions are
-// comments users can post to a snippet.
+// CreateSnippetDiscussion creates a new discussion for a single snippet.
+// Snippet discussions are comments users can post to a snippet.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/discussions.html#create-new-snippet-discussion
@@ -330,7 +335,8 @@ type AddSnippetDiscussionNoteOptions struct {
 	CreatedAt *time.Time `json:"created_at,omitempty"`
 }
 
-// AddSnippetDiscussionNote creates a new discussion to a single project snippet.
+// AddSnippetDiscussionNote creates a new discussion to a single project
+// snippet.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/discussions.html#add-note-to-existing-snippet-discussion
@@ -339,7 +345,8 @@ func (s *DiscussionsService) AddSnippetDiscussionNote(pid interface{}, snippet i
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/snippets/%d/discussions/%s/notes", url.QueryEscape(project), snippet, discussion)
+	u := fmt.Sprintf("projects/%s/snippets/%d/discussions/%s/notes", url.QueryEscape(project),
+		snippet, discussion)
 
 	req, err := s.client.NewRequest("POST", u, opt, options)
 	if err != nil {
@@ -355,8 +362,8 @@ func (s *DiscussionsService) AddSnippetDiscussionNote(pid interface{}, snippet i
 	return d, resp, err
 }
 
-// UpdateSnippetDiscussionNoteOptions represents the available UpdateSnippetDiscussion()
-// options.
+// UpdateSnippetDiscussionNoteOptions represents the available
+// UpdateSnippetDiscussion() options.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/discussions.html#modify-existing-snippet-discussion-note
@@ -373,7 +380,8 @@ func (s *DiscussionsService) UpdateSnippetDiscussionNote(pid interface{}, snippe
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/snippets/%d/discussions/%s/notes/%d", url.QueryEscape(project), snippet, discussion, note)
+	u := fmt.Sprintf("projects/%s/snippets/%d/discussions/%s/notes/%d", url.QueryEscape(project),
+		snippet, discussion, note)
 
 	req, err := s.client.NewRequest("PUT", u, opt, options)
 	if err != nil {
@@ -391,13 +399,15 @@ func (s *DiscussionsService) UpdateSnippetDiscussionNote(pid interface{}, snippe
 
 // DeleteSnippetDiscussionNote deletes an existing discussion of a snippet.
 //
+// GitLab API docs:
 // https://docs.gitlab.com/ce/api/discussions.html#delete-a-snippet-discussion-note
 func (s *DiscussionsService) DeleteSnippetDiscussionNote(pid interface{}, snippet int, discussion string, note int, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/snippets/%d/discussions/%s/notes/%d", url.QueryEscape(project), snippet, discussion, note)
+	u := fmt.Sprintf("projects/%s/snippets/%d/discussions/%s/notes/%d", url.QueryEscape(project),
+		snippet, discussion, note)
 
 	req, err := s.client.NewRequest("DELETE", u, nil, options)
 	if err != nil {
@@ -449,7 +459,8 @@ func (s *DiscussionsService) GetEpicDiscussion(gid interface{}, epic int, discus
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("groups/%s/epics/%d/discussions/%s", url.QueryEscape(project), epic, discussion)
+	u := fmt.Sprintf("groups/%s/epics/%d/discussions/%s", url.QueryEscape(project), epic,
+		discussion)
 
 	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
@@ -475,8 +486,8 @@ type CreateEpicDiscussionOptions struct {
 	CreatedAt *time.Time `url:"created_at,omitempty"`
 }
 
-// CreateEpicDiscussion creates a new discussion for a single epic. Epic discussions are
-// comments users can post to a epic.
+// CreateEpicDiscussion creates a new discussion for a single epic. Epic
+// discussions are comments users can post to a epic.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/discussions.html#create-new-epic-discussion
@@ -520,7 +531,8 @@ func (s *DiscussionsService) AddEpicDiscussionNote(gid interface{}, epic int, di
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("groups/%s/epics/%d/discussions/%s/notes", url.QueryEscape(project), epic, discussion)
+	u := fmt.Sprintf("groups/%s/epics/%d/discussions/%s/notes", url.QueryEscape(project), epic,
+		discussion)
 
 	req, err := s.client.NewRequest("POST", u, opt, options)
 	if err != nil {
@@ -536,8 +548,8 @@ func (s *DiscussionsService) AddEpicDiscussionNote(gid interface{}, epic int, di
 	return d, resp, err
 }
 
-// UpdateEpicDiscussionNoteOptions represents the available UpdateEpicDiscussion()
-// options.
+// UpdateEpicDiscussionNoteOptions represents the available
+// UpdateEpicDiscussion() options.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/discussions.html#modify-existing-epic-discussion-note
@@ -555,7 +567,8 @@ func (s *DiscussionsService) UpdateEpicDiscussionNote(gid interface{}, epic int,
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("groups/%s/epics/%d/discussions/%s/notes/%d", url.QueryEscape(project), epic, discussion, note)
+	u := fmt.Sprintf("groups/%s/epics/%d/discussions/%s/notes/%d", url.QueryEscape(project), epic,
+		discussion, note)
 
 	req, err := s.client.NewRequest("PUT", u, opt, options)
 	if err != nil {
@@ -573,13 +586,15 @@ func (s *DiscussionsService) UpdateEpicDiscussionNote(gid interface{}, epic int,
 
 // DeleteEpicDiscussionNote deletes an existing discussion of a epic.
 //
+// GitLab API docs:
 // https://docs.gitlab.com/ee/api/discussions.html#delete-an-epic-discussion-note
 func (s *DiscussionsService) DeleteEpicDiscussionNote(gid interface{}, epic int, discussion string, note int, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(gid)
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("groups/%s/epics/%d/discussions/%s/notes/%d", url.QueryEscape(project), epic, discussion, note)
+	u := fmt.Sprintf("groups/%s/epics/%d/discussions/%s/notes/%d", url.QueryEscape(project), epic,
+		discussion, note)
 
 	req, err := s.client.NewRequest("DELETE", u, nil, options)
 	if err != nil {
@@ -589,14 +604,15 @@ func (s *DiscussionsService) DeleteEpicDiscussionNote(gid interface{}, epic int,
 	return s.client.Do(req, nil)
 }
 
-// ListMergeRequestDiscussionsOptions represents the available ListMergeRequestDiscussions()
-// options.
+// ListMergeRequestDiscussionsOptions represents the available
+// ListMergeRequestDiscussions() options.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/discussions.html#list-all-merge-request-discussions
 type ListMergeRequestDiscussionsOptions ListOptions
 
-// ListMergeRequestDiscussions gets a list of all discussions for a single merge request.
+// ListMergeRequestDiscussions gets a list of all discussions for a single
+// merge request.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/discussions.html#list-all-merge-request-discussions
@@ -605,7 +621,8 @@ func (s *DiscussionsService) ListMergeRequestDiscussions(pid interface{}, mergeR
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/merge_requests/%d/discussions", url.QueryEscape(project), mergeRequest)
+	u := fmt.Sprintf("projects/%s/merge_requests/%d/discussions", url.QueryEscape(project),
+		mergeRequest)
 
 	req, err := s.client.NewRequest("GET", u, opt, options)
 	if err != nil {
@@ -621,7 +638,8 @@ func (s *DiscussionsService) ListMergeRequestDiscussions(pid interface{}, mergeR
 	return ds, resp, err
 }
 
-// GetMergeRequestDiscussion returns a single discussion for a given merge request.
+// GetMergeRequestDiscussion returns a single discussion for a given merge
+// request.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/discussions.html#get-single-merge-request-discussion
@@ -630,7 +648,8 @@ func (s *DiscussionsService) GetMergeRequestDiscussion(pid interface{}, mergeReq
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/merge_requests/%d/discussions/%s", url.QueryEscape(project), mergeRequest, discussion)
+	u := fmt.Sprintf("projects/%s/merge_requests/%d/discussions/%s", url.QueryEscape(project),
+		mergeRequest, discussion)
 
 	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
@@ -657,7 +676,8 @@ type CreateMergeRequestDiscussionOptions struct {
 	Position  *NotePosition `json:"position,omitempty"`
 }
 
-// CreateMergeRequestDiscussion creates a new discussion for a single merge request.
+// CreateMergeRequestDiscussion creates a new discussion for a single merge
+// request.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/discussions.html#create-new-merge-request-discussion
@@ -666,7 +686,8 @@ func (s *DiscussionsService) CreateMergeRequestDiscussion(pid interface{}, merge
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/merge_requests/%d/discussions", url.QueryEscape(project), mergeRequest)
+	u := fmt.Sprintf("projects/%s/merge_requests/%d/discussions", url.QueryEscape(project),
+		mergeRequest)
 
 	req, err := s.client.NewRequest("POST", u, opt, options)
 	if err != nil {
@@ -701,7 +722,8 @@ func (s *DiscussionsService) ResolveMergeRequestDiscussion(pid interface{}, merg
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/merge_requests/%d/discussions/%s", url.QueryEscape(project), mergeRequest, discussion)
+	u := fmt.Sprintf("projects/%s/merge_requests/%d/discussions/%s", url.QueryEscape(project),
+		mergeRequest, discussion)
 
 	req, err := s.client.NewRequest("PUT", u, opt, options)
 	if err != nil {
@@ -727,7 +749,8 @@ type AddMergeRequestDiscussionNoteOptions struct {
 	CreatedAt *time.Time `json:"created_at,omitempty"`
 }
 
-// AddMergeRequestDiscussionNote creates a new discussion to a single project merge request.
+// AddMergeRequestDiscussionNote creates a new discussion to a single project
+// merge request.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/discussions.html#add-note-to-existing-merge-request-discussion
@@ -736,7 +759,8 @@ func (s *DiscussionsService) AddMergeRequestDiscussionNote(pid interface{}, merg
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/merge_requests/%d/discussions/%s/notes", url.QueryEscape(project), mergeRequest, discussion)
+	u := fmt.Sprintf("projects/%s/merge_requests/%d/discussions/%s/notes",
+		url.QueryEscape(project), mergeRequest, discussion)
 
 	req, err := s.client.NewRequest("POST", u, opt, options)
 	if err != nil {
@@ -752,8 +776,8 @@ func (s *DiscussionsService) AddMergeRequestDiscussionNote(pid interface{}, merg
 	return d, resp, err
 }
 
-// UpdateMergeRequestDiscussionNoteOptions represents the available UpdateMergeRequestDiscussion()
-// options.
+// UpdateMergeRequestDiscussionNoteOptions represents the available
+// UpdateMergeRequestDiscussion() options.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/discussions.html#modify-existing-merge-request-discussion-note
@@ -762,7 +786,8 @@ type UpdateMergeRequestDiscussionNoteOptions struct {
 	CreatedAt *time.Time `json:"created_at,omitempty"`
 }
 
-// UpdateMergeRequestDiscussionNote modifies existing discussion of a merge request.
+// UpdateMergeRequestDiscussionNote modifies existing discussion of a merge
+// request.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/discussions.html#modify-existing-merge-request-discussion-note
@@ -771,7 +796,8 @@ func (s *DiscussionsService) UpdateMergeRequestDiscussionNote(pid interface{}, m
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/merge_requests/%d/discussions/%s/notes/%d", url.QueryEscape(project), mergeRequest, discussion, note)
+	u := fmt.Sprintf("projects/%s/merge_requests/%d/discussions/%s/notes/%d",
+		url.QueryEscape(project), mergeRequest, discussion, note)
 
 	req, err := s.client.NewRequest("PUT", u, opt, options)
 	if err != nil {
@@ -787,15 +813,18 @@ func (s *DiscussionsService) UpdateMergeRequestDiscussionNote(pid interface{}, m
 	return d, resp, err
 }
 
-// DeleteMergeRequestDiscussionNote deletes an existing discussion of a merge request.
+// DeleteMergeRequestDiscussionNote deletes an existing discussion of a merge
+// request.
 //
+// GitLab API docs:
 // https://docs.gitlab.com/ce/api/discussions.html#delete-a-merge-request-discussion-note
 func (s *DiscussionsService) DeleteMergeRequestDiscussionNote(pid interface{}, mergeRequest int, discussion string, note int, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/merge_requests/%d/discussions/%s/notes/%d", url.QueryEscape(project), mergeRequest, discussion, note)
+	u := fmt.Sprintf("projects/%s/merge_requests/%d/discussions/%s/notes/%d",
+		url.QueryEscape(project), mergeRequest, discussion, note)
 
 	req, err := s.client.NewRequest("DELETE", u, nil, options)
 	if err != nil {
@@ -805,61 +834,8 @@ func (s *DiscussionsService) DeleteMergeRequestDiscussionNote(pid interface{}, m
 	return s.client.Do(req, nil)
 }
 
-// UpdateMergeRequestDiscussionOptions represents the available
-// UpdateMergeRequestDiscussion() options.
-//
-// GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#modify-existing-merge-request-discussion
-type UpdateMergeRequestDiscussionOptions struct {
-	Body      *string    `url:"body,omitempty" json:"body,omitempty"`
-	CreatedAt *time.Time `json:"created_at,omitempty"`
-}
-
-// UpdateMergeRequestDiscussion modifies existing discussion of a merge request.
-//
-// https://docs.gitlab.com/ce/api/discussions.html#modify-existing-merge-request-discussion
-func (s *DiscussionsService) UpdateMergeRequestDiscussion(pid interface{}, mergeRequest int, discussion string, opt *UpdateMergeRequestDiscussionOptions, options ...OptionFunc) (*Discussion, *Response, error) {
-	project, err := parseID(pid)
-	if err != nil {
-		return nil, nil, err
-	}
-	u := fmt.Sprintf(
-		"projects/%s/merge_requests/%d/discussions/%s", url.QueryEscape(project), mergeRequest, discussion)
-	req, err := s.client.NewRequest("PUT", u, opt, options)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	d := new(Discussion)
-	resp, err := s.client.Do(req, d)
-	if err != nil {
-		return nil, resp, err
-	}
-
-	return d, resp, err
-}
-
-// DeleteMergeRequestDiscussion deletes an existing discussion of a merge request.
-//
-// https://docs.gitlab.com/ce/api/discussions.html#delete-a-merge-request-discussion
-func (s *DiscussionsService) DeleteMergeRequestDiscussion(pid interface{}, mergeRequest int, discussion string, options ...OptionFunc) (*Response, error) {
-	project, err := parseID(pid)
-	if err != nil {
-		return nil, err
-	}
-	u := fmt.Sprintf(
-		"projects/%s/merge_requests/%d/discussions/%s", url.QueryEscape(project), mergeRequest, discussion)
-
-	req, err := s.client.NewRequest("DELETE", u, nil, options)
-	if err != nil {
-		return nil, err
-	}
-
-	return s.client.Do(req, nil)
-}
-
-// ListProjectCommitDiscussionsOptions represents the available ListCommitDiscussions()
-// options.
+// ListProjectCommitDiscussionsOptions represents the available
+// ListCommitDiscussions() options.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/discussions.html#list-project-commit-discussions
@@ -877,7 +853,8 @@ func (s *DiscussionsService) ListProjectCommitDiscussions(pid interface{}, commi
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/repository/commits/%s/discussions", url.QueryEscape(project), commit)
+	u := fmt.Sprintf("projects/%s/repository/commits/%s/discussions", url.QueryEscape(project),
+		commit)
 
 	req, err := s.client.NewRequest("GET", u, opt, options)
 	if err != nil {
@@ -893,7 +870,8 @@ func (s *DiscussionsService) ListProjectCommitDiscussions(pid interface{}, commi
 	return ds, resp, err
 }
 
-// GetCommitDiscussion returns a single discussion for a specific project commit.
+// GetCommitDiscussion returns a single discussion for a specific project
+// commit.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/discussions.html#get-single-commit-discussion
@@ -919,8 +897,8 @@ func (s *DiscussionsService) GetCommitDiscussion(pid interface{}, commit string,
 	return d, resp, err
 }
 
-// CreateCommitDiscussionOptions represents the available CreateCommitDiscussion()
-// options.
+// CreateCommitDiscussionOptions represents the available
+// CreateCommitDiscussion() options.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/discussions.html#create-new-commit-discussion
@@ -939,7 +917,8 @@ func (s *DiscussionsService) CreateCommitDiscussion(pid interface{}, commit stri
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/repository/commits/%s/discussions", url.QueryEscape(project), commit)
+	u := fmt.Sprintf("projects/%s/repository/commits/%s/discussions", url.QueryEscape(project),
+		commit)
 
 	req, err := s.client.NewRequest("POST", u, opt, options)
 	if err != nil {
@@ -974,7 +953,8 @@ func (s *DiscussionsService) AddCommitDiscussionNote(pid interface{}, commit str
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/repository/commits/%s/discussions/%s/notes", url.QueryEscape(project), commit, discussion)
+	u := fmt.Sprintf("projects/%s/repository/commits/%s/discussions/%s/notes",
+		url.QueryEscape(project), commit, discussion)
 
 	req, err := s.client.NewRequest("POST", u, opt, options)
 	if err != nil {
@@ -990,8 +970,8 @@ func (s *DiscussionsService) AddCommitDiscussionNote(pid interface{}, commit str
 	return d, resp, err
 }
 
-// UpdateCommitDiscussionNoteOptions represents the available UpdateCommitDiscussion()
-// options.
+// UpdateCommitDiscussionNoteOptions represents the available
+// UpdateCommitDiscussion() options.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/discussions.html#modify-existing-commit-discussion-note
@@ -1009,7 +989,8 @@ func (s *DiscussionsService) UpdateCommitDiscussionNote(pid interface{}, commit 
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/repository/commits/%s/discussions/%s/notes/%d", url.QueryEscape(project), commit, discussion, note)
+	u := fmt.Sprintf("projects/%s/repository/commits/%s/discussions/%s/notes/%d",
+		url.QueryEscape(project), commit, discussion, note)
 
 	req, err := s.client.NewRequest("PUT", u, opt, options)
 	if err != nil {
@@ -1027,13 +1008,15 @@ func (s *DiscussionsService) UpdateCommitDiscussionNote(pid interface{}, commit 
 
 // DeleteCommitDiscussionNote deletes an existing discussion of an commit.
 //
+// GitLab API docs:
 // https://docs.gitlab.com/ce/api/discussions.html#delete-an-commit-discussion-note
 func (s *DiscussionsService) DeleteCommitDiscussionNote(pid interface{}, commit string, discussion string, note int, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/repository/commits/%s/discussions/%s/notes/%d", url.QueryEscape(project), commit, discussion, note)
+	u := fmt.Sprintf("projects/%s/repository/commits/%s/discussions/%s/notes/%d",
+		url.QueryEscape(project), commit, discussion, note)
 
 	req, err := s.client.NewRequest("DELETE", u, nil, options)
 	if err != nil {

--- a/discussions.go
+++ b/discussions.go
@@ -1,0 +1,494 @@
+//
+// Copyright 2017, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package gitlab
+
+import (
+	"fmt"
+	"net/url"
+	"time"
+)
+
+// DiscussionsService handles communication with the discussions related methods
+// of the GitLab API.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/discussions.html
+type DiscussionsService struct {
+	client *Client
+}
+
+// Discussion represents a GitLab discussion.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/discussions.html
+type Discussion struct {
+	ID         int    `json:"id"`
+	Body       string `json:"body"`
+	Attachment string `json:"attachment"`
+	Title      string `json:"title"`
+	FileName   string `json:"file_name"`
+	Author     struct {
+		ID        int        `json:"id"`
+		Username  string     `json:"username"`
+		Email     string     `json:"email"`
+		Name      string     `json:"name"`
+		State     string     `json:"state"`
+		CreatedAt *time.Time `json:"created_at"`
+		AvatarURL string     `json:"avatar_url"`
+		WebURL    string     `json:"web_url"`
+	} `json:"author"`
+	System             bool       `json:"system"`
+	ExpiresAt          *time.Time `json:"expires_at"`
+	UpdatedAt          *time.Time `json:"updated_at"`
+	CreatedAt          *time.Time `json:"created_at"`
+	DiscussionableID   int        `json:"noteable_id"`
+	DiscussionableType string     `json:"noteable_type"`
+	DiscussionableIID  int        `json:"noteable_iid"`
+}
+
+func (n Discussion) String() string {
+	return Stringify(n)
+}
+
+// ListIssueDiscussionsOptions represents the available ListIssueDiscussions() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/discussions.html#list-project-issue-discussions
+type ListIssueDiscussionsOptions struct {
+	ListOptions
+	OrderBy *string `url:"order_by,omitempty" json:"order_by,omitempty"`
+	Sort    *string `url:"sort,omitempty" json:"sort,omitempty"`
+}
+
+// ListIssueDiscussions gets a list of all discussions for a single issue.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/discussions.html#list-project-issue-discussions
+func (s *DiscussionsService) ListIssueDiscussions(pid interface{}, issue int, opt *ListIssueDiscussionsOptions, options ...OptionFunc) ([]*Discussion, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/issues/%d/discussions", url.QueryEscape(project), issue)
+
+	req, err := s.client.NewRequest("GET", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var n []*Discussion
+	resp, err := s.client.Do(req, &n)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return n, resp, err
+}
+
+// GetIssueDiscussion returns a single discussion for a specific project issue.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/discussions.html#get-single-issue-discussion
+func (s *DiscussionsService) GetIssueDiscussion(pid interface{}, issue, discussion int, options ...OptionFunc) (*Discussion, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/issues/%d/discussions/%d", url.QueryEscape(project), issue, discussion)
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	n := new(Discussion)
+	resp, err := s.client.Do(req, n)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return n, resp, err
+}
+
+// CreateIssueDiscussionOptions represents the available CreateIssueDiscussion()
+// options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/discussions.html#create-new-issue-discussion
+type CreateIssueDiscussionOptions struct {
+	Body *string `url:"body,omitempty" json:"body,omitempty"`
+}
+
+// CreateIssueDiscussion creates a new discussion to a single project issue.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/discussions.html#create-new-issue-discussion
+func (s *DiscussionsService) CreateIssueDiscussion(pid interface{}, issue int, opt *CreateIssueDiscussionOptions, options ...OptionFunc) (*Discussion, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/issues/%d/discussions", url.QueryEscape(project), issue)
+
+	req, err := s.client.NewRequest("POST", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	n := new(Discussion)
+	resp, err := s.client.Do(req, n)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return n, resp, err
+}
+
+// UpdateIssueDiscussionOptions represents the available UpdateIssueDiscussion()
+// options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/discussions.html#modify-existing-issue-discussion
+type UpdateIssueDiscussionOptions struct {
+	Body *string `url:"body,omitempty" json:"body,omitempty"`
+}
+
+// UpdateIssueDiscussion modifies existing discussion of an issue.
+//
+// https://docs.gitlab.com/ce/api/discussions.html#modify-existing-issue-discussion
+func (s *DiscussionsService) UpdateIssueDiscussion(pid interface{}, issue, discussion int, opt *UpdateIssueDiscussionOptions, options ...OptionFunc) (*Discussion, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/issues/%d/discussions/%d", url.QueryEscape(project), issue, discussion)
+
+	req, err := s.client.NewRequest("PUT", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	n := new(Discussion)
+	resp, err := s.client.Do(req, n)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return n, resp, err
+}
+
+// DeleteIssueDiscussion deletes an existing discussion of an issue.
+//
+// https://docs.gitlab.com/ce/api/discussions.html#delete-an-issue-discussion
+func (s *DiscussionsService) DeleteIssueDiscussion(pid interface{}, issue, discussion int, options ...OptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/issues/%d/discussions/%d", url.QueryEscape(project), issue, discussion)
+
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// ListSnippetDiscussionsOptions represents the available ListSnippetDiscussions() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/discussions.html#list-all-snippet-discussions
+type ListSnippetDiscussionsOptions ListOptions
+
+// ListSnippetDiscussions gets a list of all discussions for a single snippet. Snippet
+// discussions are comments users can post to a snippet.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/discussions.html#list-all-snippet-discussions
+func (s *DiscussionsService) ListSnippetDiscussions(pid interface{}, snippet int, opt *ListSnippetDiscussionsOptions, options ...OptionFunc) ([]*Discussion, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/snippets/%d/discussions", url.QueryEscape(project), snippet)
+
+	req, err := s.client.NewRequest("GET", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var n []*Discussion
+	resp, err := s.client.Do(req, &n)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return n, resp, err
+}
+
+// GetSnippetDiscussion returns a single discussion for a given snippet.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/discussions.html#get-single-snippet-discussion
+func (s *DiscussionsService) GetSnippetDiscussion(pid interface{}, snippet, discussion int, options ...OptionFunc) (*Discussion, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/snippets/%d/discussions/%d", url.QueryEscape(project), snippet, discussion)
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	n := new(Discussion)
+	resp, err := s.client.Do(req, n)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return n, resp, err
+}
+
+// CreateSnippetDiscussionOptions represents the available CreateSnippetDiscussion()
+// options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/discussions.html#create-new-snippet-discussion
+type CreateSnippetDiscussionOptions struct {
+	Body *string `url:"body,omitempty" json:"body,omitempty"`
+}
+
+// CreateSnippetDiscussion creates a new discussion for a single snippet. Snippet discussions are
+// comments users can post to a snippet.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/discussions.html#create-new-snippet-discussion
+func (s *DiscussionsService) CreateSnippetDiscussion(pid interface{}, snippet int, opt *CreateSnippetDiscussionOptions, options ...OptionFunc) (*Discussion, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/snippets/%d/discussions", url.QueryEscape(project), snippet)
+
+	req, err := s.client.NewRequest("POST", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	n := new(Discussion)
+	resp, err := s.client.Do(req, n)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return n, resp, err
+}
+
+// UpdateSnippetDiscussionOptions represents the available UpdateSnippetDiscussion()
+// options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/discussions.html#modify-existing-snippet-discussion
+type UpdateSnippetDiscussionOptions struct {
+	Body *string `url:"body,omitempty" json:"body,omitempty"`
+}
+
+// UpdateSnippetDiscussion modifies existing discussion of a snippet.
+//
+// https://docs.gitlab.com/ce/api/discussions.html#modify-existing-snippet-discussion
+func (s *DiscussionsService) UpdateSnippetDiscussion(pid interface{}, snippet, discussion int, opt *UpdateSnippetDiscussionOptions, options ...OptionFunc) (*Discussion, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/snippets/%d/discussions/%d", url.QueryEscape(project), snippet, discussion)
+
+	req, err := s.client.NewRequest("PUT", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	n := new(Discussion)
+	resp, err := s.client.Do(req, n)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return n, resp, err
+}
+
+// DeleteSnippetDiscussion deletes an existing discussion of a snippet.
+//
+// https://docs.gitlab.com/ce/api/discussions.html#delete-a-snippet-discussion
+func (s *DiscussionsService) DeleteSnippetDiscussion(pid interface{}, snippet, discussion int, options ...OptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/snippets/%d/discussions/%d", url.QueryEscape(project), snippet, discussion)
+
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// ListMergeRequestDiscussionsOptions represents the available ListMergeRequestDiscussions()
+// options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/discussions.html#list-all-merge-request-discussions
+type ListMergeRequestDiscussionsOptions ListOptions
+
+// ListMergeRequestDiscussions gets a list of all discussions for a single merge request.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/discussions.html#list-all-merge-request-discussions
+func (s *DiscussionsService) ListMergeRequestDiscussions(pid interface{}, mergeRequest int, opt *ListMergeRequestDiscussionsOptions, options ...OptionFunc) ([]*Discussion, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/merge_requests/%d/discussions", url.QueryEscape(project), mergeRequest)
+
+	req, err := s.client.NewRequest("GET", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var n []*Discussion
+	resp, err := s.client.Do(req, &n)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return n, resp, err
+}
+
+// GetMergeRequestDiscussion returns a single discussion for a given merge request.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/discussions.html#get-single-merge-request-discussion
+func (s *DiscussionsService) GetMergeRequestDiscussion(pid interface{}, mergeRequest, discussion int, options ...OptionFunc) (*Discussion, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/merge_requests/%d/discussions/%d", url.QueryEscape(project), mergeRequest, discussion)
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	n := new(Discussion)
+	resp, err := s.client.Do(req, n)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return n, resp, err
+}
+
+// CreateMergeRequestDiscussionOptions represents the available
+// CreateMergeRequestDiscussion() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/discussions.html#create-new-merge-request-discussion
+type CreateMergeRequestDiscussionOptions struct {
+	Body *string `url:"body,omitempty" json:"body,omitempty"`
+}
+
+// CreateMergeRequestDiscussion creates a new discussion for a single merge request.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/discussions.html#create-new-merge-request-discussion
+func (s *DiscussionsService) CreateMergeRequestDiscussion(pid interface{}, mergeRequest int, opt *CreateMergeRequestDiscussionOptions, options ...OptionFunc) (*Discussion, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/merge_requests/%d/discussions", url.QueryEscape(project), mergeRequest)
+
+	req, err := s.client.NewRequest("POST", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	n := new(Discussion)
+	resp, err := s.client.Do(req, n)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return n, resp, err
+}
+
+// UpdateMergeRequestDiscussionOptions represents the available
+// UpdateMergeRequestDiscussion() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/discussions.html#modify-existing-merge-request-discussion
+type UpdateMergeRequestDiscussionOptions struct {
+	Body *string `url:"body,omitempty" json:"body,omitempty"`
+}
+
+// UpdateMergeRequestDiscussion modifies existing discussion of a merge request.
+//
+// https://docs.gitlab.com/ce/api/discussions.html#modify-existing-merge-request-discussion
+func (s *DiscussionsService) UpdateMergeRequestDiscussion(pid interface{}, mergeRequest, discussion int, opt *UpdateMergeRequestDiscussionOptions, options ...OptionFunc) (*Discussion, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf(
+		"projects/%s/merge_requests/%d/discussions/%d", url.QueryEscape(project), mergeRequest, discussion)
+	req, err := s.client.NewRequest("PUT", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	n := new(Discussion)
+	resp, err := s.client.Do(req, n)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return n, resp, err
+}
+
+// DeleteMergeRequestDiscussion deletes an existing discussion of a merge request.
+//
+// https://docs.gitlab.com/ce/api/discussions.html#delete-a-merge-request-discussion
+func (s *DiscussionsService) DeleteMergeRequestDiscussion(pid interface{}, mergeRequest, discussion int, options ...OptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf(
+		"projects/%s/merge_requests/%d/discussions/%d", url.QueryEscape(project), mergeRequest, discussion)
+
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}

--- a/discussions.go
+++ b/discussions.go
@@ -34,9 +34,9 @@ type DiscussionsService struct {
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/discussions.html
 type Discussion struct {
-	ID             string `json:"id"`
-	IndividualNote bool   `json:"individual_note"`
-	Notes          []Note `json:"notes"`
+	ID             string  `json:"id"`
+	IndividualNote bool    `json:"individual_note"`
+	Notes          []*Note `json:"notes"`
 }
 
 func (d Discussion) String() string {
@@ -48,9 +48,7 @@ func (d Discussion) String() string {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/discussions.html#list-project-issue-discussions
-type ListProjectIssueDiscussionsOptions struct {
-	ListOptions
-}
+type ListProjectIssueDiscussionsOptions ListOptions
 
 // ListProjectIssueDiscussions gets a list of all discussions for a single
 // issue.
@@ -87,7 +85,9 @@ func (s *DiscussionsService) GetIssueDiscussion(pid interface{}, issue int, disc
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/issues/%d/discussions/%s", url.QueryEscape(project), issue,
+	u := fmt.Sprintf("projects/%s/issues/%d/discussions/%s",
+		url.QueryEscape(project),
+		issue,
 		discussion)
 
 	req, err := s.client.NewRequest("GET", u, nil, options)
@@ -111,7 +111,7 @@ func (s *DiscussionsService) GetIssueDiscussion(pid interface{}, issue int, disc
 // https://docs.gitlab.com/ce/api/discussions.html#create-new-issue-discussion
 type CreateIssueDiscussionOptions struct {
 	Body      *string    `url:"body,omitempty" json:"body,omitempty"`
-	CreatedAt *time.Time `json:"created_at,omitempty"`
+	CreatedAt *time.Time `url:"created_at,omitempty" json:"created_at,omitempty"`
 }
 
 // CreateIssueDiscussion creates a new discussion to a single project issue.
@@ -146,7 +146,7 @@ func (s *DiscussionsService) CreateIssueDiscussion(pid interface{}, issue int, o
 // https://docs.gitlab.com/ce/api/discussions.html#add-note-to-existing-issue-discussion
 type AddIssueDiscussionNoteOptions struct {
 	Body      *string    `url:"body,omitempty" json:"body,omitempty"`
-	CreatedAt *time.Time `json:"created_at,omitempty"`
+	CreatedAt *time.Time `url:"created_at,omitempty" json:"created_at,omitempty"`
 }
 
 // AddIssueDiscussionNote creates a new discussion to a single project issue.
@@ -158,7 +158,9 @@ func (s *DiscussionsService) AddIssueDiscussionNote(pid interface{}, issue int, 
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/issues/%d/discussions/%s/notes", url.QueryEscape(project), issue,
+	u := fmt.Sprintf("projects/%s/issues/%d/discussions/%s/notes",
+		url.QueryEscape(project),
+		issue,
 		discussion)
 
 	req, err := s.client.NewRequest("POST", u, opt, options)
@@ -181,7 +183,8 @@ func (s *DiscussionsService) AddIssueDiscussionNote(pid interface{}, issue int, 
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/discussions.html#modify-existing-issue-discussion-note
 type UpdateIssueDiscussionNoteOptions struct {
-	Body *string `url:"body,omitempty" json:"body,omitempty"`
+	Body      *string    `url:"body,omitempty" json:"body,omitempty"`
+	CreatedAt *time.Time `url:"created_at,omitempty" json:"created_at,omitempty"`
 }
 
 // UpdateIssueDiscussionNote modifies existing discussion of an issue.
@@ -193,8 +196,11 @@ func (s *DiscussionsService) UpdateIssueDiscussionNote(pid interface{}, issue in
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/issues/%d/discussions/%s/notes/%d", url.QueryEscape(project),
-		issue, discussion, note)
+	u := fmt.Sprintf("projects/%s/issues/%d/discussions/%s/notes/%d",
+		url.QueryEscape(project),
+		issue,
+		discussion,
+		note)
 
 	req, err := s.client.NewRequest("PUT", u, opt, options)
 	if err != nil {
@@ -219,8 +225,11 @@ func (s *DiscussionsService) DeleteIssueDiscussionNote(pid interface{}, issue in
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/issues/%d/discussions/%s/notes/%d", url.QueryEscape(project),
-		issue, discussion, note)
+	u := fmt.Sprintf("projects/%s/issues/%d/discussions/%s/notes/%d",
+		url.QueryEscape(project),
+		issue,
+		discussion,
+		note)
 
 	req, err := s.client.NewRequest("DELETE", u, nil, options)
 	if err != nil {
@@ -272,7 +281,9 @@ func (s *DiscussionsService) GetSnippetDiscussion(pid interface{}, snippet int, 
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/snippets/%d/discussions/%s", url.QueryEscape(project), snippet,
+	u := fmt.Sprintf("projects/%s/snippets/%d/discussions/%s",
+		url.QueryEscape(project),
+		snippet,
 		discussion)
 
 	req, err := s.client.NewRequest("GET", u, nil, options)
@@ -296,7 +307,7 @@ func (s *DiscussionsService) GetSnippetDiscussion(pid interface{}, snippet int, 
 // https://docs.gitlab.com/ce/api/discussions.html#create-new-snippet-discussion
 type CreateSnippetDiscussionOptions struct {
 	Body      *string    `url:"body,omitempty" json:"body,omitempty"`
-	CreatedAt *time.Time `url:"created_at,omitempty"`
+	CreatedAt *time.Time `url:"created_at,omitempty" json:"created_at,omitempty"`
 }
 
 // CreateSnippetDiscussion creates a new discussion for a single snippet.
@@ -332,7 +343,7 @@ func (s *DiscussionsService) CreateSnippetDiscussion(pid interface{}, snippet in
 // https://docs.gitlab.com/ce/api/discussions.html#add-note-to-existing-snippet-discussion
 type AddSnippetDiscussionNoteOptions struct {
 	Body      *string    `url:"body,omitempty" json:"body,omitempty"`
-	CreatedAt *time.Time `json:"created_at,omitempty"`
+	CreatedAt *time.Time `url:"created_at,omitempty" json:"created_at,omitempty"`
 }
 
 // AddSnippetDiscussionNote creates a new discussion to a single project
@@ -345,8 +356,10 @@ func (s *DiscussionsService) AddSnippetDiscussionNote(pid interface{}, snippet i
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/snippets/%d/discussions/%s/notes", url.QueryEscape(project),
-		snippet, discussion)
+	u := fmt.Sprintf("projects/%s/snippets/%d/discussions/%s/notes",
+		url.QueryEscape(project),
+		snippet,
+		discussion)
 
 	req, err := s.client.NewRequest("POST", u, opt, options)
 	if err != nil {
@@ -368,7 +381,8 @@ func (s *DiscussionsService) AddSnippetDiscussionNote(pid interface{}, snippet i
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/discussions.html#modify-existing-snippet-discussion-note
 type UpdateSnippetDiscussionNoteOptions struct {
-	Body *string `url:"body,omitempty" json:"body,omitempty"`
+	Body      *string    `url:"body,omitempty" json:"body,omitempty"`
+	CreatedAt *time.Time `url:"created_at,omitempty" json:"created_at,omitempty"`
 }
 
 // UpdateSnippetDiscussionNote modifies existing discussion of a snippet.
@@ -380,8 +394,11 @@ func (s *DiscussionsService) UpdateSnippetDiscussionNote(pid interface{}, snippe
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/snippets/%d/discussions/%s/notes/%d", url.QueryEscape(project),
-		snippet, discussion, note)
+	u := fmt.Sprintf("projects/%s/snippets/%d/discussions/%s/notes/%d",
+		url.QueryEscape(project),
+		snippet,
+		discussion,
+		note)
 
 	req, err := s.client.NewRequest("PUT", u, opt, options)
 	if err != nil {
@@ -406,8 +423,11 @@ func (s *DiscussionsService) DeleteSnippetDiscussionNote(pid interface{}, snippe
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/snippets/%d/discussions/%s/notes/%d", url.QueryEscape(project),
-		snippet, discussion, note)
+	u := fmt.Sprintf("projects/%s/snippets/%d/discussions/%s/notes/%d",
+		url.QueryEscape(project),
+		snippet,
+		discussion,
+		note)
 
 	req, err := s.client.NewRequest("DELETE", u, nil, options)
 	if err != nil {
@@ -430,11 +450,13 @@ type ListGroupEpicDiscussionsOptions ListOptions
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/discussions.html#list-all-epic-discussions
 func (s *DiscussionsService) ListGroupEpicDiscussions(gid interface{}, epic int, opt *ListGroupEpicDiscussionsOptions, options ...OptionFunc) ([]*Discussion, *Response, error) {
-	project, err := parseID(gid)
+	group, err := parseID(gid)
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("groups/%s/epics/%d/discussions", url.QueryEscape(project), epic)
+	u := fmt.Sprintf("groups/%s/epics/%d/discussions",
+		url.QueryEscape(group),
+		epic)
 
 	req, err := s.client.NewRequest("GET", u, opt, options)
 	if err != nil {
@@ -455,11 +477,13 @@ func (s *DiscussionsService) ListGroupEpicDiscussions(gid interface{}, epic int,
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/discussions.html#get-single-epic-discussion
 func (s *DiscussionsService) GetEpicDiscussion(gid interface{}, epic int, discussion string, options ...OptionFunc) (*Discussion, *Response, error) {
-	project, err := parseID(gid)
+	group, err := parseID(gid)
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("groups/%s/epics/%d/discussions/%s", url.QueryEscape(project), epic,
+	u := fmt.Sprintf("groups/%s/epics/%d/discussions/%s",
+		url.QueryEscape(group),
+		epic,
 		discussion)
 
 	req, err := s.client.NewRequest("GET", u, nil, options)
@@ -483,7 +507,7 @@ func (s *DiscussionsService) GetEpicDiscussion(gid interface{}, epic int, discus
 // https://docs.gitlab.com/ee/api/discussions.html#create-new-epic-discussion
 type CreateEpicDiscussionOptions struct {
 	Body      *string    `url:"body,omitempty" json:"body,omitempty"`
-	CreatedAt *time.Time `url:"created_at,omitempty"`
+	CreatedAt *time.Time `url:"created_at,omitempty" json:"created_at,omitempty"`
 }
 
 // CreateEpicDiscussion creates a new discussion for a single epic. Epic
@@ -492,11 +516,13 @@ type CreateEpicDiscussionOptions struct {
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/discussions.html#create-new-epic-discussion
 func (s *DiscussionsService) CreateEpicDiscussion(gid interface{}, epic int, opt *CreateEpicDiscussionOptions, options ...OptionFunc) (*Discussion, *Response, error) {
-	project, err := parseID(gid)
+	group, err := parseID(gid)
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("groups/%s/epics/%d/discussions", url.QueryEscape(project), epic)
+	u := fmt.Sprintf("groups/%s/epics/%d/discussions",
+		url.QueryEscape(group),
+		epic)
 
 	req, err := s.client.NewRequest("POST", u, opt, options)
 	if err != nil {
@@ -519,7 +545,7 @@ func (s *DiscussionsService) CreateEpicDiscussion(gid interface{}, epic int, opt
 // https://docs.gitlab.com/ee/api/discussions.html#add-note-to-existing-epic-discussion
 type AddEpicDiscussionNoteOptions struct {
 	Body      *string    `url:"body,omitempty" json:"body,omitempty"`
-	CreatedAt *time.Time `json:"created_at,omitempty"`
+	CreatedAt *time.Time `url:"created_at,omitempty" json:"created_at,omitempty"`
 }
 
 // AddEpicDiscussionNote creates a new discussion to a single project epic.
@@ -527,11 +553,13 @@ type AddEpicDiscussionNoteOptions struct {
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/discussions.html#add-note-to-existing-epic-discussion
 func (s *DiscussionsService) AddEpicDiscussionNote(gid interface{}, epic int, discussion string, opt *AddEpicDiscussionNoteOptions, options ...OptionFunc) (*Discussion, *Response, error) {
-	project, err := parseID(gid)
+	group, err := parseID(gid)
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("groups/%s/epics/%d/discussions/%s/notes", url.QueryEscape(project), epic,
+	u := fmt.Sprintf("groups/%s/epics/%d/discussions/%s/notes",
+		url.QueryEscape(group),
+		epic,
 		discussion)
 
 	req, err := s.client.NewRequest("POST", u, opt, options)
@@ -555,7 +583,7 @@ func (s *DiscussionsService) AddEpicDiscussionNote(gid interface{}, epic int, di
 // https://docs.gitlab.com/ee/api/discussions.html#modify-existing-epic-discussion-note
 type UpdateEpicDiscussionNoteOptions struct {
 	Body      *string    `url:"body,omitempty" json:"body,omitempty"`
-	CreatedAt *time.Time `json:"created_at,omitempty"`
+	CreatedAt *time.Time `url:"created_at,omitempty" json:"created_at,omitempty"`
 }
 
 // UpdateEpicDiscussionNote modifies existing discussion of a epic.
@@ -563,11 +591,13 @@ type UpdateEpicDiscussionNoteOptions struct {
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/discussions.html#modify-existing-epic-discussion-note
 func (s *DiscussionsService) UpdateEpicDiscussionNote(gid interface{}, epic int, discussion string, note int, opt *UpdateEpicDiscussionNoteOptions, options ...OptionFunc) (*Discussion, *Response, error) {
-	project, err := parseID(gid)
+	group, err := parseID(gid)
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("groups/%s/epics/%d/discussions/%s/notes/%d", url.QueryEscape(project), epic,
+	u := fmt.Sprintf("groups/%s/epics/%d/discussions/%s/notes/%d",
+		url.QueryEscape(group),
+		epic,
 		discussion, note)
 
 	req, err := s.client.NewRequest("PUT", u, opt, options)
@@ -589,11 +619,13 @@ func (s *DiscussionsService) UpdateEpicDiscussionNote(gid interface{}, epic int,
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/discussions.html#delete-an-epic-discussion-note
 func (s *DiscussionsService) DeleteEpicDiscussionNote(gid interface{}, epic int, discussion string, note int, options ...OptionFunc) (*Response, error) {
-	project, err := parseID(gid)
+	group, err := parseID(gid)
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("groups/%s/epics/%d/discussions/%s/notes/%d", url.QueryEscape(project), epic,
+	u := fmt.Sprintf("groups/%s/epics/%d/discussions/%s/notes/%d",
+		url.QueryEscape(group),
+		epic,
 		discussion, note)
 
 	req, err := s.client.NewRequest("DELETE", u, nil, options)
@@ -621,7 +653,8 @@ func (s *DiscussionsService) ListMergeRequestDiscussions(pid interface{}, mergeR
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/merge_requests/%d/discussions", url.QueryEscape(project),
+	u := fmt.Sprintf("projects/%s/merge_requests/%d/discussions",
+		url.QueryEscape(project),
 		mergeRequest)
 
 	req, err := s.client.NewRequest("GET", u, opt, options)
@@ -648,8 +681,10 @@ func (s *DiscussionsService) GetMergeRequestDiscussion(pid interface{}, mergeReq
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/merge_requests/%d/discussions/%s", url.QueryEscape(project),
-		mergeRequest, discussion)
+	u := fmt.Sprintf("projects/%s/merge_requests/%d/discussions/%s",
+		url.QueryEscape(project),
+		mergeRequest,
+		discussion)
 
 	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
@@ -672,8 +707,8 @@ func (s *DiscussionsService) GetMergeRequestDiscussion(pid interface{}, mergeReq
 // https://docs.gitlab.com/ce/api/discussions.html#create-new-merge-request-discussion
 type CreateMergeRequestDiscussionOptions struct {
 	Body      *string       `url:"body,omitempty" json:"body,omitempty"`
-	CreatedAt *time.Time    `url:"created_at,omitempty"`
-	Position  *NotePosition `json:"position,omitempty"`
+	CreatedAt *time.Time    `url:"created_at,omitempty" json:"created_at,omitempty"`
+	Position  *NotePosition `url:"position,omitempty" json:"position,omitempty"`
 }
 
 // CreateMergeRequestDiscussion creates a new discussion for a single merge
@@ -686,7 +721,8 @@ func (s *DiscussionsService) CreateMergeRequestDiscussion(pid interface{}, merge
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/merge_requests/%d/discussions", url.QueryEscape(project),
+	u := fmt.Sprintf("projects/%s/merge_requests/%d/discussions",
+		url.QueryEscape(project),
 		mergeRequest)
 
 	req, err := s.client.NewRequest("POST", u, opt, options)
@@ -709,7 +745,7 @@ func (s *DiscussionsService) CreateMergeRequestDiscussion(pid interface{}, merge
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/discussions.html#resolve-a-merge-request-discussion
 type ResolveMergeRequestDiscussionOptions struct {
-	Resolved bool `url:"resolved" json:"resolved"`
+	Resolved *bool `url:"resolved,omitempty" json:"resolved,omitempty"`
 }
 
 // ResolveMergeRequestDiscussion resolves/unresolves whole discussion of a merge
@@ -722,7 +758,8 @@ func (s *DiscussionsService) ResolveMergeRequestDiscussion(pid interface{}, merg
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/merge_requests/%d/discussions/%s", url.QueryEscape(project),
+	u := fmt.Sprintf("projects/%s/merge_requests/%d/discussions/%s",
+		url.QueryEscape(project),
 		mergeRequest, discussion)
 
 	req, err := s.client.NewRequest("PUT", u, opt, options)
@@ -746,7 +783,7 @@ func (s *DiscussionsService) ResolveMergeRequestDiscussion(pid interface{}, merg
 // https://docs.gitlab.com/ce/api/discussions.html#add-note-to-existing-merge-request-discussion
 type AddMergeRequestDiscussionNoteOptions struct {
 	Body      *string    `url:"body,omitempty" json:"body,omitempty"`
-	CreatedAt *time.Time `json:"created_at,omitempty"`
+	CreatedAt *time.Time `url:"created_at,omitempty" json:"created_at,omitempty"`
 }
 
 // AddMergeRequestDiscussionNote creates a new discussion to a single project
@@ -760,7 +797,9 @@ func (s *DiscussionsService) AddMergeRequestDiscussionNote(pid interface{}, merg
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/merge_requests/%d/discussions/%s/notes",
-		url.QueryEscape(project), mergeRequest, discussion)
+		url.QueryEscape(project),
+		mergeRequest,
+		discussion)
 
 	req, err := s.client.NewRequest("POST", u, opt, options)
 	if err != nil {
@@ -783,7 +822,7 @@ func (s *DiscussionsService) AddMergeRequestDiscussionNote(pid interface{}, merg
 // https://docs.gitlab.com/ce/api/discussions.html#modify-existing-merge-request-discussion-note
 type UpdateMergeRequestDiscussionNoteOptions struct {
 	Body      *string    `url:"body,omitempty" json:"body,omitempty"`
-	CreatedAt *time.Time `json:"created_at,omitempty"`
+	CreatedAt *time.Time `url:"created_at,omitempty" json:"created_at,omitempty"`
 }
 
 // UpdateMergeRequestDiscussionNote modifies existing discussion of a merge
@@ -797,7 +836,10 @@ func (s *DiscussionsService) UpdateMergeRequestDiscussionNote(pid interface{}, m
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/merge_requests/%d/discussions/%s/notes/%d",
-		url.QueryEscape(project), mergeRequest, discussion, note)
+		url.QueryEscape(project),
+		mergeRequest,
+		discussion,
+		note)
 
 	req, err := s.client.NewRequest("PUT", u, opt, options)
 	if err != nil {
@@ -824,7 +866,10 @@ func (s *DiscussionsService) DeleteMergeRequestDiscussionNote(pid interface{}, m
 		return nil, err
 	}
 	u := fmt.Sprintf("projects/%s/merge_requests/%d/discussions/%s/notes/%d",
-		url.QueryEscape(project), mergeRequest, discussion, note)
+		url.QueryEscape(project),
+		mergeRequest,
+		discussion,
+		note)
 
 	req, err := s.client.NewRequest("DELETE", u, nil, options)
 	if err != nil {
@@ -839,9 +884,7 @@ func (s *DiscussionsService) DeleteMergeRequestDiscussionNote(pid interface{}, m
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/discussions.html#list-project-commit-discussions
-type ListProjectCommitDiscussionsOptions struct {
-	ListOptions
-}
+type ListProjectCommitDiscussionsOptions ListOptions
 
 // ListProjectCommitDiscussions gets a list of all discussions for a single
 // commit.
@@ -853,7 +896,8 @@ func (s *DiscussionsService) ListProjectCommitDiscussions(pid interface{}, commi
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/repository/commits/%s/discussions", url.QueryEscape(project),
+	u := fmt.Sprintf("projects/%s/repository/commits/%s/discussions",
+		url.QueryEscape(project),
 		commit)
 
 	req, err := s.client.NewRequest("GET", u, opt, options)
@@ -880,7 +924,9 @@ func (s *DiscussionsService) GetCommitDiscussion(pid interface{}, commit string,
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/repository/commits/%s/discussions/%s", url.QueryEscape(project), commit,
+	u := fmt.Sprintf("projects/%s/repository/commits/%s/discussions/%s",
+		url.QueryEscape(project),
+		commit,
 		discussion)
 
 	req, err := s.client.NewRequest("GET", u, nil, options)
@@ -904,8 +950,8 @@ func (s *DiscussionsService) GetCommitDiscussion(pid interface{}, commit string,
 // https://docs.gitlab.com/ce/api/discussions.html#create-new-commit-discussion
 type CreateCommitDiscussionOptions struct {
 	Body      *string       `url:"body,omitempty" json:"body,omitempty"`
-	CreatedAt *time.Time    `json:"created_at,omitempty"`
-	Position  *NotePosition `json:"position,omitempty"`
+	CreatedAt *time.Time    `url:"created_at,omitempty" json:"created_at,omitempty"`
+	Position  *NotePosition `url:"position,omitempty" json:"position,omitempty"`
 }
 
 // CreateCommitDiscussion creates a new discussion to a single project commit.
@@ -917,7 +963,8 @@ func (s *DiscussionsService) CreateCommitDiscussion(pid interface{}, commit stri
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/repository/commits/%s/discussions", url.QueryEscape(project),
+	u := fmt.Sprintf("projects/%s/repository/commits/%s/discussions",
+		url.QueryEscape(project),
 		commit)
 
 	req, err := s.client.NewRequest("POST", u, opt, options)
@@ -941,7 +988,7 @@ func (s *DiscussionsService) CreateCommitDiscussion(pid interface{}, commit stri
 // https://docs.gitlab.com/ce/api/discussions.html#add-note-to-existing-commit-discussion
 type AddCommitDiscussionNoteOptions struct {
 	Body      *string    `url:"body,omitempty" json:"body,omitempty"`
-	CreatedAt *time.Time `json:"created_at,omitempty"`
+	CreatedAt *time.Time `url:"created_at,omitempty" json:"created_at,omitempty"`
 }
 
 // AddCommitDiscussionNote creates a new discussion to a single project commit.
@@ -954,7 +1001,9 @@ func (s *DiscussionsService) AddCommitDiscussionNote(pid interface{}, commit str
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/repository/commits/%s/discussions/%s/notes",
-		url.QueryEscape(project), commit, discussion)
+		url.QueryEscape(project),
+		commit,
+		discussion)
 
 	req, err := s.client.NewRequest("POST", u, opt, options)
 	if err != nil {
@@ -977,7 +1026,7 @@ func (s *DiscussionsService) AddCommitDiscussionNote(pid interface{}, commit str
 // https://docs.gitlab.com/ce/api/discussions.html#modify-existing-commit-discussion-note
 type UpdateCommitDiscussionNoteOptions struct {
 	Body      *string    `url:"body,omitempty" json:"body,omitempty"`
-	CreatedAt *time.Time `json:"created_at,omitempty"`
+	CreatedAt *time.Time `url:"created_at,omitempty" json:"created_at,omitempty"`
 }
 
 // UpdateCommitDiscussionNote modifies existing discussion of an commit.
@@ -990,7 +1039,10 @@ func (s *DiscussionsService) UpdateCommitDiscussionNote(pid interface{}, commit 
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/repository/commits/%s/discussions/%s/notes/%d",
-		url.QueryEscape(project), commit, discussion, note)
+		url.QueryEscape(project),
+		commit,
+		discussion,
+		note)
 
 	req, err := s.client.NewRequest("PUT", u, opt, options)
 	if err != nil {
@@ -1016,7 +1068,10 @@ func (s *DiscussionsService) DeleteCommitDiscussionNote(pid interface{}, commit 
 		return nil, err
 	}
 	u := fmt.Sprintf("projects/%s/repository/commits/%s/discussions/%s/notes/%d",
-		url.QueryEscape(project), commit, discussion, note)
+		url.QueryEscape(project),
+		commit,
+		discussion,
+		note)
 
 	req, err := s.client.NewRequest("DELETE", u, nil, options)
 	if err != nil {

--- a/discussions.go
+++ b/discussions.go
@@ -37,6 +37,7 @@ type Discussion struct {
 	ID         int    `json:"id"`
 	Body       string `json:"body"`
 	Attachment string `json:"attachment"`
+	Type       string `json:"type,omitempty"`
 	Title      string `json:"title"`
 	FileName   string `json:"file_name"`
 	Author     struct {
@@ -49,13 +50,25 @@ type Discussion struct {
 		AvatarURL string     `json:"avatar_url"`
 		WebURL    string     `json:"web_url"`
 	} `json:"author"`
-	System             bool       `json:"system"`
-	ExpiresAt          *time.Time `json:"expires_at"`
-	UpdatedAt          *time.Time `json:"updated_at"`
-	CreatedAt          *time.Time `json:"created_at"`
-	DiscussionableID   int        `json:"noteable_id"`
-	DiscussionableType string     `json:"noteable_type"`
-	DiscussionableIID  int        `json:"noteable_iid"`
+	System       bool       `json:"system"`
+	ExpiresAt    *time.Time `json:"expires_at"`
+	UpdatedAt    *time.Time `json:"updated_at"`
+	CreatedAt    *time.Time `json:"created_at"`
+	NoteableID   int        `json:"noteable_id"`
+	NoteableType string     `json:"noteable_type"`
+	Resolvable   bool       `json:"resolvable"`
+	Resolved     bool       `json:"resolved"`
+	ResolvedBy   struct {
+		ID        int        `json:"id"`
+		Username  string     `json:"username"`
+		Email     string     `json:"email"`
+		Name      string     `json:"name"`
+		State     string     `json:"state"`
+		CreatedAt *time.Time `json:"created_at"`
+		AvatarURL string     `json:"avatar_url"`
+		WebURL    string     `json:"web_url"`
+	} `json:"resolved_by"`
+	NoteableIID int `json:"noteable_iid"`
 }
 
 func (n Discussion) String() string {

--- a/discussions.go
+++ b/discussions.go
@@ -216,7 +216,7 @@ func (s *DiscussionsService) DeleteIssueDiscussionNote(pid interface{}, issue in
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/issues/%d/discussions/%s/notes/%d", url.QueryEscape(project), issue, discussion)
+	u := fmt.Sprintf("projects/%s/issues/%d/discussions/%s/notes/%d", url.QueryEscape(project), issue, discussion, note)
 
 	req, err := s.client.NewRequest("DELETE", u, nil, options)
 	if err != nil {
@@ -397,7 +397,7 @@ func (s *DiscussionsService) DeleteSnippetDiscussionNote(pid interface{}, snippe
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/snippets/%d/discussions/%s/notes/%d", url.QueryEscape(project), snippet, discussion)
+	u := fmt.Sprintf("projects/%s/snippets/%d/discussions/%s/notes/%d", url.QueryEscape(project), snippet, discussion, note)
 
 	req, err := s.client.NewRequest("DELETE", u, nil, options)
 	if err != nil {
@@ -579,7 +579,7 @@ func (s *DiscussionsService) DeleteEpicDiscussionNote(gid interface{}, epic int,
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("groups/%s/epics/%d/discussions/%s/notes/%d", url.QueryEscape(project), epic, discussion)
+	u := fmt.Sprintf("groups/%s/epics/%d/discussions/%s/notes/%d", url.QueryEscape(project), epic, discussion, note)
 
 	req, err := s.client.NewRequest("DELETE", u, nil, options)
 	if err != nil {
@@ -625,7 +625,7 @@ func (s *DiscussionsService) ListMergeRequestDiscussions(pid interface{}, mergeR
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/discussions.html#get-single-merge-request-discussion
-func (s *DiscussionsService) GetMergeRequestDiscussion(pid interface{}, mergeRequest, discussion string, options ...OptionFunc) (*Discussion, *Response, error) {
+func (s *DiscussionsService) GetMergeRequestDiscussion(pid interface{}, mergeRequest int, discussion string, options ...OptionFunc) (*Discussion, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
@@ -795,7 +795,7 @@ func (s *DiscussionsService) DeleteMergeRequestDiscussionNote(pid interface{}, m
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/merge_requests/%d/discussions/%s/notes/%d", url.QueryEscape(project), mergeRequest, discussion)
+	u := fmt.Sprintf("projects/%s/merge_requests/%d/discussions/%s/notes/%d", url.QueryEscape(project), mergeRequest, discussion, note)
 
 	req, err := s.client.NewRequest("DELETE", u, nil, options)
 	if err != nil {
@@ -818,7 +818,7 @@ type UpdateMergeRequestDiscussionOptions struct {
 // UpdateMergeRequestDiscussion modifies existing discussion of a merge request.
 //
 // https://docs.gitlab.com/ce/api/discussions.html#modify-existing-merge-request-discussion
-func (s *DiscussionsService) UpdateMergeRequestDiscussion(pid interface{}, mergeRequest, discussion string, opt *UpdateMergeRequestDiscussionOptions, options ...OptionFunc) (*Discussion, *Response, error) {
+func (s *DiscussionsService) UpdateMergeRequestDiscussion(pid interface{}, mergeRequest int, discussion string, opt *UpdateMergeRequestDiscussionOptions, options ...OptionFunc) (*Discussion, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
@@ -842,7 +842,7 @@ func (s *DiscussionsService) UpdateMergeRequestDiscussion(pid interface{}, merge
 // DeleteMergeRequestDiscussion deletes an existing discussion of a merge request.
 //
 // https://docs.gitlab.com/ce/api/discussions.html#delete-a-merge-request-discussion
-func (s *DiscussionsService) DeleteMergeRequestDiscussion(pid interface{}, mergeRequest, discussion string, options ...OptionFunc) (*Response, error) {
+func (s *DiscussionsService) DeleteMergeRequestDiscussion(pid interface{}, mergeRequest int, discussion string, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, err
@@ -1033,7 +1033,7 @@ func (s *DiscussionsService) DeleteCommitDiscussionNote(pid interface{}, commit 
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/repository/commits/%s/discussions/%s/notes/%d", url.QueryEscape(project), commit, discussion)
+	u := fmt.Sprintf("projects/%s/repository/commits/%s/discussions/%s/notes/%d", url.QueryEscape(project), commit, discussion, note)
 
 	req, err := s.client.NewRequest("DELETE", u, nil, options)
 	if err != nil {

--- a/gitlab.go
+++ b/gitlab.go
@@ -283,6 +283,7 @@ type Client struct {
 	CustomAttribute       *CustomAttributesService
 	DeployKeys            *DeployKeysService
 	Deployments           *DeploymentsService
+	Discussions           *DiscussionsService
 	Environments          *EnvironmentsService
 	Events                *EventsService
 	Features              *FeaturesService

--- a/gitlab.go
+++ b/gitlab.go
@@ -423,6 +423,7 @@ func newClient(httpClient *http.Client) *Client {
 	c.CustomAttribute = &CustomAttributesService{client: c}
 	c.DeployKeys = &DeployKeysService{client: c}
 	c.Deployments = &DeploymentsService{client: c}
+	c.Discussions = &DiscussionsService{client: c}
 	c.Environments = &EnvironmentsService{client: c}
 	c.Events = &EventsService{client: c}
 	c.Features = &FeaturesService{client: c}

--- a/notes.go
+++ b/notes.go
@@ -55,9 +55,23 @@ type Note struct {
 	CreatedAt    *time.Time `json:"created_at"`
 	NoteableID   int        `json:"noteable_id"`
 	NoteableType string     `json:"noteable_type"`
-	Resolvable   bool       `json:"resolvable"`
-	Resolved     bool       `json:"resolved"`
-	ResolvedBy   struct {
+	Position     struct {
+		BaseSHA      string `json:"base_sha"`
+		StartSHA     string `json:"start_sha"`
+		HeadSHA      string `json:"head_sha"`
+		PositionType string `json:"position_type"`
+		NewPath      string `json:"new_path,omitempty"`
+		OldPath      string `json:"old_path,omitempty"`
+		NewLine      int    `json:"new_line,omitempty"`
+		OldLine      int    `json:"old_line,omitempty"`
+		Width        int    `json:"width,omitempty"`
+		Height       int    `json:"height,omitempty"`
+		X            int    `json:"x,omitempty"`
+		Y            int    `json:"y,omitempty"`
+	} `json:"position,omitempty"`
+	Resolvable bool `json:"resolvable"`
+	Resolved   bool `json:"resolved"`
+	ResolvedBy struct {
 		ID        int        `json:"id"`
 		Username  string     `json:"username"`
 		Email     string     `json:"email"`

--- a/notes.go
+++ b/notes.go
@@ -40,33 +40,31 @@ type Note struct {
 	Title      string `json:"title"`
 	FileName   string `json:"file_name"`
 	Author     struct {
-		ID        int        `json:"id"`
-		Username  string     `json:"username"`
-		Email     string     `json:"email"`
-		Name      string     `json:"name"`
-		State     string     `json:"state"`
-		CreatedAt *time.Time `json:"created_at"`
-		AvatarURL string     `json:"avatar_url"`
-		WebURL    string     `json:"web_url"`
+		ID        int    `json:"id"`
+		Username  string `json:"username"`
+		Email     string `json:"email"`
+		Name      string `json:"name"`
+		State     string `json:"state"`
+		AvatarURL string `json:"avatar_url"`
+		WebURL    string `json:"web_url"`
 	} `json:"author"`
-	System       bool         `json:"system"`
-	ExpiresAt    *time.Time   `json:"expires_at"`
-	UpdatedAt    *time.Time   `json:"updated_at"`
-	CreatedAt    *time.Time   `json:"created_at"`
-	NoteableID   int          `json:"noteable_id"`
-	NoteableType string       `json:"noteable_type"`
-	Position     NotePosition `json:"position,omitempty"`
-	Resolvable   bool         `json:"resolvable"`
-	Resolved     bool         `json:"resolved"`
+	System       bool          `json:"system"`
+	ExpiresAt    *time.Time    `json:"expires_at"`
+	UpdatedAt    *time.Time    `json:"updated_at"`
+	CreatedAt    *time.Time    `json:"created_at"`
+	NoteableID   int           `json:"noteable_id"`
+	NoteableType string        `json:"noteable_type"`
+	Position     *NotePosition `json:"position"`
+	Resolvable   bool          `json:"resolvable"`
+	Resolved     bool          `json:"resolved"`
 	ResolvedBy   struct {
-		ID        int        `json:"id"`
-		Username  string     `json:"username"`
-		Email     string     `json:"email"`
-		Name      string     `json:"name"`
-		State     string     `json:"state"`
-		CreatedAt *time.Time `json:"created_at"`
-		AvatarURL string     `json:"avatar_url"`
-		WebURL    string     `json:"web_url"`
+		ID        int    `json:"id"`
+		Username  string `json:"username"`
+		Email     string `json:"email"`
+		Name      string `json:"name"`
+		State     string `json:"state"`
+		AvatarURL string `json:"avatar_url"`
+		WebURL    string `json:"web_url"`
 	} `json:"resolved_by"`
 	NoteableIID int `json:"noteable_iid"`
 }

--- a/notes.go
+++ b/notes.go
@@ -55,7 +55,19 @@ type Note struct {
 	CreatedAt    *time.Time `json:"created_at"`
 	NoteableID   int        `json:"noteable_id"`
 	NoteableType string     `json:"noteable_type"`
-	NoteableIID  int        `json:"noteable_iid"`
+	Resolvable   bool       `json:"resolvable"`
+	Resolved     bool       `json:"resolved"`
+	ResolvedBy   struct {
+		ID        int        `json:"id"`
+		Username  string     `json:"username"`
+		Email     string     `json:"email"`
+		Name      string     `json:"name"`
+		State     string     `json:"state"`
+		CreatedAt *time.Time `json:"created_at"`
+		AvatarURL string     `json:"avatar_url"`
+		WebURL    string     `json:"web_url"`
+	} `json:"resolved_by"`
+	NoteableIID int `json:"noteable_iid"`
 }
 
 func (n Note) String() string {

--- a/notes.go
+++ b/notes.go
@@ -49,29 +49,16 @@ type Note struct {
 		AvatarURL string     `json:"avatar_url"`
 		WebURL    string     `json:"web_url"`
 	} `json:"author"`
-	System       bool       `json:"system"`
-	ExpiresAt    *time.Time `json:"expires_at"`
-	UpdatedAt    *time.Time `json:"updated_at"`
-	CreatedAt    *time.Time `json:"created_at"`
-	NoteableID   int        `json:"noteable_id"`
-	NoteableType string     `json:"noteable_type"`
-	Position     struct {
-		BaseSHA      string `json:"base_sha"`
-		StartSHA     string `json:"start_sha"`
-		HeadSHA      string `json:"head_sha"`
-		PositionType string `json:"position_type"`
-		NewPath      string `json:"new_path,omitempty"`
-		OldPath      string `json:"old_path,omitempty"`
-		NewLine      int    `json:"new_line,omitempty"`
-		OldLine      int    `json:"old_line,omitempty"`
-		Width        int    `json:"width,omitempty"`
-		Height       int    `json:"height,omitempty"`
-		X            int    `json:"x,omitempty"`
-		Y            int    `json:"y,omitempty"`
-	} `json:"position,omitempty"`
-	Resolvable bool `json:"resolvable"`
-	Resolved   bool `json:"resolved"`
-	ResolvedBy struct {
+	System       bool         `json:"system"`
+	ExpiresAt    *time.Time   `json:"expires_at"`
+	UpdatedAt    *time.Time   `json:"updated_at"`
+	CreatedAt    *time.Time   `json:"created_at"`
+	NoteableID   int          `json:"noteable_id"`
+	NoteableType string       `json:"noteable_type"`
+	Position     NotePosition `json:"position,omitempty"`
+	Resolvable   bool         `json:"resolvable"`
+	Resolved     bool         `json:"resolved"`
+	ResolvedBy   struct {
 		ID        int        `json:"id"`
 		Username  string     `json:"username"`
 		Email     string     `json:"email"`
@@ -82,6 +69,22 @@ type Note struct {
 		WebURL    string     `json:"web_url"`
 	} `json:"resolved_by"`
 	NoteableIID int `json:"noteable_iid"`
+}
+
+// NotePosition represents the "position" attributes on a note
+type NotePosition struct {
+	BaseSHA      string `json:"base_sha"`
+	StartSHA     string `json:"start_sha"`
+	HeadSHA      string `json:"head_sha"`
+	PositionType string `json:"position_type"`
+	NewPath      string `json:"new_path,omitempty"`
+	NewLine      int    `json:"new_line,omitempty"`
+	OldPath      string `json:"old_path,omitempty"`
+	OldLine      int    `json:"old_line,omitempty"`
+	Width        int    `json:"width,omitempty"`
+	Height       int    `json:"height,omitempty"`
+	X            int    `json:"x,omitempty"`
+	Y            int    `json:"y,omitempty"`
 }
 
 func (n Note) String() string {


### PR DESCRIPTION
Mostly copy/paste from NotesService, except some field names are the same and some are additional for discussions in the Discussion type.

Signed-off-by: Sune Keller <absukl@almbrand.dk>