### PR TITLE
Consistently use `SHA`

### DIFF
--- a/deployments.go
+++ b/deployments.go
@@ -34,7 +34,7 @@ type Deployment struct {
 	ID          int          `json:"id"`
 	IID         int          `json:"iid"`
 	Ref         string       `json:"ref"`
-	Sha         string       `json:"sha"`
+	SHA         string       `json:"sha"`
 	CreatedAt   *time.Time   `json:"created_at"`
 	User        *ProjectUser `json:"user"`
 	Environment *Environment `json:"environment"`
@@ -54,7 +54,7 @@ type Deployment struct {
 		Commit     *Commit    `json:"commit"`
 		Pipeline   struct {
 			ID     int    `json:"id"`
-			Sha    string `json:"sha"`
+			SHA    string `json:"sha"`
 			Ref    string `json:"ref"`
 			Status string `json:"status"`
 		} `json:"pipeline"`

--- a/event_parsing_test.go
+++ b/event_parsing_test.go
@@ -1236,7 +1236,7 @@ func TestParseBuildHook(t *testing.T) {
 		t.Errorf("BuildAllowFailure is %v, want %v", event.BuildAllowFailure, false)
 	}
 
-	if event.Commit.Sha != "2293ada6b400935a1378653304eaf6221e0fdb8f" {
-		t.Errorf("Commit SHA is %v, want %v", event.Commit.Sha, "2293ada6b400935a1378653304eaf6221e0fdb8f")
+	if event.Commit.SHA != "2293ada6b400935a1378653304eaf6221e0fdb8f" {
+		t.Errorf("Commit SHA is %v, want %v", event.Commit.SHA, "2293ada6b400935a1378653304eaf6221e0fdb8f")
 	}
 }

--- a/event_types.go
+++ b/event_types.go
@@ -29,7 +29,7 @@ type PushEvent struct {
 	Before      string `json:"before"`
 	After       string `json:"after"`
 	Ref         string `json:"ref"`
-	CheckoutSha string `json:"checkout_sha"`
+	CheckoutSHA string `json:"checkout_sha"`
 	UserID      int    `json:"user_id"`
 	UserName    string `json:"user_name"`
 	UserEmail   string `json:"user_email"`
@@ -77,7 +77,7 @@ type TagEvent struct {
 	Before      string `json:"before"`
 	After       string `json:"after"`
 	Ref         string `json:"ref"`
-	CheckoutSha string `json:"checkout_sha"`
+	CheckoutSHA string `json:"checkout_sha"`
 	UserID      int    `json:"user_id"`
 	UserName    string `json:"user_name"`
 	UserAvatar  string `json:"user_avatar"`
@@ -290,12 +290,12 @@ type MergeCommentEvent struct {
 		} `json:"merge_params"`
 		MergeWhenPipelineSucceeds bool        `json:"merge_when_pipeline_succeeds"`
 		MergeUserID               int         `json:"merge_user_id"`
-		MergeCommitSha            string      `json:"merge_commit_sha"`
+		MergeCommitSHA            string      `json:"merge_commit_sha"`
 		DeletedAt                 string      `json:"deleted_at"`
-		InProgressMergeCommitSha  string      `json:"in_progress_merge_commit_sha"`
+		InProgressMergeCommitSHA  string      `json:"in_progress_merge_commit_sha"`
 		LockVersion               int         `json:"lock_version"`
 		ApprovalsBeforeMerge      string      `json:"approvals_before_merge"`
-		RebaseCommitSha           string      `json:"rebase_commit_sha"`
+		RebaseCommitSHA           string      `json:"rebase_commit_sha"`
 		TimeEstimate              int         `json:"time_estimate"`
 		Squash                    bool        `json:"squash"`
 		LastEditedAt              string      `json:"last_edited_at"`
@@ -456,11 +456,11 @@ type MergeEvent struct {
 		} `json:"merge_params"`
 		MergeWhenBuildSucceeds   bool        `json:"merge_when_build_succeeds"`
 		MergeUserID              int         `json:"merge_user_id"`
-		MergeCommitSha           string      `json:"merge_commit_sha"`
+		MergeCommitSHA           string      `json:"merge_commit_sha"`
 		DeletedAt                string      `json:"deleted_at"`
 		ApprovalsBeforeMerge     string      `json:"approvals_before_merge"`
-		RebaseCommitSha          string      `json:"rebase_commit_sha"`
-		InProgressMergeCommitSha string      `json:"in_progress_merge_commit_sha"`
+		RebaseCommitSHA          string      `json:"rebase_commit_sha"`
+		InProgressMergeCommitSHA string      `json:"in_progress_merge_commit_sha"`
 		LockVersion              int         `json:"lock_version"`
 		TimeEstimate             int         `json:"time_estimate"`
 		Source                   *Repository `json:"source"`
@@ -562,8 +562,8 @@ type PipelineEvent struct {
 		ID         int      `json:"id"`
 		Ref        string   `json:"ref"`
 		Tag        bool     `json:"tag"`
-		Sha        string   `json:"sha"`
-		BeforeSha  string   `json:"before_sha"`
+		SHA        string   `json:"sha"`
+		BeforeSHA  string   `json:"before_sha"`
 		Status     string   `json:"status"`
 		Stages     []string `json:"stages"`
 		CreatedAt  string   `json:"created_at"`
@@ -638,8 +638,8 @@ type BuildEvent struct {
 	ObjectKind        string  `json:"object_kind"`
 	Ref               string  `json:"ref"`
 	Tag               bool    `json:"tag"`
-	BeforeSha         string  `json:"before_sha"`
-	Sha               string  `json:"sha"`
+	BeforeSHA         string  `json:"before_sha"`
+	SHA               string  `json:"sha"`
 	BuildID           int     `json:"build_id"`
 	BuildName         string  `json:"build_name"`
 	BuildStage        string  `json:"build_stage"`
@@ -657,7 +657,7 @@ type BuildEvent struct {
 	} `json:"user"`
 	Commit struct {
 		ID          int    `json:"id"`
-		Sha         string `json:"sha"`
+		SHA         string `json:"sha"`
 		Message     string `json:"message"`
 		AuthorName  string `json:"author_name"`
 		AuthorEmail string `json:"author_email"`

--- a/merge_requests.go
+++ b/merge_requests.go
@@ -571,7 +571,7 @@ type AcceptMergeRequestOptions struct {
 	MergeCommitMessage        *string `url:"merge_commit_message,omitempty" json:"merge_commit_message,omitempty"`
 	ShouldRemoveSourceBranch  *bool   `url:"should_remove_source_branch,omitempty" json:"should_remove_source_branch,omitempty"`
 	MergeWhenPipelineSucceeds *bool   `url:"merge_when_pipeline_succeeds,omitempty" json:"merge_when_pipeline_succeeds,omitempty"`
-	Sha                       *string `url:"sha,omitempty" json:"sha,omitempty"`
+	SHA                       *string `url:"sha,omitempty" json:"sha,omitempty"`
 }
 
 // AcceptMergeRequest merges changes submitted with MR using this API. If merge

--- a/pipeline_schedules.go
+++ b/pipeline_schedules.go
@@ -47,7 +47,7 @@ type PipelineSchedule struct {
 	Owner        *User      `json:"owner"`
 	LastPipeline struct {
 		ID     int    `json:"id"`
-		Sha    string `json:"sha"`
+		SHA    string `json:"sha"`
 		Ref    string `json:"ref"`
 		Status string `json:"status"`
 	} `json:"last_pipeline"`

--- a/pipelines.go
+++ b/pipelines.go
@@ -45,8 +45,8 @@ type Pipeline struct {
 	ID         int    `json:"id"`
 	Status     string `json:"status"`
 	Ref        string `json:"ref"`
-	Sha        string `json:"sha"`
-	BeforeSha  string `json:"before_sha"`
+	SHA        string `json:"sha"`
+	BeforeSHA  string `json:"before_sha"`
 	Tag        bool   `json:"tag"`
 	YamlErrors string `json:"yaml_errors"`
 	User       struct {
@@ -77,7 +77,7 @@ type PipelineList []struct {
 	ID     int    `json:"id"`
 	Status string `json:"status"`
 	Ref    string `json:"ref"`
-	Sha    string `json:"sha"`
+	SHA    string `json:"sha"`
 }
 
 func (i PipelineList) String() string {

--- a/todos.go
+++ b/todos.go
@@ -69,10 +69,10 @@ type TodoTarget struct {
 	// Only available for type MergeRequest
 	ApprovalsBeforeMerge      bool   `json:"approvals_before_merge"`
 	ForceRemoveSourceBranch   bool   `json:"force_remove_source_branch"`
-	MergeCommitSha            string `json:"merge_commit_sha"`
+	MergeCommitSHA            string `json:"merge_commit_sha"`
 	MergeWhenPipelineSucceeds bool   `json:"merge_when_pipeline_succeeds"`
 	MergeStatus               string `json:"merge_status"`
-	Sha                       string `json:"sha"`
+	SHA                       string `json:"sha"`
 	ShouldRemoveSourceBranch  bool   `json:"should_remove_source_branch"`
 	SourceBranch              string `json:"source_branch"`
 	SourceProjectID           int    `json:"source_project_id"`


### PR DESCRIPTION
Corrected and complete version of https://github.com/xanzy/go-gitlab/pull/535

`SHA` is inconsistently called `Sha` in a number of places, which makes using `go-gitlab` inconsistent.

This merge request replaces all references to `Sha` with `SHA` for consistency. This is definitely a breaking change.