### PR TITLE
fix godoc for RepositoriesService.RawFileContent

### DIFF
--- a/repositories.go
+++ b/repositories.go
@@ -81,12 +81,12 @@ func (s *RepositoriesService) ListTree(pid interface{}, opt *ListTreeOptions, op
 	return t, resp, err
 }
 
-// RawFileContent gets information about blob in repository like size and
-// content.  Note that blob content is Base64 encoded.
+// GetBlob gets information about blob in repository like size and content.
+// Note that blob content is Base64 encoded.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/repositories.html#get-a-blob-from-repository
-func (s *RepositoriesService) RawFileContent(pid interface{}, sha string, options ...OptionFunc) ([]byte, *Response, error) {
+func (s *RepositoriesService) GetBlob(pid interface{}, sha string, options ...OptionFunc) ([]byte, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err

--- a/repositories.go
+++ b/repositories.go
@@ -81,10 +81,11 @@ func (s *RepositoriesService) ListTree(pid interface{}, opt *ListTreeOptions, op
 	return t, resp, err
 }
 
-// RawFileContent gets the raw file contents for a file by commit SHA and path
+// RawFileContent gets information about blob in repository like size and
+// content.  Note that blob content is Base64 encoded.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/repositories.html#raw-file-content
+// https://docs.gitlab.com/ce/api/repositories.html#get-a-blob-from-repository
 func (s *RepositoriesService) RawFileContent(pid interface{}, sha string, options ...OptionFunc) ([]byte, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {


### PR DESCRIPTION
As an aside, would it be more clear if `RawFileContent` was named `Blob` instead?