### PR TITLE
[Merge requests API] Add missing field: merge_error

### DIFF
--- a/merge_requests.go
+++ b/merge_requests.go
@@ -71,6 +71,7 @@ type MergeRequest struct {
 	Milestone                 *Milestone `json:"milestone"`
 	MergeWhenPipelineSucceeds bool       `json:"merge_when_pipeline_succeeds"`
 	MergeStatus               string     `json:"merge_status"`
+	MergeError                string     `json:"merge_error"`
 	MergedBy                  struct {
 		ID        int        `json:"id"`
 		Username  string     `json:"username"`


### PR DESCRIPTION
Hi,

I've noticed that Merge requests API client doesn't provide "merge error". The field is available once the end client calls MR API with the _ include_rebase_in_progress_ option. The field _rebase_in_progress_ has been already defined correctly.

This PR has been prepared according to the instruction available here:
https://docs.gitlab.com/ee/api/merge_requests.html#rebase-a-merge-request

/cc @svanharmelen 

Thanks,
Marcin