### PR TITLE
Add LocalMarkdownVersion field to Settings and UpdateSettingsOptions

### DIFF
--- a/settings.go
+++ b/settings.go
@@ -75,6 +75,7 @@ type Settings struct {
 	ImportSources                       []string          `json:"import_sources"`
 	KodingEnabled                       bool              `json:"koding_enabled"`
 	KodingURL                           string            `json:"koding_url"`
+	LocalMarkdownVersion                int               `json:"local_markdown_version"`
 	MaxArtifactsSize                    int               `json:"max_artifacts_size"`
 	MaxAttachmentSize                   int               `json:"max_attachment_size"`
 	MaxPagesSize                        int               `json:"max_pages_size"`
@@ -195,6 +196,7 @@ type UpdateSettingsOptions struct {
 	ImportSources                       []string          `url:"import_sources,omitempty" json:"import_sources,omitempty"`
 	KodingEnabled                       *bool             `url:"koding_enabled,omitempty" json:"koding_enabled,omitempty"`
 	KodingURL                           *string           `url:"koding_url,omitempty" json:"koding_url,omitempty"`
+	LocalMarkdownVersion                *int              `url:"local_markdown_version,omitempty" json:"local_markdown_version,omitempty"`
 	MaxArtifactsSize                    *int              `url:"max_artifacts_size,omitempty" json:"max_artifacts_size,omitempty"`
 	MaxAttachmentSize                   *int              `url:"max_attachment_size,omitempty" json:"max_attachment_size,omitempty"`
 	MaxPagesSize                        *int              `url:"max_pages_size,omitempty" json:"max_pages_size,omitempty"`


### PR DESCRIPTION
Add LocalMarkdownVersion field to Settings and UpdateSettingsOptions.
Incrementing LocalMarkdownVersion invalidates GitLab's internal
Markdown cache, which is helpful in certain situations.  See:

https://docs.gitlab.com/ce/administration/invalidate_markdown_cache.html
https://docs.gitlab.com/ce/api/settings.html#get-current-application-settings
https://docs.gitlab.com/ce/api/settings.html#change-application-settings