### PR TITLE
issues: added `in` option

### DIFF
--- a/issues.go
+++ b/issues.go
@@ -162,6 +162,7 @@ type ListGroupIssuesOptions struct {
 	OrderBy         *string    `url:"order_by,omitempty" json:"order_by,omitempty"`
 	Sort            *string    `url:"sort,omitempty" json:"sort,omitempty"`
 	Search          *string    `url:"search,omitempty" json:"search,omitempty"`
+	In              *string    `url:"in,omitempty" json:"in,omitempty"`
 	CreatedAfter    *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
 	CreatedBefore   *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
 	UpdatedAfter    *time.Time `url:"updated_after,omitempty" json:"updated_after,omitempty"`
@@ -209,6 +210,7 @@ type ListProjectIssuesOptions struct {
 	OrderBy         *string    `url:"order_by,omitempty" json:"order_by,omitempty"`
 	Sort            *string    `url:"sort,omitempty" json:"sort,omitempty"`
 	Search          *string    `url:"search,omitempty" json:"search,omitempty"`
+	In              *string    `url:"in,omitempty" json:"in,omitempty"`
 	CreatedAfter    *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
 	CreatedBefore   *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
 	UpdatedAfter    *time.Time `url:"updated_after,omitempty" json:"updated_after,omitempty"`


### PR DESCRIPTION
Adding the `in` option to groups and projects when getting issues, as it is a functionality that is provided but not documented.

Have made a MR at Gitlab for documenting this - https://gitlab.com/gitlab-org/gitlab-ce/merge_requests/30053 .