### PR TITLE
Add resource label events

### DIFF
--- a/gitlab.go
+++ b/gitlab.go
@@ -341,6 +341,7 @@ type Client struct {
 	Releases              *ReleasesService
 	Repositories          *RepositoriesService
 	RepositoryFiles       *RepositoryFilesService
+	ResourceLabelEvents   *ResourceLabelEventsService
 	Runners               *RunnersService
 	Search                *SearchService
 	Services              *ServicesService
@@ -490,6 +491,7 @@ func newClient(httpClient *http.Client) *Client {
 	c.Releases = &ReleasesService{client: c}
 	c.Repositories = &RepositoriesService{client: c}
 	c.RepositoryFiles = &RepositoryFilesService{client: c}
+	c.ResourceLabelEvents = &ResourceLabelEventsService{client: c}
 	c.Runners = &RunnersService{client: c}
 	c.Search = &SearchService{client: c}
 	c.Services = &ServicesService{client: c}

--- a/resource_label_events.go
+++ b/resource_label_events.go
@@ -1,0 +1,212 @@
+//
+// Copyright 2017, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package gitlab
+
+import (
+	"fmt"
+	"time"
+)
+
+// ResourceLabelEventsService handles communication with the event related methods of
+// the GitLab API.
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/resource_label_events.html
+type ResourceLabelEventsService struct {
+	client *Client
+}
+
+// ContributionEvent represents a user's contribution
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/resource_label_events.html#get-single-issue-label-event
+type ResourceLabelEvent struct {
+	ID              int        `json:"id"`
+	Action          string     `json:"action"`
+	CreatedAt       *time.Time `json:"created_at"`
+	ResourceType    string     `json:"resource_type"`
+	ResourceID      int        `json:"resource_id"`
+	User struct {
+		ID        int    `json:"id"`
+		Name      string `json:"name"`
+		Username  string `json:"username"`
+		State     string `json:"state"`
+		AvatarURL string `json:"avatar_url"`
+		WebURL    string `json:"web_url"`
+	} `json:"user"`
+	Label struct {
+		ID          int    `json:"id"`
+		Name        string `json:"name"`
+		Color       string `json:"color"`
+		TextColor   string `json:"text_color"`
+		Description string `json:"description"`
+	} `json:"label"`
+}
+
+// ListResourceLabelEventsOptions represents the options for 
+type ListResourceLabelEventsOptions struct {
+	ListOptions
+}
+
+// ListIssueResourceLabelEvents retrieves resource label events
+// for the specified project and issue.
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/resource_label_events.html#list-project-issue-label-events
+func (s *ResourceLabelEventsService) ListIssueResourceLabelEvents(pid interface{}, issue int, opt *ListResourceLabelEventsOptions, options ...OptionFunc) ([]*ResourceLabelEvent, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	u := fmt.Sprintf("projects/%s/issues/%d/resource_label_events", pathEscape(project), issue)
+
+	req, err := s.client.NewRequest("GET", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var rs []*ResourceLabelEvent
+	resp, err := s.client.Do(req, &rs)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return rs, resp, err
+}
+
+// GetIssueResourceLabelEvent gets a single issue-label-event.
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/resource_label_events.html#get-single-issue-label-event
+func (s *ResourceLabelEventsService) GetIssueResourceLabelEvent(pid interface{}, issue int, event int, options ...OptionFunc) (*ResourceLabelEvent, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/issues/%d/resource_label_events/%d", pathEscape(project), issue, event)
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	e := new(ResourceLabelEvent)
+	resp, err := s.client.Do(req, e)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return e, resp, err
+}
+
+// ListGroupEpicResourceLabelEvents retrieves resource label events
+// for the specified group and epic.
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/resource_label_events.html#list-group-epic-label-events
+func (s *ResourceLabelEventsService) ListGroupEpicResourceLabelEvents(gid interface{}, epic int, opt *ListResourceLabelEventsOptions, options ...OptionFunc) ([]*ResourceLabelEvent, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	u := fmt.Sprintf("groups/%s/epics/%d/resource_label_events", pathEscape(group), epic)
+
+	req, err := s.client.NewRequest("GET", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var rs []*ResourceLabelEvent
+	resp, err := s.client.Do(req, &rs)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return rs, resp, err
+}
+
+// GetGroupEpicResourceLabelEvent gets a single group epic label event.
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/resource_label_events.html#get-single-epic-label-event
+func (s *ResourceLabelEventsService) GetGroupEpicResourceLabelEvent(gid interface{}, epic int, event int, options ...OptionFunc) (*ResourceLabelEvent, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/epics/%d/resource_label_events/%d", pathEscape(group), epic, event)
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	e := new(ResourceLabelEvent)
+	resp, err := s.client.Do(req, e)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return e, resp, err
+}
+
+// ListMergeRequestResourceLabelEvents retrieves resource label events
+// for the specified project and merge request.
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/resource_label_events.html#list-project-merge-request-label-events
+func (s *ResourceLabelEventsService) ListMergeRequestResourceLabelEvents(pid interface{}, request int, opt *ListResourceLabelEventsOptions, options ...OptionFunc) ([]*ResourceLabelEvent, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	u := fmt.Sprintf("projects/%s/merge_requests/%d/resource_label_events", pathEscape(project), request)
+
+	req, err := s.client.NewRequest("GET", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var rs []*ResourceLabelEvent
+	resp, err := s.client.Do(req, &rs)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return rs, resp, err
+}
+
+// GetMergeRequestResourceLabelEvent gets a single merge request label event.
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/resource_label_events.html#get-single-merge-request-label-event
+func (s *ResourceLabelEventsService) GetMergeRequestResourceLabelEvent(pid interface{}, request int, event int, options ...OptionFunc) (*ResourceLabelEvent, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/merge_requests/%d/resource_label_events/%d", pathEscape(project), request, event)
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	e := new(ResourceLabelEvent)
+	resp, err := s.client.Do(req, e)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return e, resp, err
+}

--- a/resource_label_events.go
+++ b/resource_label_events.go
@@ -21,8 +21,8 @@ import (
 	"time"
 )
 
-// ResourceLabelEventsService handles communication with the event related methods of
-// the GitLab API.
+// ResourceLabelEventsService handles communication with the event related
+// methods of the GitLab API.
 //
 // GitLab API docs: https://docs.gitlab.com/ee/api/resource_label_events.html
 type ResourceLabelEventsService struct {
@@ -33,13 +33,13 @@ type ResourceLabelEventsService struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/resource_label_events.html#get-single-issue-label-event
-type ResourceLabelEvent struct {
-	ID              int        `json:"id"`
-	Action          string     `json:"action"`
-	CreatedAt       *time.Time `json:"created_at"`
-	ResourceType    string     `json:"resource_type"`
-	ResourceID      int        `json:"resource_id"`
-	User struct {
+type LabelEvent struct {
+	ID           int        `json:"id"`
+	Action       string     `json:"action"`
+	CreatedAt    *time.Time `json:"created_at"`
+	ResourceType string     `json:"resource_type"`
+	ResourceID   int        `json:"resource_id"`
+	User         struct {
 		ID        int    `json:"id"`
 		Name      string `json:"name"`
 		Username  string `json:"username"`
@@ -56,21 +56,25 @@ type ResourceLabelEvent struct {
 	} `json:"label"`
 }
 
-// ListResourceLabelEventsOptions represents the options for resource label events services list functions.
-type ListResourceLabelEventsOptions struct {
+// ListLabelEventsOptions represents the options for all resource label events
+// list methods.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/resource_label_events.html#list-project-issue-label-events
+type ListLabelEventsOptions struct {
 	ListOptions
 }
 
-// ListIssueResourceLabelEvents retrieves resource label events
-// for the specified project and issue.
+// ListIssueLabelEvents retrieves resource label events for the
+// specified project and issue.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/resource_label_events.html#list-project-issue-label-events
-func (s *ResourceLabelEventsService) ListIssueResourceLabelEvents(pid interface{}, issue int, opt *ListResourceLabelEventsOptions, options ...OptionFunc) ([]*ResourceLabelEvent, *Response, error) {
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/resource_label_events.html#list-project-issue-label-events
+func (s *ResourceLabelEventsService) ListIssueLabelEvents(pid interface{}, issue int, opt *ListLabelEventsOptions, options ...OptionFunc) ([]*LabelEvent, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
-
 	u := fmt.Sprintf("projects/%s/issues/%d/resource_label_events", pathEscape(project), issue)
 
 	req, err := s.client.NewRequest("GET", u, opt, options)
@@ -78,19 +82,20 @@ func (s *ResourceLabelEventsService) ListIssueResourceLabelEvents(pid interface{
 		return nil, nil, err
 	}
 
-	var rs []*ResourceLabelEvent
-	resp, err := s.client.Do(req, &rs)
+	var ls []*LabelEvent
+	resp, err := s.client.Do(req, &ls)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return rs, resp, err
+	return ls, resp, err
 }
 
-// GetIssueResourceLabelEvent gets a single issue-label-event.
+// GetIssueLabelEvent gets a single issue-label-event.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/resource_label_events.html#get-single-issue-label-event
-func (s *ResourceLabelEventsService) GetIssueResourceLabelEvent(pid interface{}, issue int, event int, options ...OptionFunc) (*ResourceLabelEvent, *Response, error) {
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/resource_label_events.html#get-single-issue-label-event
+func (s *ResourceLabelEventsService) GetIssueLabelEvent(pid interface{}, issue int, event int, options ...OptionFunc) (*LabelEvent, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
@@ -102,25 +107,25 @@ func (s *ResourceLabelEventsService) GetIssueResourceLabelEvent(pid interface{},
 		return nil, nil, err
 	}
 
-	e := new(ResourceLabelEvent)
-	resp, err := s.client.Do(req, e)
+	l := new(LabelEvent)
+	resp, err := s.client.Do(req, l)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return e, resp, err
+	return l, resp, err
 }
 
-// ListGroupEpicResourceLabelEvents retrieves resource label events
-// for the specified group and epic.
+// ListGroupEpicLabelEvents retrieves resource label events for the specified
+// group and epic.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/resource_label_events.html#list-group-epic-label-events
-func (s *ResourceLabelEventsService) ListGroupEpicResourceLabelEvents(gid interface{}, epic int, opt *ListResourceLabelEventsOptions, options ...OptionFunc) ([]*ResourceLabelEvent, *Response, error) {
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/resource_label_events.html#list-group-epic-label-events
+func (s *ResourceLabelEventsService) ListGroupEpicLabelEvents(gid interface{}, epic int, opt *ListLabelEventsOptions, options ...OptionFunc) ([]*LabelEvent, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
 		return nil, nil, err
 	}
-
 	u := fmt.Sprintf("groups/%s/epics/%d/resource_label_events", pathEscape(group), epic)
 
 	req, err := s.client.NewRequest("GET", u, opt, options)
@@ -128,19 +133,20 @@ func (s *ResourceLabelEventsService) ListGroupEpicResourceLabelEvents(gid interf
 		return nil, nil, err
 	}
 
-	var rs []*ResourceLabelEvent
-	resp, err := s.client.Do(req, &rs)
+	var ls []*LabelEvent
+	resp, err := s.client.Do(req, &ls)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return rs, resp, err
+	return ls, resp, err
 }
 
-// GetGroupEpicResourceLabelEvent gets a single group epic label event.
+// GetGroupEpicLabelEvent gets a single group epic label event.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/resource_label_events.html#get-single-epic-label-event
-func (s *ResourceLabelEventsService) GetGroupEpicResourceLabelEvent(gid interface{}, epic int, event int, options ...OptionFunc) (*ResourceLabelEvent, *Response, error) {
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/resource_label_events.html#get-single-epic-label-event
+func (s *ResourceLabelEventsService) GetGroupEpicLabelEvent(gid interface{}, epic int, event int, options ...OptionFunc) (*LabelEvent, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
 		return nil, nil, err
@@ -152,25 +158,25 @@ func (s *ResourceLabelEventsService) GetGroupEpicResourceLabelEvent(gid interfac
 		return nil, nil, err
 	}
 
-	e := new(ResourceLabelEvent)
-	resp, err := s.client.Do(req, e)
+	l := new(LabelEvent)
+	resp, err := s.client.Do(req, l)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return e, resp, err
+	return l, resp, err
 }
 
-// ListMergeRequestResourceLabelEvents retrieves resource label events
-// for the specified project and merge request.
+// ListMergeLabelEvents retrieves resource label events for the specified
+// project and merge request.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/resource_label_events.html#list-project-merge-request-label-events
-func (s *ResourceLabelEventsService) ListMergeRequestResourceLabelEvents(pid interface{}, request int, opt *ListResourceLabelEventsOptions, options ...OptionFunc) ([]*ResourceLabelEvent, *Response, error) {
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/resource_label_events.html#list-project-merge-request-label-events
+func (s *ResourceLabelEventsService) ListMergeLabelEvents(pid interface{}, request int, opt *ListLabelEventsOptions, options ...OptionFunc) ([]*LabelEvent, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
-
 	u := fmt.Sprintf("projects/%s/merge_requests/%d/resource_label_events", pathEscape(project), request)
 
 	req, err := s.client.NewRequest("GET", u, opt, options)
@@ -178,19 +184,20 @@ func (s *ResourceLabelEventsService) ListMergeRequestResourceLabelEvents(pid int
 		return nil, nil, err
 	}
 
-	var rs []*ResourceLabelEvent
-	resp, err := s.client.Do(req, &rs)
+	var ls []*LabelEvent
+	resp, err := s.client.Do(req, &ls)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return rs, resp, err
+	return ls, resp, err
 }
 
-// GetMergeRequestResourceLabelEvent gets a single merge request label event.
+// GetMergeRequestLabelEvent gets a single merge request label event.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/resource_label_events.html#get-single-merge-request-label-event
-func (s *ResourceLabelEventsService) GetMergeRequestResourceLabelEvent(pid interface{}, request int, event int, options ...OptionFunc) (*ResourceLabelEvent, *Response, error) {
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/resource_label_events.html#get-single-merge-request-label-event
+func (s *ResourceLabelEventsService) GetMergeRequestLabelEvent(pid interface{}, request int, event int, options ...OptionFunc) (*LabelEvent, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
@@ -202,11 +209,11 @@ func (s *ResourceLabelEventsService) GetMergeRequestResourceLabelEvent(pid inter
 		return nil, nil, err
 	}
 
-	e := new(ResourceLabelEvent)
-	resp, err := s.client.Do(req, e)
+	l := new(LabelEvent)
+	resp, err := s.client.Do(req, l)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return e, resp, err
+	return l, resp, err
 }

--- a/resource_label_events.go
+++ b/resource_label_events.go
@@ -56,7 +56,7 @@ type ResourceLabelEvent struct {
 	} `json:"label"`
 }
 
-// ListResourceLabelEventsOptions represents the options for 
+// ListResourceLabelEventsOptions represents the options for resource label events services list functions.
 type ListResourceLabelEventsOptions struct {
 	ListOptions
 }


### PR DESCRIPTION
This is in response to issue #600 

Decided just to create the MR with hopes of getting this in sooner (so I don't have to run on my fork). Note that I've tested the the project-issue functions, however, since I do not have epics and do not use merge labels those have not been thoroughly tested but follow the published API specs. 

I've tried to follow what was done already for some of the other services. For instance the ResourceLabelEvent structure is based on the struct I saw in the Event service.
