### PR TITLE
Add omitempty tag to approval_before_merge field of CreateProjectOptions

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -444,7 +444,7 @@ type CreateProjectOptions struct {
 	TagList                                   *[]string         `url:"tag_list,omitempty" json:"tag_list,omitempty"`
 	PrintingMergeRequestLinkEnabled           *bool             `url:"printing_merge_request_link_enabled,omitempty" json:"printing_merge_request_link_enabled,omitempty"`
 	CIConfigPath                              *string           `url:"ci_config_path,omitempty" json:"ci_config_path,omitempty"`
-	ApprovalsBeforeMerge                      *int              `url:"approvals_before_merge" json:"approvals_before_merge"`
+	ApprovalsBeforeMerge                      *int              `url:"approvals_before_merge,omitempty" json:"approvals_before_merge,omitempty"`
 }
 
 // CreateProject creates a new project owned by the authenticated user.


### PR DESCRIPTION
Without this change in case when there are no any field changes EditProject method fails with internal server error. It is crucial to be fixed to enhance terraform project resource with this argument.