### PR TITLE
Add API URL to the JIRA service integration

### DIFF
--- a/services.go
+++ b/services.go
@@ -389,6 +389,7 @@ type JiraService struct {
 // https://docs.gitlab.com/ce/api/services.html#jira
 type JiraServiceProperties struct {
 	URL                   *string `url:"url,omitempty" json:"url,omitempty"`
+	APIURL                *string `url:"api_url,omitempty" json:"api_url,omitempty"`
 	ProjectKey            *string `url:"project_key,omitempty" json:"project_key,omitempty" `
 	Username              *string `url:"username,omitempty" json:"username,omitempty" `
 	Password              *string `url:"password,omitempty" json:"password,omitempty" `

--- a/services_test.go
+++ b/services_test.go
@@ -138,6 +138,7 @@ func TestSetJiraService(t *testing.T) {
 
 	opt := &SetJiraServiceOptions{
 		URL:                   String("asd"),
+		APIURL:                String("asd"),
 		ProjectKey:            String("as"),
 		Username:              String("aas"),
 		Password:              String("asd"),


### PR DESCRIPTION
I needed the ability to set the API URL.

https://docs.gitlab.com/ce/api/services.html#createedit-jira-service