### PR TITLE
ListTodo allows for ListOptions

### DIFF
--- a/testdata/list_todos.json
+++ b/testdata/list_todos.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": 1,
+    "state": "pending",
+    "target": {
+      "id": 1,
+      "approvals_before_merge": 2
+    }
+  },
+  {
+    "id": 2,
+    "state": "pending",
+    "target": {
+      "id": 2,
+      "approvals_before_merge": null
+    }
+  }
+]

--- a/todos.go
+++ b/todos.go
@@ -121,6 +121,7 @@ func (t Todo) String() string {
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/todos.html#get-a-list-of-todos
 type ListTodosOptions struct {
+	ListOptions
 	Action    *TodoAction `url:"action,omitempty" json:"action,omitempty"`
 	AuthorID  *int        `url:"author_id,omitempty" json:"author_id,omitempty"`
 	ProjectID *int        `url:"project_id,omitempty" json:"project_id,omitempty"`

--- a/todos_test.go
+++ b/todos_test.go
@@ -1,10 +1,10 @@
 package gitlab
 
 import (
-	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestListTodos(t *testing.T) {
@@ -13,21 +13,16 @@ func TestListTodos(t *testing.T) {
 
 	mux.HandleFunc("/api/v4/todos", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, `[{"id":1,"state": "pending","target":{"id":1,"approvals_before_merge":2}},{"id":2,"state":"pending","target":{"id":2,"approvals_before_merge":null}}]`)
+		mustWriteHTTPResponse(t, w, "testdata/list_todos.json")
 	})
 
-	opts := &ListTodosOptions{}
+	opts := &ListTodosOptions{ListOptions: ListOptions{PerPage: 2}}
 	todos, _, err := client.Todos.ListTodos(opts)
 
-	if err != nil {
-		t.Errorf("Todos.ListTodos returned error: %v", err)
-	}
+	require.NoError(t, err)
 
 	want := []*Todo{{ID: 1, State: "pending", Target: TodoTarget{ID: 1, ApprovalsBeforeMerge: 2}}, {ID: 2, State: "pending", Target: TodoTarget{ID: 2}}}
-	if !reflect.DeepEqual(want, todos) {
-		t.Errorf("Todos.ListTodos returned %+v, want %+v", todos, want)
-	}
-
+	require.Equal(t, want, todos)
 }
 
 func TestMarkAllTodosAsDone(t *testing.T) {
@@ -40,10 +35,7 @@ func TestMarkAllTodosAsDone(t *testing.T) {
 	})
 
 	_, err := client.Todos.MarkAllTodosAsDone()
-
-	if err != nil {
-		t.Fatalf("Todos.MarkTodosRead returns an error: %v", err)
-	}
+	require.NoError(t, err)
 }
 
 func TestMarkTodoAsDone(t *testing.T) {
@@ -55,8 +47,5 @@ func TestMarkTodoAsDone(t *testing.T) {
 	})
 
 	_, err := client.Todos.MarkTodoAsDone(1)
-
-	if err != nil {
-		t.Fatalf("Todos.MarkTodoRead returns an error: %v", err)
-	}
+	require.NoError(t, err)
 }


### PR DESCRIPTION
The GitLab API Docs are missing these options, but they are supported as
the GitLab specs show[1], and can be verified for a signed in user[2].

Including them here breaks the interface when users used assignments
without Field names.

[1]: https://gitlab.com/gitlab-org/gitlab-ce/blob/4325986f25b7523acac49cfaefb7149208ae8553/spec/requests/api/todos_spec.rb#L39
[2]: https://gitlab.com/api/v4/todos?per_page=1