### PR TITLE
Update service jira: fix JiraIssueTransitionID type from string to int

### DIFF
--- a/services.go
+++ b/services.go
@@ -393,7 +393,7 @@ type JiraServiceProperties struct {
 	ProjectKey            *string `url:"project_key,omitempty" json:"project_key,omitempty" `
 	Username              *string `url:"username,omitempty" json:"username,omitempty" `
 	Password              *string `url:"password,omitempty" json:"password,omitempty" `
-	JiraIssueTransitionID *string `url:"jira_issue_transition_id,omitempty" json:"jira_issue_transition_id,omitempty"`
+	JiraIssueTransitionID *int    `url:"jira_issue_transition_id,omitempty" json:"jira_issue_transition_id,omitempty"`
 }
 
 // GetJiraService gets Jira service settings for a project.

--- a/services_test.go
+++ b/services_test.go
@@ -141,7 +141,7 @@ func TestSetJiraService(t *testing.T) {
 		ProjectKey:            String("as"),
 		Username:              String("aas"),
 		Password:              String("asd"),
-		JiraIssueTransitionID: String("asd"),
+		JiraIssueTransitionID: Int(2),
 	}
 
 	_, err := client.Services.SetJiraService(1, opt)


### PR DESCRIPTION
Hi there,

This is a tiny fix for the JIRA service.

JiraIssueTransitionID parameter is currently a string when it should be an int, as mentioned in the [doc](https://docs.gitlab.com/ce/api/services.html#jira).

This currently creates error when unmarshalling the Json into the Go struct:
`json: cannot unmarshal number into Go struct field JiraServiceProperties.jira_issue_transition_id of type string`

Thanks,