### PR TITLE
Add Status and Type as ListRunnersOptions

### DIFF
--- a/runners.go
+++ b/runners.go
@@ -80,7 +80,9 @@ type RunnerDetails struct {
 // https://docs.gitlab.com/ce/api/runners.html#list-owned-runners
 type ListRunnersOptions struct {
 	ListOptions
-	Scope *string `url:"scope,omitempty" json:"scope,omitempty"`
+	Scope  *string `url:"scope,omitempty" json:"scope,omitempty"`
+	Status *string `url:"status,omitempty" json:"status,omitempty"`
+	Type   *string `url:"type,omitempty" json:"type,omitempty"`
 }
 
 // ListRunners gets a list of runners accessible by the authenticated user.


### PR DESCRIPTION
# Objective

Add `Type` and `Status` fields to `ListRunnersOptions` since `Scope` is being deprecated. See the updated docs: https://docs.gitlab.com/ee/api/runners.html 

# Context

As of GitLab 11.4, `Type` and `Status` filters are supported for filtering Runners, and `Scope` has been deprecated.
* `Type`: https://gitlab.com/gitlab-org/gitlab-ce/merge_requests/19649
* `Status`: https://gitlab.com/gitlab-org/gitlab-ce/merge_requests/19625

As a heads up, the `TagList` filter will be rolling out with 11.9: https://gitlab.com/gitlab-org/gitlab-ce/merge_requests/19740