### PR TITLE
Fix func of GetProject by namespace

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -322,7 +322,7 @@ func (s *ProjectsService) GetProject(pid interface{}, options ...OptionFunc) (*P
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s", url.QueryEscape(project))
+	u := fmt.Sprintf("projects/%s", url.PathEscape(project))
 
 	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {


### PR DESCRIPTION
#https://docs.gitlab.com/ce/api/projects.html#get-single-project
GET /projects/:id    The ID or URL-encoded path of the project

I found it didn't work with v4.


