### PR TITLE
Add support for GroupLabels

### DIFF
--- a/gitlab.go
+++ b/gitlab.go
@@ -305,6 +305,7 @@ type Client struct {
 	GitIgnoreTemplates    *GitIgnoreTemplatesService
 	GroupBadges           *GroupBadgesService
 	GroupIssueBoards      *GroupIssueBoardsService
+	GroupLabels           *GroupLabelsService
 	GroupMembers          *GroupMembersService
 	GroupMilestones       *GroupMilestonesService
 	GroupVariables        *GroupVariablesService
@@ -451,6 +452,7 @@ func newClient(httpClient *http.Client) *Client {
 	c.GitIgnoreTemplates = &GitIgnoreTemplatesService{client: c}
 	c.GroupBadges = &GroupBadgesService{client: c}
 	c.GroupIssueBoards = &GroupIssueBoardsService{client: c}
+	c.GroupLabels = &GroupLabelsService{client: c}
 	c.GroupMembers = &GroupMembersService{client: c}
 	c.GroupMilestones = &GroupMilestonesService{client: c}
 	c.GroupVariables = &GroupVariablesService{client: c}

--- a/group_labels.go
+++ b/group_labels.go
@@ -60,7 +60,8 @@ type CreateGroupLabelOptions CreateLabelOptions
 // CreateGroupLabel creates a new label for given group with given name and
 // color.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/group_labels.html#create-a-new-group-label
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/group_labels.html#create-a-new-group-label
 func (s *GroupLabelsService) CreateGroupLabel(gid interface{}, opt *CreateGroupLabelOptions, options ...OptionFunc) (*GroupLabel, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {

--- a/group_labels.go
+++ b/group_labels.go
@@ -109,7 +109,8 @@ func (s *GroupLabelsService) DeleteGroupLabel(gid interface{}, opt *DeleteGroupL
 
 // UpdateGroupLabelOptions represents the available UpdateGroupLabel() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/group_labels.html#update-a-group-label
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/group_labels.html#update-a-group-label
 type UpdateGroupLabelOptions UpdateLabelOptions
 
 // UpdateGroupLabel updates an existing label with new name or now color. At least

--- a/group_labels.go
+++ b/group_labels.go
@@ -116,7 +116,8 @@ type UpdateGroupLabelOptions UpdateLabelOptions
 // UpdateGroupLabel updates an existing label with new name or now color. At least
 // one parameter is required, to update the label.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/labels.html#edit-an-existing-label
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/group_labels.html#update-a-group-label
 func (s *GroupLabelsService) UpdateGroupLabel(gid interface{}, opt *UpdateGroupLabelOptions, options ...OptionFunc) (*GroupLabel, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {

--- a/group_labels.go
+++ b/group_labels.go
@@ -85,7 +85,8 @@ func (s *GroupLabelsService) CreateGroupLabel(gid interface{}, opt *CreateGroupL
 
 // DeleteGroupLabelOptions represents the available DeleteGroupLabel() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/group_labels.html#delete-a-group-label
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/group_labels.html#delete-a-group-label
 type DeleteGroupLabelOptions DeleteLabelOptions
 
 // DeleteGroupLabel deletes a group label given by its name.

--- a/group_labels.go
+++ b/group_labels.go
@@ -1,19 +1,3 @@
-//
-// Copyright 2017, Sander van Harmelen
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-
 package gitlab
 
 import (

--- a/group_labels.go
+++ b/group_labels.go
@@ -29,7 +29,8 @@ type ListGroupLabelsOptions ListOptions
 
 // ListGroupLabels gets all labels for given group.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/group_labels.html#list-group-labels
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/group_labels.html#list-group-labels
 func (s *GroupLabelsService) ListGroupLabels(gid interface{}, opt *ListGroupLabelsOptions, options ...OptionFunc) ([]*GroupLabel, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {

--- a/group_labels.go
+++ b/group_labels.go
@@ -1,0 +1,207 @@
+//
+// Copyright 2017, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package gitlab
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// GroupLabelsService handles communication with the label related methods of the
+// GitLab API.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/group_labels.html
+type GroupLabelsService struct {
+	client *Client
+}
+
+// GroupLabel represents a GitLab group label.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/group_labels.html
+type GroupLabel Label
+
+func (l GroupLabel) String() string {
+	return Stringify(l)
+}
+
+// ListGroupLabelsOptions represents the available ListGroupLabels() options.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/labels.html#list-labels
+type ListGroupLabelsOptions ListOptions
+
+// ListGroupLabels gets all labels for given group.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/group_labels.html#list-group-labels
+func (s *GroupLabelsService) ListGroupLabels(gid interface{}, opt *ListGroupLabelsOptions, options ...OptionFunc) ([]*GroupLabel, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/labels", url.QueryEscape(group))
+
+	req, err := s.client.NewRequest("GET", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var l []*GroupLabel
+	resp, err := s.client.Do(req, &l)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return l, resp, err
+}
+
+// CreateGroupLabelOptions represents the available CreateGroupLabel() options.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/group_labels.html#create-a-new-group-label
+type CreateGroupLabelOptions CreateLabelOptions
+
+// CreateGroupLabel creates a new label for given group with given name and
+// color.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/group_labels.html#create-a-new-group-label
+func (s *GroupLabelsService) CreateGroupLabel(gid interface{}, opt *CreateGroupLabelOptions, options ...OptionFunc) (*GroupLabel, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/labels", url.QueryEscape(group))
+
+	req, err := s.client.NewRequest("POST", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	l := new(GroupLabel)
+	resp, err := s.client.Do(req, l)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return l, resp, err
+}
+
+// DeleteGroupLabelOptions represents the available DeleteGroupLabel() options.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/group_labels.html#delete-a-group-label
+type DeleteGroupLabelOptions DeleteLabelOptions
+
+// DeleteGroupLabel deletes a group label given by its name.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/labels.html#delete-a-label
+func (s *GroupLabelsService) DeleteGroupLabel(gid interface{}, opt *DeleteGroupLabelOptions, options ...OptionFunc) (*Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("groups/%s/labels", url.QueryEscape(group))
+
+	req, err := s.client.NewRequest("DELETE", u, opt, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// UpdateGroupLabelOptions represents the available UpdateGroupLabel() options.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/group_labels.html#update-a-group-label
+type UpdateGroupLabelOptions UpdateLabelOptions
+
+// UpdateGroupLabel updates an existing label with new name or now color. At least
+// one parameter is required, to update the label.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/labels.html#edit-an-existing-label
+func (s *GroupLabelsService) UpdateGroupLabel(gid interface{}, opt *UpdateGroupLabelOptions, options ...OptionFunc) (*GroupLabel, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/labels", url.QueryEscape(group))
+
+	req, err := s.client.NewRequest("PUT", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	l := new(GroupLabel)
+	resp, err := s.client.Do(req, l)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return l, resp, err
+}
+
+// SubscribeToGroupLabel subscribes the authenticated user to a label to receive
+// notifications. If the user is already subscribed to the label, the status
+// code 304 is returned.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/group_labels.html#subscribe-to-a-group-label
+func (s *GroupLabelsService) SubscribeToGroupLabel(gid interface{}, labelID interface{}, options ...OptionFunc) (*GroupLabel, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	label, err := parseID(labelID)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/labels/%s/subscribe", url.QueryEscape(group), label)
+
+	req, err := s.client.NewRequest("POST", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	l := new(GroupLabel)
+	resp, err := s.client.Do(req, l)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return l, resp, err
+}
+
+// UnsubscribeFromGroupLabel unsubscribes the authenticated user from a label to not
+// receive notifications from it. If the user is not subscribed to the label, the
+// status code 304 is returned.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/group_labels.html#unsubscribe-from-a-group-label
+func (s *GroupLabelsService) UnsubscribeFromGroupLabel(gid interface{}, labelID interface{}, options ...OptionFunc) (*Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, err
+	}
+	label, err := parseID(labelID)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("groups/%s/labels/%s/unsubscribe", url.QueryEscape(group), label)
+
+	req, err := s.client.NewRequest("POST", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}

--- a/group_labels.go
+++ b/group_labels.go
@@ -53,7 +53,8 @@ func (s *GroupLabelsService) ListGroupLabels(gid interface{}, opt *ListGroupLabe
 
 // CreateGroupLabelOptions represents the available CreateGroupLabel() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/group_labels.html#create-a-new-group-label
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/group_labels.html#create-a-new-group-label
 type CreateGroupLabelOptions CreateLabelOptions
 
 // CreateGroupLabel creates a new label for given group with given name and

--- a/group_labels_test.go
+++ b/group_labels_test.go
@@ -1,0 +1,141 @@
+package gitlab
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestCreateGroupGroupLabel(t *testing.T) {
+	mux, server, client := setup()
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v4/groups/1/labels", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		fmt.Fprint(w, `{"id":1, "name": "My GroupLabel", "color" : "#11FF22"}`)
+	})
+
+	l := &CreateGroupLabelOptions{
+		Name:  String("My GroupLabel"),
+		Color: String("#11FF22"),
+	}
+	label, _, err := client.GroupLabels.CreateGroupLabel("1", l)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+	want := &GroupLabel{ID: 1, Name: "My GroupLabel", Color: "#11FF22"}
+	if !reflect.DeepEqual(want, label) {
+		t.Errorf("GroupLabels.CreateGroupLabel returned %+v, want %+v", label, want)
+	}
+}
+
+func TestDeleteGroupLabel(t *testing.T) {
+	mux, server, client := setup()
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v4/groups/1/labels", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+	})
+
+	label := &DeleteGroupLabelOptions{
+		Name: String("My GroupLabel"),
+	}
+
+	_, err := client.GroupLabels.DeleteGroupLabel("1", label)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func TestUpdateGroupLabel(t *testing.T) {
+	mux, server, client := setup()
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v4/groups/1/labels", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		fmt.Fprint(w, `{"id":1, "name": "New GroupLabel", "color" : "#11FF23" , "description":"This is updated label"}`)
+	})
+
+	l := &UpdateGroupLabelOptions{
+		Name:        String("My GroupLabel"),
+		NewName:     String("New GroupLabel"),
+		Color:       String("#11FF23"),
+		Description: String("This is updated label"),
+	}
+
+	label, resp, err := client.GroupLabels.UpdateGroupLabel("1", l)
+
+	if resp == nil {
+		log.Fatal(err)
+	}
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	want := &GroupLabel{ID: 1, Name: "New GroupLabel", Color: "#11FF23", Description: "This is updated label"}
+
+	if !reflect.DeepEqual(want, label) {
+		t.Errorf("GroupLabels.UpdateGroupLabel returned %+v, want %+v", label, want)
+	}
+}
+
+func TestSubscribeToGroupLabel(t *testing.T) {
+	mux, server, client := setup()
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v4/groups/1/labels/5/subscribe", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		fmt.Fprint(w, `{  "id" : 5, "name" : "bug", "color" : "#d9534f", "description": "Bug reported by user", "open_issues_count": 1, "closed_issues_count": 0, "open_merge_requests_count": 1, "subscribed": true,"priority": null}`)
+	})
+
+	label, _, err := client.GroupLabels.SubscribeToGroupLabel("1", "5")
+	if err != nil {
+		log.Fatal(err)
+	}
+	want := &GroupLabel{ID: 5, Name: "bug", Color: "#d9534f", Description: "Bug reported by user", OpenIssuesCount: 1, ClosedIssuesCount: 0, OpenMergeRequestsCount: 1, Subscribed: true}
+	if !reflect.DeepEqual(want, label) {
+		t.Errorf("GroupLabels.SubscribeToGroupLabel returned %+v, want %+v", label, want)
+	}
+}
+
+func TestUnsubscribeFromGroupLabel(t *testing.T) {
+	mux, server, client := setup()
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v4/groups/1/labels/5/unsubscribe", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+	})
+
+	_, err := client.GroupLabels.UnsubscribeFromGroupLabel("1", "5")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func TestListGroupLabels(t *testing.T) {
+	mux, server, client := setup()
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v4/groups/1/labels", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `[{  "id" : 5, "name" : "bug", "color" : "#d9534f", "description": "Bug reported by user", "open_issues_count": 1, "closed_issues_count": 0, "open_merge_requests_count": 1, "subscribed": true,"priority": null}]`)
+	})
+
+	o := &ListGroupLabelsOptions{
+		Page:    1,
+		PerPage: 10,
+	}
+	label, _, err := client.GroupLabels.ListGroupLabels("1", o)
+	if err != nil {
+		t.Log(err.Error() == "invalid ID type 1.1, the ID must be an int or a string")
+
+	}
+	want := []*GroupLabel{{ID: 5, Name: "bug", Color: "#d9534f", Description: "Bug reported by user", OpenIssuesCount: 1, ClosedIssuesCount: 0, OpenMergeRequestsCount: 1, Subscribed: true}}
+	if !reflect.DeepEqual(want, label) {
+		t.Errorf("GroupLabels.ListGroupLabels returned %+v, want %+v", label, want)
+	}
+}


### PR DESCRIPTION
Hello,

this PR adds support for group labels. Since the API is basically same as project labels it's more or less copy/paste of existing labels code.

Issue: https://github.com/xanzy/go-gitlab/issues/563