### PR TITLE
Update Jira service: change JiraTransitionID from int to string

### DIFF
--- a/services.go
+++ b/services.go
@@ -17,7 +17,11 @@
 package gitlab
 
 import (
+	"encoding/json"
 	"fmt"
+	"net/url"
+	"reflect"
+	"strconv"
 	"time"
 )
 
@@ -394,6 +398,40 @@ type JiraServiceProperties struct {
 	Username              string `json:"username,omitempty" `
 	Password              string `json:"password,omitempty" `
 	JiraIssueTransitionID string `json:"jira_issue_transition_id,omitempty"`
+}
+
+// UnmarshalJSON decodes the Jira Service Properties.
+//
+// The Gitlab API returns under some circumstances JiraIssueTransitionID
+// as a string and sometimes as an integer. This function converts the
+// returned value into an integer.
+func (p *JiraServiceProperties) UnmarshalJSON(b []byte) error {
+	type Alias JiraServiceProperties
+	aux := &struct {
+		JiraIssueTransitionID interface{} `url:"jira_issue_transition_id,omitempty" json:"jira_issue_transition_id,omitempty"`
+		*Alias
+	}{
+		Alias: (*Alias)(p),
+	}
+
+	if err := json.Unmarshal(b, &aux); err != nil {
+		return err
+	}
+
+	switch id := aux.JiraIssueTransitionID.(type) {
+	case string:
+		converted, err := strconv.Atoi(id)
+		if err != nil {
+			return err
+		}
+		p.JiraIssueTransitionID = func(i int) *int { return &i }(converted)
+	case float64:
+		p.JiraIssueTransitionID = Int(int(id))
+	default:
+		return fmt.Errorf("failed to unmarshal JiraTransitionID of type: %s", reflect.TypeOf(id))
+	}
+
+	return nil
 }
 
 // GetJiraService gets Jira service settings for a project.

--- a/services.go
+++ b/services.go
@@ -19,7 +19,6 @@ package gitlab
 import (
 	"encoding/json"
 	"fmt"
-	"reflect"
 	"strconv"
 	"time"
 )
