### PR TITLE
Added support for job events.

### DIFF
--- a/event_parsing.go
+++ b/event_parsing.go
@@ -13,6 +13,7 @@ type EventType string
 const (
 	EventTypeBuild        EventType = "Build Hook"
 	EventTypeIssue        EventType = "Issue Hook"
+	EventTypeJob          EventType = "Job Hook"
 	EventTypeMergeRequest EventType = "Merge Request Hook"
 	EventTypeNote         EventType = "Note Hook"
 	EventTypePipeline     EventType = "Pipeline Hook"
@@ -68,6 +69,8 @@ func ParseWebhook(eventType EventType, payload []byte) (event interface{}, err e
 		event = &BuildEvent{}
 	case EventTypeIssue:
 		event = &IssueEvent{}
+	case EventTypeJob:
+		event = &JobEvent{}
 	case EventTypeMergeRequest:
 		event = &MergeEvent{}
 	case EventTypePipeline:

--- a/event_types.go
+++ b/event_types.go
@@ -172,8 +172,8 @@ type JobEvent struct {
 	ObjectKind        string  `json:"object_kind"`
 	Ref               string  `json:"ref"`
 	Tag               bool    `json:"tag"`
-	BeforeSha         string  `json:"before_sha"`
-	Sha               string  `json:"sha"`
+	BeforeSHA         string  `json:"before_sha"`
+	SHA               string  `json:"sha"`
 	BuildID           int     `json:"build_id"`
 	BuildName         string  `json:"build_name"`
 	BuildStage        string  `json:"build_stage"`

--- a/event_types.go
+++ b/event_types.go
@@ -163,6 +163,47 @@ type IssueEvent struct {
 	} `json:"assignee"`
 }
 
+// JobEvent represents a job event.
+//
+// GitLab API docs:
+// TODO: link to docs instead of src once they are published.
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/master/lib/gitlab/data_builder/build.rb
+type JobEvent struct {
+	ObjectKind        string  `json:"object_kind"`
+	Ref               string  `json:"ref"`
+	Tag               bool    `json:"tag"`
+	BeforeSha         string  `json:"before_sha"`
+	Sha               string  `json:"sha"`
+	BuildID           int     `json:"build_id"`
+	BuildName         string  `json:"build_name"`
+	BuildStage        string  `json:"build_stage"`
+	BuildStatus       string  `json:"build_status"`
+	BuildStartedAt    string  `json:"build_started_at"`
+	BuildFinishedAt   string  `json:"build_finished_at"`
+	BuildDuration     float64 `json:"build_duration"`
+	BuildAllowFailure bool    `json:"build_allow_failure"`
+	ProjectID         int     `json:"project_id"`
+	ProjectName       string  `json:"project_name"`
+	User              struct {
+		ID    int    `json:"id"`
+		Name  string `json:"name"`
+		Email string `json:"email"`
+	} `json:"user"`
+	Commit struct {
+		ID          int    `json:"id"`
+		SHA         string `json:"sha"`
+		Message     string `json:"message"`
+		AuthorName  string `json:"author_name"`
+		AuthorEmail string `json:"author_email"`
+		AuthorURL   string `json:"author_url"`
+		Status      string `json:"status"`
+		Duration    int    `json:"duration"`
+		StartedAt   string `json:"started_at"`
+		FinishedAt  string `json:"finished_at"`
+	} `json:"commit"`
+	Repository *Repository `json:"repository"`
+}
+
 // CommitCommentEvent represents a comment on a commit event.
 //
 // GitLab API docs:


### PR DESCRIPTION
This adds support for job event webhooks. However, while the option exists in the interface, it is still undocumented in GitLab. (I'm not sure why.)