### PR TITLE
[Jobs] Pass job query string parameter to opt{} instead of static definition

### DIFF
--- a/jobs.go
+++ b/jobs.go
@@ -188,7 +188,13 @@ func (s *JobsService) DownloadArtifactsFile(pid interface{}, refName string, job
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/jobs/artifacts/%s/download?job=%s", url.QueryEscape(project), refName, job)
+
+    var q struct {
+        Job string `url:"job,omitempty" json:"job,omitempty"`
+    }
+    q.Job = job
+
+	u := fmt.Sprintf("projects/%s/jobs/artifacts/%s/download", url.QueryEscape(project), refName)
 
 	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {

--- a/jobs.go
+++ b/jobs.go
@@ -178,25 +178,26 @@ func (s *JobsService) GetJobArtifacts(pid interface{}, jobID int, options ...Opt
 	return artifactsBuf, resp, err
 }
 
+// DownloadArtifactsFileOptions represents the available DownloadArtifactsFile() options.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/jobs.html#download-the-artifacts-file
+type DownloadArtifactsFileOptions struct {
+	Job *string `url:"job,omitempty" json:"job,omitempty"`
+}
+
 // DownloadArtifactsFile download the artifacts file from the given
 // reference name and job provided the job finished successfully.
 //
-// GitLab API docs:
-// https://docs.gitlab.com/ce/api/jobs.html#download-the-artifacts-file
-func (s *JobsService) DownloadArtifactsFile(pid interface{}, refName string, job string, options ...OptionFunc) (io.Reader, *Response, error) {
+// GitLab API docs: https://docs.gitlab.com/ce/api/jobs.html#download-the-artifacts-file
+func (s *JobsService) DownloadArtifactsFile(pid interface{}, refName string, opt *DownloadArtifactsFileOptions, options ...OptionFunc) (io.Reader, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 
-    var q struct {
-        Job string `url:"job,omitempty" json:"job,omitempty"`
-    }
-    q.Job = job
-
 	u := fmt.Sprintf("projects/%s/jobs/artifacts/%s/download", url.QueryEscape(project), refName)
 
-	req, err := s.client.NewRequest("GET", u, q, options)
+	req, err := s.client.NewRequest("GET", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/jobs.go
+++ b/jobs.go
@@ -178,23 +178,25 @@ func (s *JobsService) GetJobArtifacts(pid interface{}, jobID int, options ...Opt
 	return artifactsBuf, resp, err
 }
 
-// DownloadArtifactsFileOptions represents the available DownloadArtifactsFile() options.
+// DownloadArtifactsFileOptions represents the available DownloadArtifactsFile()
+// options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/jobs.html#download-the-artifacts-file
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/jobs.html#download-the-artifacts-file
 type DownloadArtifactsFileOptions struct {
-	Job *string `url:"job,omitempty" json:"job,omitempty"`
+	Job *string `url:"job" json:"job"`
 }
 
 // DownloadArtifactsFile download the artifacts file from the given
 // reference name and job provided the job finished successfully.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/jobs.html#download-the-artifacts-file
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/jobs.html#download-the-artifacts-file
 func (s *JobsService) DownloadArtifactsFile(pid interface{}, refName string, opt *DownloadArtifactsFileOptions, options ...OptionFunc) (io.Reader, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
-
 	u := fmt.Sprintf("projects/%s/jobs/artifacts/%s/download", url.QueryEscape(project), refName)
 
 	req, err := s.client.NewRequest("GET", u, opt, options)

--- a/jobs.go
+++ b/jobs.go
@@ -196,7 +196,7 @@ func (s *JobsService) DownloadArtifactsFile(pid interface{}, refName string, job
 
 	u := fmt.Sprintf("projects/%s/jobs/artifacts/%s/download", url.QueryEscape(project), refName)
 
-	req, err := s.client.NewRequest("GET", u, nil, options)
+	req, err := s.client.NewRequest("GET", u, q, options)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Hey,

**The issue:**
I was getting an error 404 from gitlab on every `DownloadArtifactsFile` call (https://docs.gitlab.com/11.6/ee/api/jobs.html#download-the-artifacts-archive)
`api/v4/projects/345/jobs/artifacts/master/download?job=build: 404 {error: 404 Not Found}`

**Solving the issue**
Job query string parameter was not passing "dynamically" to the "request builder".


