### PR TITLE
Add Fork Project Options

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -557,18 +557,27 @@ func (s *ProjectsService) EditProject(pid interface{}, opt *EditProjectOptions, 
 	return p, resp, err
 }
 
+// ForkProjectOptions represents the available ForkProject() options.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#fork-project
+type ForkProjectOptions struct {
+	Namespace *string `url:"namespace,omitempty" json:"namespace,omitempty"`
+	Name *string`url:"name,omitempty" json:"name,omitempty" `
+	Path *string`url:"path,omitempty" json:"path,omitempty"`
+}
+
 // ForkProject forks a project into the user namespace of the authenticated
 // user.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#fork-project
-func (s *ProjectsService) ForkProject(pid interface{}, options ...OptionFunc) (*Project, *Response, error) {
+func (s *ProjectsService) ForkProject(pid interface{}, opt *ForkProjectOptions, options ...OptionFunc) (*Project, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/fork", pathEscape(project))
 
-	req, err := s.client.NewRequest("POST", u, nil, options)
+	req, err := s.client.NewRequest("POST", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/projects.go
+++ b/projects.go
@@ -562,8 +562,8 @@ func (s *ProjectsService) EditProject(pid interface{}, opt *EditProjectOptions, 
 // GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#fork-project
 type ForkProjectOptions struct {
 	Namespace *string `url:"namespace,omitempty" json:"namespace,omitempty"`
-	Name *string`url:"name,omitempty" json:"name,omitempty" `
-	Path *string`url:"path,omitempty" json:"path,omitempty"`
+	Name      *string `url:"name,omitempty" json:"name,omitempty" `
+	Path      *string `url:"path,omitempty" json:"path,omitempty"`
 }
 
 // ForkProject forks a project into the user namespace of the authenticated

--- a/projects_test.go
+++ b/projects_test.go
@@ -522,3 +522,32 @@ func TestChangeAllowedApprovers(t *testing.T) {
 		t.Errorf("Projects.ChangeAllowedApprovers returned %+v, want %+v", approvals, want)
 	}
 }
+
+func TestForkProject(t *testing.T) {
+	mux, server, client := setup()
+	defer teardown(server)
+
+	namespace := "mynamespace"
+	name := "myreponame"
+	path := "myrepopath"
+
+	mux.HandleFunc("/api/v4/projects/1/fork", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		testBody(t, r, fmt.Sprintf(`{"namespace":"%s","name":"%s","path":"%s"}`, namespace, name, path))
+		fmt.Fprint(w, `{"id":2}`)
+	})
+
+	project, _, err := client.Projects.ForkProject(1, &ForkProjectOptions{
+		Namespace: &namespace,
+		Name:      &name,
+		Path:      &path,
+	})
+	if err != nil {
+		t.Errorf("Projects.ForkProject returned error: %v", err)
+	}
+
+	want := &Project{ID: 2}
+	if !reflect.DeepEqual(want, project) {
+		t.Errorf("Projects.ForProject returned %+v, want %+v", project, want)
+	}
+}


### PR DESCRIPTION
With the current implementation, it's impossible to set a namespace, a name, or a path.

These attributes are supported by the API, but there's no way to set them, and the implementation of the OptionFun forces everything to be a JSON payload, thus it doesn't work.

With this change, we can set the attributes using a `ForkProjectOptions` symmetrical to the rest of the methods all around.