### PR TITLE
Add domain to project cluster

### DIFF
--- a/project_clusters.go
+++ b/project_clusters.go
@@ -37,6 +37,7 @@ type ProjectClustersService struct {
 type ProjectCluster struct {
 	ID                 int                 `json:"id"`
 	Name               string              `json:"name"`
+	Domain             string              `json:"domain"`
 	CreatedAt          *time.Time          `json:"created_at"`
 	ProviderType       string              `json:"provider_type"`
 	PlatformType       string              `json:"platform_type"`
@@ -116,6 +117,7 @@ func (s *ProjectClustersService) GetCluster(pid interface{}, cluster int, option
 // https://docs.gitlab.com/ee/api/project_clusters.html#add-existing-cluster-to-project
 type AddClusterOptions struct {
 	Name               *string                       `url:"name,omitempty" json:"name,omitempty"`
+	Domain             *string                       `url:"domain,omitempty" json:"domain,omitempty"`
 	Enabled            *bool                         `url:"enabled,omitempty" json:"enabled,omitempty"`
 	EnvironmentScope   *string                       `url:"environment_scope,omitempty" json:"environment_scope,omitempty"`
 	PlatformKubernetes *AddPlatformKubernetesOptions `url:"platform_kubernetes_attributes,omitempty" json:"platform_kubernetes_attributes,omitempty"`
@@ -161,6 +163,7 @@ func (s *ProjectClustersService) AddCluster(pid interface{}, opt *AddClusterOpti
 // https://docs.gitlab.com/ee/api/project_clusters.html#edit-project-cluster
 type EditClusterOptions struct {
 	Name               *string                        `url:"name,omitempty" json:"name,omitempty"`
+	Domain             *string                        `url:"domain,omitempty" json:"domain,omitempty"`
 	EnvironmentScope   *string                        `url:"environment_scope,omitempty" json:"environment_scope,omitempty"`
 	PlatformKubernetes *EditPlatformKubernetesOptions `url:"platform_kubernetes_attributes,omitempty" json:"platform_kubernetes_attributes,omitempty"`
 }

--- a/project_clusters_test.go
+++ b/project_clusters_test.go
@@ -17,6 +17,7 @@ func TestListClusters(t *testing.T) {
   {
     "id":18,
     "name":"cluster-1",
+    "domain":"example.com",
     "created_at":"2019-01-02T20:18:12.563Z",
     "provider_type":"user",
     "platform_type":"kubernetes",
@@ -56,6 +57,10 @@ func TestListClusters(t *testing.T) {
 	if clusters[0].ID != 18 {
 		t.Errorf("expected clusterID 1; got %d", clusters[0].ID)
 	}
+
+	if clusters[0].Domain != "example.com" {
+		t.Errorf("expected cluster domain example.com; got %q", clusters[0].Domain)
+	}
 }
 
 func TestGetCluster(t *testing.T) {
@@ -68,6 +73,7 @@ func TestGetCluster(t *testing.T) {
 		response := `{
   "id":18,
   "name":"cluster-1",
+  "domain":"example.com",
   "created_at":"2019-01-02T20:18:12.563Z",
   "provider_type":"user",
   "platform_type":"kubernetes",
@@ -131,6 +137,10 @@ func TestGetCluster(t *testing.T) {
 	if cluster.ID != 18 {
 		t.Errorf("expected clusterID 18; got %d", cluster.ID)
 	}
+
+	if cluster.Domain != "example.com" {
+		t.Errorf("expected cluster domain example.com; got %q", cluster.Domain)
+	}
 }
 
 func TestAddCluster(t *testing.T) {
@@ -143,6 +153,7 @@ func TestAddCluster(t *testing.T) {
 		response := `{
   "id":24,
   "name":"cluster-5",
+  "domain":"example.com",
   "created_at":"2019-01-03T21:53:40.610Z",
   "provider_type":"user",
   "platform_type":"kubernetes",
@@ -218,6 +229,7 @@ func TestEditCluster(t *testing.T) {
 		response := `{
   "id":24,
   "name":"new-cluster-name",
+  "domain":"example.com",
   "created_at":"2019-01-03T21:53:40.610Z",
   "provider_type":"user",
   "platform_type":"kubernetes",


### PR DESCRIPTION
This PR adds a new field to project cluster `domain`.

The feature has been introduced in GitLab 1.10.

