### PR TITLE
Add missing end point GetPipelineVariables in Pipelines API

### DIFF
--- a/pipelines.go
+++ b/pipelines.go
@@ -168,6 +168,30 @@ func (s *PipelinesService) GetPipeline(pid interface{}, pipeline int, options ..
 	return p, resp, err
 }
 
+// GetPipelineVariables gets the variables of a single project pipeline.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/pipelines.html#get-variables-of-a-pipeline
+func (s *PipelinesService) GetPipelineVariables(pid interface{}, pipeline int, options ...OptionFunc) ([]*PipelineVariable, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/pipelines/%d/variables", pathEscape(project), pipeline)
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var p []*PipelineVariable
+	resp, err := s.client.Do(req, &p)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return p, resp, err
+}
+
 // CreatePipelineOptions represents the available CreatePipeline() options.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/pipelines.html#create-a-new-pipeline

--- a/pipelines.go
+++ b/pipelines.go
@@ -209,7 +209,7 @@ func (s *PipelinesService) RetryPipelineBuild(pid interface{}, pipeline int, opt
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/pipelines/%d/retry", project, pipeline)
+	u := fmt.Sprintf("projects/%s/pipelines/%d/retry", pathEscape(project), pipeline)
 
 	req, err := s.client.NewRequest("POST", u, nil, options)
 	if err != nil {
@@ -234,7 +234,7 @@ func (s *PipelinesService) CancelPipelineBuild(pid interface{}, pipeline int, op
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/pipelines/%d/cancel", project, pipeline)
+	u := fmt.Sprintf("projects/%s/pipelines/%d/cancel", pathEscape(project), pipeline)
 
 	req, err := s.client.NewRequest("POST", u, nil, options)
 	if err != nil {
@@ -259,7 +259,7 @@ func (s *PipelinesService) DeletePipeline(pid interface{}, pipeline int, options
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/pipelines/%d", project, pipeline)
+	u := fmt.Sprintf("projects/%s/pipelines/%d", pathEscape(project), pipeline)
 
 	req, err := s.client.NewRequest("DELETE", u, nil, options)
 	if err != nil {

--- a/pipelines_test.go
+++ b/pipelines_test.go
@@ -48,6 +48,26 @@ func TestGetPipeline(t *testing.T) {
 	}
 }
 
+func TestGetPipelineVariables(t *testing.T) {
+	mux, server, client := setup()
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v4/projects/1/pipelines/5949167/variables", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `[{"key":"RUN_NIGHTLY_BUILD","variable_type":"env_var","value":"true"},{"key":"foo","value":"bar"}]`)
+	})
+
+	variables, _, err := client.Pipelines.GetPipelineVariables(1, 5949167)
+	if err != nil {
+		t.Errorf("Pipelines.GetPipelineVariables returned error: %v", err)
+	}
+
+	want := []*PipelineVariable{{Key: "RUN_NIGHTLY_BUILD", Value: "true"}, {Key: "foo", Value: "bar"}}
+	if !reflect.DeepEqual(want, variables) {
+		t.Errorf("Pipelines.GetPipelineVariables returned %+v, want %+v", variables, want)
+	}
+}
+
 func TestCreatePipeline(t *testing.T) {
 	mux, server, client := setup()
 	defer teardown(server)


### PR DESCRIPTION
This end point was missing. See GitLab docs: https://docs.gitlab.com/ce/api/pipelines.html#get-variables-of-a-pipeline

Added the code together with a unit test.

Also added an small amend on some of the existing end points that were not path escaping the project ids.
