### PR TITLE
add WIP to ListProjectMergeRequestOptions as well

### DIFF
--- a/merge_requests.go
+++ b/merge_requests.go
@@ -271,6 +271,7 @@ type ListProjectMergeRequestsOptions struct {
 	SourceBranch    *string    `url:"source_branch,omitempty" json:"source_branch,omitempty"`
 	TargetBranch    *string    `url:"target_branch,omitempty" json:"target_branch,omitempty"`
 	Search          *string    `url:"search,omitempty" json:"search,omitempty"`
+	WIP             *string    `url:"wip,omitempty" json:"wip,omitempty"`
 }
 
 // ListProjectMergeRequests gets all merge requests for this project.


### PR DESCRIPTION
Missed one on my last PR.  WIP is also on List Project Merge Requests but In is not https://docs.gitlab.com/ce/api/merge_requests.html#list-project-merge-requests.  I double checked that neither are on List Group Merge Requests https://docs.gitlab.com/ce/api/merge_requests.html#list-group-merge-requests