### PR TITLE
Add support for revert a commit

### DIFF
--- a/commits.go
+++ b/commits.go
@@ -492,7 +492,7 @@ type CherryPickCommitOptions struct {
 	TargetBranch *string `url:"branch" json:"branch,omitempty"`
 }
 
-// CherryPickCommit sherry picks a commit to a given branch.
+// CherryPickCommit cherry picks a commit to a given branch.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/commits.html#cherry-pick-a-commit
 func (s *CommitsService) CherryPickCommit(pid interface{}, sha string, opt *CherryPickCommitOptions, options ...OptionFunc) (*Commit, *Response, error) {

--- a/commits.go
+++ b/commits.go
@@ -515,3 +515,34 @@ func (s *CommitsService) CherryPickCommit(pid interface{}, sha string, opt *Cher
 
 	return c, resp, err
 }
+
+// RevertCommitOptions represents the available RevertCommit() options.
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/commits.html#revert-a-commit
+type RevertCommitOptions struct {
+	Branch *string `url:"branch,omitempty" json:"branch,omitempty"`
+}
+
+// RevertCommit reverts a commit in a given branch.
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/commits.html#revert-a-commit
+func (s *CommitsService) RevertCommit(pid interface{}, sha string, opt *RevertCommitOptions, options ...OptionFunc) (*Commit, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/repository/commits/%s/revert", pathEscape(project), sha)
+
+	req, err := s.client.NewRequest("POST", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var c *Commit
+	resp, err := s.client.Do(req, &c)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return c, resp, err
+}

--- a/commits.go
+++ b/commits.go
@@ -485,11 +485,11 @@ func (s *CommitsService) GetMergeRequestsByCommit(pid interface{}, sha string, o
 	return mrs, resp, err
 }
 
-// CherryPickCommitOptions represents the available options for cherry-picking a commit.
+// CherryPickCommitOptions represents the available CherryPickCommit() options.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/commits.html#cherry-pick-a-commit
 type CherryPickCommitOptions struct {
-	TargetBranch *string `url:"branch" json:"branch,omitempty"`
+	Branch *string `url:"branch,omitempty" json:"branch,omitempty"`
 }
 
 // CherryPickCommit cherry picks a commit to a given branch.

--- a/commits_test.go
+++ b/commits_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var testRevertCommitTargetBranch = "release"
+
 func TestGetCommit(t *testing.T) {
 	mux, server, client := setup()
 	defer teardown(server)
@@ -90,4 +92,85 @@ func TestSetCommitStatus(t *testing.T) {
 	if !reflect.DeepEqual(want, status) {
 		t.Errorf("Commits.SetCommitStatus returned %+v, want %+v", status, want)
 	}
+}
+
+func TestRevertCommit_NoOptions(t *testing.T) {
+	mux, server, client := setup()
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v4/projects/1/repository/commits/b0b3a907f41409829b307a28b82fdbd552ee5a27/revert", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		mustWriteHTTPResponse(t, w, "testdata/get_commit.json")
+	})
+
+	commit, resp, err := client.Commits.RevertCommit("1", "b0b3a907f41409829b307a28b82fdbd552ee5a27", nil)
+	if err != nil {
+		t.Fatalf("Commits.RevertCommit returned error: %v, response: %v", err, resp)
+	}
+
+	want := &Commit{
+		ID:             "6104942438c14ec7bd21c6cd5bd995272b3faff6",
+		ShortID:        "6104942438c",
+		Title:          "Sanitize for network graph",
+		AuthorName:     "randx",
+		AuthorEmail:    "dmitriy.zaporozhets@gmail.com",
+		CommitterName:  "Dmitriy",
+		CommitterEmail: "dmitriy.zaporozhets@gmail.com",
+		Message:        "Sanitize for network graph",
+		ParentIDs:      []string{"ae1d9fb46aa2b07ee9836d49862ec4e2c46fbbba"},
+		Stats:          &CommitStats{Additions: 15, Deletions: 10, Total: 25},
+		Status:         BuildState(Running),
+		LastPipeline: &PipelineInfo{
+			ID:     8,
+			Ref:    "master",
+			SHA:    "2dc6aa325a317eda67812f05600bdf0fcdc70ab0",
+			Status: "created",
+			WebURL: "https://gitlab.com/gitlab-org/gitlab-ce/pipelines/54268416",
+		},
+		ProjectID: 13083,
+	}
+
+	assert.Equal(t, want, commit)
+}
+
+func TestRevertCommit_WithOptions(t *testing.T) {
+	mux, server, client := setup()
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v4/projects/1/repository/commits/b0b3a907f41409829b307a28b82fdbd552ee5a27/revert", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		testBody(t, r, `{"branch":"release"}`)
+		mustWriteHTTPResponse(t, w, "testdata/get_commit.json")
+	})
+
+	commit, resp, err := client.Commits.RevertCommit("1", "b0b3a907f41409829b307a28b82fdbd552ee5a27", &RevertCommitOptions{
+		Branch: &testRevertCommitTargetBranch,
+	})
+	if err != nil {
+		t.Fatalf("Commits.RevertCommit returned error: %v, response: %v", err, resp)
+	}
+
+	want := &Commit{
+		ID:             "6104942438c14ec7bd21c6cd5bd995272b3faff6",
+		ShortID:        "6104942438c",
+		Title:          "Sanitize for network graph",
+		AuthorName:     "randx",
+		AuthorEmail:    "dmitriy.zaporozhets@gmail.com",
+		CommitterName:  "Dmitriy",
+		CommitterEmail: "dmitriy.zaporozhets@gmail.com",
+		Message:        "Sanitize for network graph",
+		ParentIDs:      []string{"ae1d9fb46aa2b07ee9836d49862ec4e2c46fbbba"},
+		Stats:          &CommitStats{Additions: 15, Deletions: 10, Total: 25},
+		Status:         BuildState(Running),
+		LastPipeline: &PipelineInfo{
+			ID:     8,
+			Ref:    "master",
+			SHA:    "2dc6aa325a317eda67812f05600bdf0fcdc70ab0",
+			Status: "created",
+			WebURL: "https://gitlab.com/gitlab-org/gitlab-ce/pipelines/54268416",
+		},
+		ProjectID: 13083,
+	}
+
+	assert.Equal(t, want, commit)
 }


### PR DESCRIPTION
Hi,

the client library lacks support for "revert a commit" operation, that Gitlab introduced in 11.5 version. This PR allows for such operation.

/cc @svanharmelen 