### PR TITLE
Fix inconsistently cased pipeline sha

### DIFF
--- a/pipelines.go
+++ b/pipelines.go
@@ -92,7 +92,7 @@ type ListProjectPipelinesOptions struct {
 	Scope      *string          `url:"scope,omitempty" json:"scope,omitempty"`
 	Status     *BuildStateValue `url:"status,omitempty" json:"status,omitempty"`
 	Ref        *string          `url:"ref,omitempty" json:"ref,omitempty"`
-	SHA        *string          `url:"sha,omitempty" json:"sha,omitempty"`
+	Sha        *string          `url:"sha,omitempty" json:"sha,omitempty"`
 	YamlErrors *bool            `url:"yaml_errors,omitempty" json:"yaml_errors,omitempty"`
 	Name       *string          `url:"name,omitempty" json:"name,omitempty"`
 	Username   *string          `url:"username,omitempty" json:"username,omitempty"`


### PR DESCRIPTION
Added in https://github.com/xanzy/go-gitlab/pull/493 the capitalization of `SHA` is inconsistent with the rest of the Pipelines methods.

There is also inconsistency in other files `Sha` appears to be used more frequently. I can open a more comprehensive merge request to update this elsewhere if desired. Both this and a sweeping change would be a breaking change.