### PR TITLE
add "managed" flag for toggling managed clusters during create

### DIFF
--- a/project_clusters.go
+++ b/project_clusters.go
@@ -118,6 +118,7 @@ type AddClusterOptions struct {
 	Name               *string                       `url:"name,omitempty" json:"name,omitempty"`
 	Domain             *string                       `url:"domain,omitempty" json:"domain,omitempty"`
 	Enabled            *bool                         `url:"enabled,omitempty" json:"enabled,omitempty"`
+	Managed            *bool                         `url:"managed,omitempty" json:"managed,omitempty"`
 	EnvironmentScope   *string                       `url:"environment_scope,omitempty" json:"environment_scope,omitempty"`
 	PlatformKubernetes *AddPlatformKubernetesOptions `url:"platform_kubernetes_attributes,omitempty" json:"platform_kubernetes_attributes,omitempty"`
 }


### PR DESCRIPTION
The gitlab api now has a ["managed"](https://docs.gitlab.com/ee/api/project_clusters.html#add-existing-cluster-to-project) field to disable cluster management features when adding a kubernetes cluster.  Disabling this allows you to specify an unprivileged, namespace-scoped token to gitlab, to avoid granting it cluster admin. This implements that field. Default is true if you don't supply it.

Existing testing doesn't seem to cover stuff at the property-level, so I didn't implement it. Since it defaults to true if the field isn't sent, this _shouldn't_ affect anything else.