@@ -404,18 +403,18 @@ type JiraServiceProperties struct {
 // This allows support of JiraIssueTransitionID for both type string (>11.9) and float64 (<11.9)
 func (p *JiraServiceProperties) UnmarshalJSON(b []byte) error {
 	type Alias JiraServiceProperties
-	aux := &struct {
-		JiraIssueTransitionID interface{} `url:"jira_issue_transition_id,omitempty" json:"jira_issue_transition_id,omitempty"`
+	raw := struct {
 		*Alias
+		JiraIssueTransitionID interface{} `json:"jira_issue_transition_id"`
 	}{
 		Alias: (*Alias)(p),
 	}
 
-	if err := json.Unmarshal(b, &aux); err != nil {
+	if err := json.Unmarshal(b, &raw); err != nil {
 		return err
 	}
 
-	switch id := aux.JiraIssueTransitionID.(type) {
+	switch id := raw.JiraIssueTransitionID.(type) {
 	case nil:
 		p.JiraIssueTransitionID = ""
 	case string:
@@ -423,7 +422,7 @@ func (p *JiraServiceProperties) UnmarshalJSON(b []byte) error {
 	case float64:
 		p.JiraIssueTransitionID = strconv.Itoa(int(id))
 	default:
-		return fmt.Errorf("failed to unmarshal JiraTransitionID of type: %v", reflect.TypeOf(id))
+		return fmt.Errorf("failed to unmarshal JiraTransitionID of type: %T", id)
 	}
 
 	return nil

--- a/services_test.go
+++ b/services_test.go
@@ -115,14 +115,39 @@ func TestGetJiraService(t *testing.T) {
 
 	mux.HandleFunc("/api/v4/projects/1/services/jira", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, `{"id":1}`)
+		fmt.Fprint(w, `{"id":1, "properties": {"jira_issue_transition_id": "2"}}`)
 	})
-	want := &JiraService{Service: Service{ID: 1}}
+
+	mux.HandleFunc("/api/v4/projects/2/services/jira", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{"id":1, "properties": {"jira_issue_transition_id": 2}}`)
+	})
+
+	mux.HandleFunc("/api/v4/projects/3/services/jira", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{"id":3, "properties": {"jira_issue_transition_id": "2,3"}}`)
+	})
+
+	want := &JiraService{
+		Service: Service{ID: 1},
+		Properties: &JiraServiceProperties{
+			JiraIssueTransitionID: Int(2),
+		}}
 
 	service, _, err := client.Services.GetJiraService(1)
 	if err != nil {
 		t.Fatalf("Services.GetJiraService returns an error: %v", err)
 	}
+
+	if !reflect.DeepEqual(want, service) {
+		t.Errorf("Services.GetJiraService returned %+v, want %+v", service, want)
+	}
+
+	service, _, err = client.Services.GetJiraService(2)
+	if err != nil {
+		t.Fatalf("Services.GetJiraService returns an error: %v", err)
+	}
+
 	if !reflect.DeepEqual(want, service) {
 		t.Errorf("Services.GetJiraService returned %+v, want %+v", service, want)
 	}

--- a/services_test.go
+++ b/services_test.go
@@ -113,43 +113,60 @@ func TestGetJiraService(t *testing.T) {
 	mux, server, client := setup()
 	defer teardown(server)
 
-	mux.HandleFunc("/api/v4/projects/1/services/jira", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v4/projects/0/services/jira", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{"id":1, "properties": {"jira_issue_transition_id": "2"}}`)
 	})
 
-	mux.HandleFunc("/api/v4/projects/2/services/jira", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v4/projects/1/services/jira", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{"id":1, "properties": {"jira_issue_transition_id": 2}}`)
 	})
 
-	mux.HandleFunc("/api/v4/projects/3/services/jira", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v4/projects/2/services/jira", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, `{"id":3, "properties": {"jira_issue_transition_id": "2,3"}}`)
+		fmt.Fprint(w, `{"id":1, "properties": {"jira_issue_transition_id": "2,3"}}`)
 	})
 
-	want := &JiraService{
-		Service: Service{ID: 1},
-		Properties: &JiraServiceProperties{
-			JiraIssueTransitionID: Int(2),
-		}}
+	mux.HandleFunc("/api/v4/projects/3/services/jira", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{"id":1, "properties": {}}`)
+	})
 
-	service, _, err := client.Services.GetJiraService(1)
-	if err != nil {
-		t.Fatalf("Services.GetJiraService returns an error: %v", err)
+	want := []*JiraService{
+		&JiraService{
+			Service: Service{ID: 1},
+			Properties: &JiraServiceProperties{
+				JiraIssueTransitionID: "2",
+			},
+		},
+		&JiraService{
+			Service: Service{ID: 1},
+			Properties: &JiraServiceProperties{
+				JiraIssueTransitionID: "2",
+			},
+		},
+		&JiraService{
+			Service: Service{ID: 1},
+			Properties: &JiraServiceProperties{
+				JiraIssueTransitionID: "2,3",
+			},
+		},
+		&JiraService{
+			Service:    Service{ID: 1},
+			Properties: &JiraServiceProperties{},
+		},
 	}
 
-	if !reflect.DeepEqual(want, service) {
-		t.Errorf("Services.GetJiraService returned %+v, want %+v", service, want)
-	}
+	for testcase := 0; testcase < len(want); testcase++ {
+		service, _, err := client.Services.GetJiraService(testcase)
+		if err != nil {
+			t.Fatalf("Services.GetJiraService returns an error: %v", err)
+		}
 
-	service, _, err = client.Services.GetJiraService(2)
-	if err != nil {
-		t.Fatalf("Services.GetJiraService returns an error: %v", err)
-	}
-
-	if !reflect.DeepEqual(want, service) {
-		t.Errorf("Services.GetJiraService returned %+v, want %+v", service, want)
+		if !reflect.DeepEqual(want[testcase], service) {
+			t.Errorf("Services.GetJiraService returned %+v, want %+v", service, want[testcase])
+		}
 	}
 }
 
@@ -167,7 +184,7 @@ func TestSetJiraService(t *testing.T) {
 		ProjectKey:            String("as"),
 		Username:              String("aas"),
 		Password:              String("asd"),
-		JiraIssueTransitionID: String("2"),
+		JiraIssueTransitionID: String("2,3"),
 	}
 
 	_, err := client.Services.SetJiraService(1, opt)


### PR DESCRIPTION
Hi,

This is an update to https://github.com/xanzy/go-gitlab/pull/547.

This makes *JiraTransitionID* a string while still supporting previous Gitlab version (<11.9) when it was an int (cf. https://gitlab.com/gitlab-org/gitlab-ce/blob/master/CHANGELOG.md#L443).

Best,