### PR TITLE
Add support of filename, path and commit id to GetFileOptions

### DIFF
--- a/gitlab.go
+++ b/gitlab.go
@@ -72,8 +72,8 @@ const (
 	OwnerPermissions      AccessLevelValue = 50
 
 	// These are deprecated and should be removed in a future version
-	MasterPermissions     AccessLevelValue = 40
-	OwnerPermission       AccessLevelValue = 50
+	MasterPermissions AccessLevelValue = 40
+	OwnerPermission   AccessLevelValue = 50
 )
 
 // BuildStateValue represents a GitLab build state.

--- a/repository_files.go
+++ b/repository_files.go
@@ -54,6 +54,9 @@ func (r File) String() string {
 // https://docs.gitlab.com/ce/api/repository_files.html#get-file-from-repository
 type GetFileOptions struct {
 	Ref *string `url:"ref,omitempty" json:"ref,omitempty"`
+	FileName *string `url:"file_name,omitempty" json:"file_name,omitempty"`
+	FilePath *string `url:"file_path,omitempty" json:"file_path,omitempty"`
+	CommitID *string `url:"commit_id,omitempty" json:"commit_id,omitempty"`
 }
 
 // GetFile allows you to receive information about a file in repository like

--- a/repository_files.go
+++ b/repository_files.go
@@ -53,7 +53,7 @@ func (r File) String() string {
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/repository_files.html#get-file-from-repository
 type GetFileOptions struct {
-	Ref *string `url:"ref,omitempty" json:"ref,omitempty"`
+	Ref      *string `url:"ref,omitempty" json:"ref,omitempty"`
 	FileName *string `url:"file_name,omitempty" json:"file_name,omitempty"`
 	FilePath *string `url:"file_path,omitempty" json:"file_path,omitempty"`
 	CommitID *string `url:"commit_id,omitempty" json:"commit_id,omitempty"`

--- a/tags_test.go
+++ b/tags_test.go
@@ -16,7 +16,7 @@ func TestListTags(t *testing.T) {
 		fmt.Fprint(w, `[{"name": "1.0.0"},{"name": "1.0.1"}]`)
 	})
 
-	opt := &ListTagsOptions{ListOptions: ListOptions{Page:2, PerPage: 3}}
+	opt := &ListTagsOptions{ListOptions: ListOptions{Page: 2, PerPage: 3}}
 
 	tags, _, err := client.Tags.ListTags(1, opt)
 	if err != nil {


### PR DESCRIPTION
This change will give the ability to get repository files by name and commit sha.
Detailed info about this options available at [GitLab API](https://docs.gitlab.com/ee/api/repository_files.html#get-file-from-repository).