### PR TITLE
Added approvers change functions for merge requests

### DIFF
--- a/merge_request_approvals.go
+++ b/merge_request_approvals.go
@@ -126,3 +126,72 @@ func (s *MergeRequestApprovalsService) UnapproveMergeRequest(pid interface{}, mr
 
 	return s.client.Do(req, nil)
 }
+
+// ChangeMergeRequestApprovalConfigurationOptions represents the available
+// ChangeMergeRequestApprovalConfiguration() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/merge_request_approvals.html#change-approval-configuration
+type ChangeMergeRequestApprovalConfigurationOptions struct {
+	ApprovalsRequired *int `url:"approvals_required" json:"approvals_required"`
+}
+
+// ChangeMergeRequestApprovalConfiguration updates the approval configuration of a MR.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/merge_request_approvals.html#change-approval-configuration
+func (s *MergeRequestApprovalsService) ChangeMergeRequestApprovalConfiguration(pid interface{}, mergeRequestIID int, opt *ChangeMergeRequestApprovalConfigurationOptions, options ...OptionFunc) (*MergeRequest, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/merge_requests/%d/approvals", pathEscape(project), mergeRequestIID)
+
+	req, err := s.client.NewRequest("POST", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	m := new(MergeRequest)
+	resp, err := s.client.Do(req, m)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return m, resp, err
+}
+
+// ChangeMergeRequestAllowedApproversOptions represents the available
+// ChangeMergeRequestAllowedApprovers() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/merge_request_approvals.html#change-allowed-approvers-for-merge-request
+type ChangeMergeRequestAllowedApproversOptions struct {
+	ApproverIDs      []int `url:"approver_ids" json:"approver_ids"`
+	ApproverGroupIDs []int `url:"approver_group_ids" json:"approver_group_ids"`
+}
+
+// ChangeMergeRequestAllowedApprovers updates the approvers for a MR.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/merge_request_approvals.html#change-allowed-approvers-for-merge-request
+func (s *MergeRequestApprovalsService) ChangeMergeRequestAllowedApprovers(pid interface{}, mergeRequestIID int, opt *ChangeMergeRequestAllowedApproversOptions, options ...OptionFunc) (*MergeRequest, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/merge_requests/%d/approvers", pathEscape(project), mergeRequestIID)
+
+	req, err := s.client.NewRequest("PUT", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	m := new(MergeRequest)
+	resp, err := s.client.Do(req, m)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return m, resp, err
+}


### PR DESCRIPTION
Added a couple missing functions for approval/approvers management on merge requests :
- https://docs.gitlab.com/ee/api/merge_request_approvals.html#change-approval-configuration
- https://docs.gitlab.com/ee/api/merge_request_approvals.html#change-allowed-approvers-for-merge-request