### PR TITLE
Add mirror related fields to Project struct

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -82,6 +82,11 @@ type Project struct {
 	RequestAccessEnabled                      bool              `json:"request_access_enabled"`
 	MergeMethod                               MergeMethodValue  `json:"merge_method"`
 	ForkedFromProject                         *ForkParent       `json:"forked_from_project"`
+	Mirror                                    bool              `json:"mirror"`
+	MirrorUserID                              int               `json:"mirror_user_id"`
+	MirrorTriggerBuilds                       bool              `json:"mirror_trigger_builds"`
+	OnlyMirrorProtectedBranches               bool              `json:"only_mirror_protected_branches"`
+	MirrorOverwritesDivergedBranches          bool              `json:"mirror_overwrites_diverged_branches"`
 	SharedWithGroups                          []struct {
 		GroupID          int    `json:"group_id"`
 		GroupName        string `json:"group_name"`


### PR DESCRIPTION
The [official documentation](https://docs.gitlab.com/ee/api/projects.html#get-single-project) doesn't seem to be up-to-date so they're not shown in their example but we can do a check ourselves:

```console
$ curl -s -H "Private-Token: <gitlab_token>" "https://gitlab.com/api/v4/projects/gnachman%2Fiterm2" | jq .
{
  ...
  "mirror": true,
  "mirror_user_id": 55954,
  "mirror_trigger_builds": false,
  "only_mirror_protected_branches": null,
  "mirror_overwrites_diverged_branches": null,
  ...
}
```