### PR TITLE
tell json encoder polling_interval_multiplier is encoded as string type

### DIFF
--- a/settings.go
+++ b/settings.go
@@ -92,7 +92,7 @@ type Settings struct {
 	PerformanceBarEnabled               bool              `json:"performance_bar_enabled"`
 	PlantumlEnabled                     bool              `json:"plantuml_enabled"`
 	PlantumlURL                         string            `json:"plantuml_url"`
-	PollingIntervalMultiplier           float64           `json:"polling_interval_multiplier"`
+	PollingIntervalMultiplier           float64           `json:"polling_interval_multiplier,string"`
 	ProjectExportEnabled                bool              `json:"project_export_enabled"`
 	PrometheusMetricsEnabled            bool              `json:"prometheus_metrics_enabled"`
 	RecaptchaEnabled                    bool              `json:"recaptcha_enabled"`


### PR DESCRIPTION
Gitlab return `polling_interval_multiplier` as `string` type since it's a `decimal` type and it's handle in rails as string (due to JSON imprecision).

see example:
https://gist.github.com/ahuret/b3174d18f2d379b6ca9d9a9f7f0eb837

Golang JSON decoder accept as annotation to indicates float64 is encoded as string.