### PR TITLE
Add the MergeRequestsCount to the Issue

### DIFF
--- a/issues.go
+++ b/issues.go
@@ -65,32 +65,33 @@ type IssueLinks struct {
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/issues.html
 type Issue struct {
-	ID               int              `json:"id"`
-	IID              int              `json:"iid"`
-	ProjectID        int              `json:"project_id"`
-	Milestone        *Milestone       `json:"milestone"`
-	Author           *IssueAuthor     `json:"author"`
-	Description      string           `json:"description"`
-	State            string           `json:"state"`
-	Assignees        []*IssueAssignee `json:"assignees"`
-	Assignee         *IssueAssignee   `json:"assignee"`
-	Upvotes          int              `json:"upvotes"`
-	Downvotes        int              `json:"downvotes"`
-	Labels           []string         `json:"labels"`
-	Title            string           `json:"title"`
-	UpdatedAt        *time.Time       `json:"updated_at"`
-	CreatedAt        *time.Time       `json:"created_at"`
-	ClosedAt         *time.Time       `json:"closed_at"`
-	Subscribed       bool             `json:"subscribed"`
-	UserNotesCount   int              `json:"user_notes_count"`
-	DueDate          *ISOTime         `json:"due_date"`
-	WebURL           string           `json:"web_url"`
-	TimeStats        *TimeStats       `json:"time_stats"`
-	Confidential     bool             `json:"confidential"`
-	Weight           int              `json:"weight"`
-	DiscussionLocked bool             `json:"discussion_locked"`
-	Links            *IssueLinks      `json:"_links"`
-	IssueLinkID      int              `json:"issue_link_id"`
+	ID                int              `json:"id"`
+	IID               int              `json:"iid"`
+	ProjectID         int              `json:"project_id"`
+	Milestone         *Milestone       `json:"milestone"`
+	Author            *IssueAuthor     `json:"author"`
+	Description       string           `json:"description"`
+	State             string           `json:"state"`
+	Assignees         []*IssueAssignee `json:"assignees"`
+	Assignee          *IssueAssignee   `json:"assignee"`
+	Upvotes           int              `json:"upvotes"`
+	Downvotes         int              `json:"downvotes"`
+	Labels            []string         `json:"labels"`
+	Title             string           `json:"title"`
+	UpdatedAt         *time.Time       `json:"updated_at"`
+	CreatedAt         *time.Time       `json:"created_at"`
+	ClosedAt          *time.Time       `json:"closed_at"`
+	Subscribed        bool             `json:"subscribed"`
+	UserNotesCount    int              `json:"user_notes_count"`
+	DueDate           *ISOTime         `json:"due_date"`
+	WebURL            string           `json:"web_url"`
+	TimeStats         *TimeStats       `json:"time_stats"`
+	Confidential      bool             `json:"confidential"`
+	Weight            int              `json:"weight"`
+	DiscussionLocked  bool             `json:"discussion_locked"`
+	Links             *IssueLinks      `json:"_links"`
+	IssueLinkID       int              `json:"issue_link_id"`
+	MergeRequestCount int              `json:"merge_requests_count"`
 }
 
 func (i Issue) String() string {

--- a/issues_test.go
+++ b/issues_test.go
@@ -14,7 +14,7 @@ func TestGetIssue(t *testing.T) {
 
 	mux.HandleFunc("/api/v4/projects/1/issues/5", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, `{"id":1, "description": "This is test project", "author" : {"id" : 1, "name": "snehal"}, "assignees":[{"id":1}]}`)
+		fmt.Fprint(w, `{"id":1, "description": "This is test project", "author" : {"id" : 1, "name": "snehal"}, "assignees":[{"id":1}],"merge_requests_count": 1}`)
 	})
 
 	issue, _, err := client.Issues.GetIssue("1", 5)
@@ -23,10 +23,11 @@ func TestGetIssue(t *testing.T) {
 	}
 
 	want := &Issue{
-		ID:          1,
-		Description: "This is test project",
-		Author:      &IssueAuthor{ID: 1, Name: "snehal"},
-		Assignees:   []*IssueAssignee{{ID: 1}},
+		ID:                1,
+		Description:       "This is test project",
+		Author:            &IssueAuthor{ID: 1, Name: "snehal"},
+		Assignees:         []*IssueAssignee{{ID: 1}},
+		MergeRequestCount: 1,
 	}
 
 	if !reflect.DeepEqual(want, issue) {


### PR DESCRIPTION
GitLab would expose this information, but this field wasn't parsed in
the struct. A test case was updated to have an execution test of the
parsing.

GitLab docs: https://docs.gitlab.com/ee/api/issues.html#list-project-issues