### PR TITLE
Fixed multiple scope jobs selection

### DIFF
--- a/jobs.go
+++ b/jobs.go
@@ -71,7 +71,7 @@ type Job struct {
 // ListJobsOptions are options for two list apis
 type ListJobsOptions struct {
 	ListOptions
-	Scope []BuildStateValue `url:"scope,omitempty" json:"scope,omitempty"`
+	Scope []BuildStateValue `url:"scope[],omitempty" json:"scope,omitempty"`
 }
 
 // ListProjectJobs gets a list of jobs in a project.


### PR DESCRIPTION
At the moment if we provide multiple scopes in listprojectjobs request, the library returns jobs with the last provided state in the scope list.
This is because the scope parameter should have braces in its name as shown in the example: https://docs.gitlab.com/ee/api/jobs.html#list-pipeline-jobs