### PR TITLE
Added custom writer to Archive

### DIFF
--- a/repositories.go
+++ b/repositories.go
@@ -19,6 +19,7 @@ package gitlab
 import (
 	"bytes"
 	"fmt"
+	"io"
 )
 
 // RepositoriesService handles communication with the repositories related
@@ -138,6 +139,7 @@ func (s *RepositoriesService) RawBlobContent(pid interface{}, sha string, option
 type ArchiveOptions struct {
 	Format *string `url:"-" json:"-"`
 	SHA    *string `url:"sha,omitempty" json:"sha,omitempty"`
+	Writer *io.Writer `url:"-" json:"-"`
 }
 
 // Archive gets an archive of the repository.
@@ -162,7 +164,13 @@ func (s *RepositoriesService) Archive(pid interface{}, opt *ArchiveOptions, opti
 	}
 
 	var b bytes.Buffer
-	resp, err := s.client.Do(req, &b)
+	var resp *Response
+	if opt != nil && opt.Writer != nil {
+		resp, err = s.client.Do(req, opt.Writer)
+	} else {
+		resp, err = s.client.Do(req, &b)
+	}
+
 	if err != nil {
 		return nil, resp, err
 	}

--- a/repositories.go
+++ b/repositories.go
@@ -137,8 +137,8 @@ func (s *RepositoriesService) RawBlobContent(pid interface{}, sha string, option
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/repositories.html#get-file-archive
 type ArchiveOptions struct {
-	Format *string `url:"-" json:"-"`
-	SHA    *string `url:"sha,omitempty" json:"sha,omitempty"`
+	Format *string    `url:"-" json:"-"`
+	SHA    *string    `url:"sha,omitempty" json:"sha,omitempty"`
 	Writer *io.Writer `url:"-" json:"-"`
 }
 


### PR DESCRIPTION
Added the ability to set a custom Writer in options passed to Archive of RepositoriesService.

Very useful when you do not want to store the contents of the repository in the memory and use the Reader directly.

Storing large repositories in memory is not very convenient.
