### PR TITLE
Update list of available access levels

### DIFF
--- a/gitlab.go
+++ b/gitlab.go
@@ -64,12 +64,12 @@ type AccessLevelValue int
 //
 // GitLab API docs: https://docs.gitlab.com/ce/permissions/permissions.html
 const (
-	NoPermissions        AccessLevelValue = 0
-	GuestPermissions     AccessLevelValue = 10
-	ReporterPermissions  AccessLevelValue = 20
-	DeveloperPermissions AccessLevelValue = 30
-	MasterPermissions    AccessLevelValue = 40
-	OwnerPermission      AccessLevelValue = 50
+	NoPermissions         AccessLevelValue = 0
+	GuestPermissions      AccessLevelValue = 10
+	ReporterPermissions   AccessLevelValue = 20
+	DeveloperPermissions  AccessLevelValue = 30
+	MaintainerPermissions AccessLevelValue = 40
+	OwnerPermissions      AccessLevelValue = 50
 )
 
 // BuildStateValue represents a GitLab build state.

--- a/gitlab.go
+++ b/gitlab.go
@@ -70,6 +70,10 @@ const (
 	DeveloperPermissions  AccessLevelValue = 30
 	MaintainerPermissions AccessLevelValue = 40
 	OwnerPermissions      AccessLevelValue = 50
+
+	// These are deprecated and should be removed in a future version
+	MasterPermissions     AccessLevelValue = 40
+	OwnerPermission       AccessLevelValue = 50
 )
 
 // BuildStateValue represents a GitLab build state.


### PR DESCRIPTION
Update list of available access levels:
- Change `OwnerPermission` to plural
- Rename `Master` to `Maintainer`, see https://about.gitlab.com/2018/06/22/gitlab-11-0-released/#master-role-renamed-to-maintainer  for more information

We might want to keep `MasterPermissions` a `OwnerPermission` for backwards compatibility.