### PR TITLE
Update GetCommit entity fields

### DIFF
--- a/commits.go
+++ b/commits.go
@@ -48,6 +48,8 @@ type Commit struct {
 	ParentIDs      []string         `json:"parent_ids"`
 	Stats          *CommitStats     `json:"stats"`
 	Status         *BuildStateValue `json:"status"`
+	LastPipeline   *PipelineInfo    `json:"last_pipeline"`
+	ProjectID      int              `json:"project_id"`
 }
 
 // CommitStats represents the number of added and deleted files in a commit.

--- a/commits_test.go
+++ b/commits_test.go
@@ -5,7 +5,48 @@ import (
 	"net/http"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
+
+func TestGetCommit(t *testing.T) {
+	mux, server, client := setup()
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v4/projects/1/repository/commits/b0b3a907f41409829b307a28b82fdbd552ee5a27", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		mustWriteHTTPResponse(t, w, "testdata/get_commit.json")
+	})
+
+	commit, resp, err := client.Commits.GetCommit("1", "b0b3a907f41409829b307a28b82fdbd552ee5a27", nil)
+	if err != nil {
+		t.Fatalf("Commits.GetCommit returned error: %v, response: %v", err, resp)
+	}
+
+	want := &Commit{
+		ID:             "6104942438c14ec7bd21c6cd5bd995272b3faff6",
+		ShortID:        "6104942438c",
+		Title:          "Sanitize for network graph",
+		AuthorName:     "randx",
+		AuthorEmail:    "dmitriy.zaporozhets@gmail.com",
+		CommitterName:  "Dmitriy",
+		CommitterEmail: "dmitriy.zaporozhets@gmail.com",
+		Message:        "Sanitize for network graph",
+		ParentIDs:      []string{"ae1d9fb46aa2b07ee9836d49862ec4e2c46fbbba"},
+		Stats:          &CommitStats{Additions: 15, Deletions: 10, Total: 25},
+		Status:         BuildState(Running),
+		LastPipeline: &PipelineInfo{
+			ID:     8,
+			Ref:    "master",
+			SHA:    "2dc6aa325a317eda67812f05600bdf0fcdc70ab0",
+			Status: "created",
+			WebURL: "https://gitlab.com/gitlab-org/gitlab-ce/pipelines/54268416",
+		},
+		ProjectID: 13083,
+	}
+
+	assert.Equal(t, want, commit)
+}
 
 func TestGetCommitStatuses(t *testing.T) {
 	mux, server, client := setup()

--- a/gitlab_test.go
+++ b/gitlab_test.go
@@ -5,9 +5,11 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 )
@@ -56,6 +58,17 @@ func testBody(t *testing.T, r *http.Request, want string) {
 
 	if got := buffer.String(); got != want {
 		t.Errorf("Request body: %s, want %s", got, want)
+	}
+}
+
+func mustWriteHTTPResponse(t *testing.T, w io.Writer, fixturePath string) {
+	f, err := os.Open(fixturePath)
+	if err != nil {
+		t.Fatalf("error opening fixture file: %v", err)
+	}
+
+	if _, err = io.Copy(w, f); err != nil {
+		t.Fatalf("error writing response: %v", err)
 	}
 }
 

--- a/pipelines.go
+++ b/pipelines.go
@@ -74,7 +74,11 @@ func (i Pipeline) String() string {
 // PipelineList represents a GitLab list project pipelines
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/pipelines.html#list-project-pipelines
-type PipelineList []struct {
+type PipelineList []*PipelineInfo
+
+// PipelineInfo shows the basic entities of a pipeline, mostly used as fields
+// on other assets, like Commit.
+type PipelineInfo struct {
 	ID     int    `json:"id"`
 	Status string `json:"status"`
 	Ref    string `json:"ref"`

--- a/testdata/get_commit.json
+++ b/testdata/get_commit.json
@@ -1,0 +1,27 @@
+{
+  "id": "6104942438c14ec7bd21c6cd5bd995272b3faff6",
+  "short_id": "6104942438c",
+  "title": "Sanitize for network graph",
+  "author_name": "randx",
+  "author_email": "dmitriy.zaporozhets@gmail.com",
+  "committer_name": "Dmitriy",
+  "committer_email": "dmitriy.zaporozhets@gmail.com",
+  "message": "Sanitize for network graph",
+  "parent_ids": [
+    "ae1d9fb46aa2b07ee9836d49862ec4e2c46fbbba"
+  ],
+  "last_pipeline" : {
+    "id": 8,
+    "ref": "master",
+    "sha": "2dc6aa325a317eda67812f05600bdf0fcdc70ab0",
+    "status": "created",
+    "web_url":"https://gitlab.com/gitlab-org/gitlab-ce/pipelines/54268416"
+  },
+  "stats": {
+    "additions": 15,
+    "deletions": 10,
+    "total": 25
+  },
+  "status": "running",
+  "project_id":13083
+}


### PR DESCRIPTION
I wanted to leverage this API call, but it was missing data that I'd
like to use. I've added the fields and a test case.

For the test case, I've removed the timestamps as it made the code a bit
ugly. But the rest is fully covered.