### PR TITLE
Set request.GetBody to fix redirect issues

### DIFF
--- a/gitlab.go
+++ b/gitlab.go
@@ -562,6 +562,9 @@ func (c *Client) NewRequest(method, path string, opt interface{}, options []Opti
 
 		u.RawQuery = ""
 		req.Body = ioutil.NopCloser(bodyReader)
+		req.GetBody = func() (io.ReadCloser, error) {
+			return ioutil.NopCloser(bodyReader), nil
+		}
 		req.ContentLength = int64(bodyReader.Len())
 		req.Header.Set("Content-Type", "application/json")
 	}


### PR DESCRIPTION
Gitlab uses the 307 status code to indicate a redirect. Since Go 1.8
that status code is supported by the HTTP package but it requires an
additional field (`GetBody`) to be set to enable resending the body.

Fixes #523 