### PR TITLE
Add GetProjectOptions to support additional attributes

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -320,19 +320,28 @@ func (s *ProjectsService) GetProjectLanguages(pid interface{}, options ...Option
 	return p, resp, err
 }
 
+// GetProjectOptions represents the available GetProject() options.
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/projects.html#get-single-project
+type GetProjectOptions struct {
+	Statistics           *bool `url:"statistics,omitempty" json:"statistics,omitempty"`
+	License              *bool `url:"license,omitempty" json:"license,omitempty"`
+	WithCustomAttributes *bool `url:"with_custom_attributes,omitempty" json:"with_custom_attributes,omitempty"`
+}
+
 // GetProject gets a specific project, identified by project ID or
 // NAMESPACE/PROJECT_NAME, which is owned by the authenticated user.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/projects.html#get-single-project
-func (s *ProjectsService) GetProject(pid interface{}, options ...OptionFunc) (*Project, *Response, error) {
+func (s *ProjectsService) GetProject(pid interface{}, opt *GetProjectOptions, options ...OptionFunc) (*Project, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("GET", u, nil, options)
+	req, err := s.client.NewRequest("GET", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/projects_test.go
+++ b/projects_test.go
@@ -194,7 +194,7 @@ func TestGetProjectByID(t *testing.T) {
 	})
 	want := &Project{ID: 1}
 
-	project, _, err := client.Projects.GetProject(1)
+	project, _, err := client.Projects.GetProject(1, nil)
 	if err != nil {
 		t.Fatalf("Projects.GetProject returns an error: %v", err)
 	}
@@ -215,7 +215,43 @@ func TestGetProjectByName(t *testing.T) {
 	})
 	want := &Project{ID: 1}
 
-	project, _, err := client.Projects.GetProject("namespace/name")
+	project, _, err := client.Projects.GetProject("namespace/name", nil)
+	if err != nil {
+		t.Fatalf("Projects.GetProject returns an error: %v", err)
+	}
+
+	if !reflect.DeepEqual(want, project) {
+		t.Errorf("Projects.GetProject returned %+v, want %+v", project, want)
+	}
+}
+
+func TestGetProjectWithOptions(t *testing.T) {
+	mux, server, client := setup()
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v4/projects/1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{
+			"id":1,
+			"statistics": {
+				"commit_count": 37,
+				"storage_size": 1038090,
+				"repository_size": 1038090,
+				"lfs_objects_size": 0,
+				"job_artifacts_size": 0
+			}}`)
+	})
+	want := &Project{ID: 1, Statistics: &ProjectStatistics{
+		CommitCount: 37,
+		StorageStatistics: StorageStatistics{
+			StorageSize:      1038090,
+			RepositorySize:   1038090,
+			LfsObjectsSize:   0,
+			JobArtifactsSize: 0,
+		},
+	}}
+
+	project, _, err := client.Projects.GetProject(1, &GetProjectOptions{Statistics: Bool(true)})
 	if err != nil {
 		t.Fatalf("Projects.GetProject returns an error: %v", err)
 	}
@@ -373,10 +409,10 @@ func TestGetApprovalConfiguration(t *testing.T) {
 	}
 
 	want := &ProjectApprovals{
-		Approvers:            []*MergeRequestApproverUser{},
-		ApproverGroups:       []*MergeRequestApproverGroup{},
-		ApprovalsBeforeMerge: 3,
-		ResetApprovalsOnPush: false,
+		Approvers:                                 []*MergeRequestApproverUser{},
+		ApproverGroups:                            []*MergeRequestApproverGroup{},
+		ApprovalsBeforeMerge:                      3,
+		ResetApprovalsOnPush:                      false,
 		DisableOverridingApproversPerMergeRequest: false,
 	}
 
@@ -411,10 +447,10 @@ func TestChangeApprovalConfiguration(t *testing.T) {
 	}
 
 	want := &ProjectApprovals{
-		Approvers:            []*MergeRequestApproverUser{},
-		ApproverGroups:       []*MergeRequestApproverGroup{},
-		ApprovalsBeforeMerge: 3,
-		ResetApprovalsOnPush: false,
+		Approvers:                                 []*MergeRequestApproverUser{},
+		ApproverGroups:                            []*MergeRequestApproverGroup{},
+		ApprovalsBeforeMerge:                      3,
+		ResetApprovalsOnPush:                      false,
 		DisableOverridingApproversPerMergeRequest: false,
 	}
 


### PR DESCRIPTION
This PR adds support for specifying additional attributes to the `GetProject` method,  such as to include project statistics in the response.

Docs: https://docs.gitlab.com/ce/api/projects.html#get-single-project