### PR TITLE
Add IID field to CreateIssueOptions and CreatedAt field to CreateIssueNoteOptions

### DIFF
--- a/issues.go
+++ b/issues.go
@@ -270,6 +270,7 @@ func (s *IssuesService) GetIssue(pid interface{}, issue int, options ...OptionFu
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/issues.html#new-issues
 type CreateIssueOptions struct {
+	IID                                *int       `url:"iid,omitempty" json:"iid,omitempty"`
 	Title                              *string    `url:"title,omitempty" json:"title,omitempty"`
 	Description                        *string    `url:"description,omitempty" json:"description,omitempty"`
 	Confidential                       *bool      `url:"confidential,omitempty" json:"confidential,omitempty"`

--- a/notes.go
+++ b/notes.go
@@ -154,7 +154,8 @@ func (s *NotesService) GetIssueNote(pid interface{}, issue, note int, options ..
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/notes.html#create-new-issue-note
 type CreateIssueNoteOptions struct {
-	Body *string `url:"body,omitempty" json:"body,omitempty"`
+	Body      *string    `url:"body,omitempty" json:"body,omitempty"`
+	CreatedAt *time.Time `url:"created_at,omitempty" json:"created_at,omitempty"`
 }
 
 // CreateIssueNote creates a new note to a single project issue.


### PR DESCRIPTION
Add IID field to CreateIssueOptions, which allows explicitly setting
the internal ID assigned to the new issue at creation time.  This
allows preserving issue ID's when migrating issues into GitLab from a
different issue tracker.

Add CreatedAt field to CreateIssueNoteOptions, which allows explicitly
setting the creation time assigned to the new issue note.  This allows
preserving a comment's creation time when migrating comments into
GitLab from a different issue tracker.

See https://docs.gitlab.com/ce/api/issues.html#new-issue and https://docs.gitlab.com/ce/api/notes.html#create-new-issue-note