### PR TITLE
allow to search project milestone by title

### DIFF
--- a/milestones.go
+++ b/milestones.go
@@ -55,9 +55,10 @@ func (m Milestone) String() string {
 // https://docs.gitlab.com/ce/api/milestones.html#list-project-milestones
 type ListMilestonesOptions struct {
 	ListOptions
-	IIDs   []int  `url:"iids,omitempty" json:"iids,omitempty"`
-	State  string `url:"state,omitempty" json:"state,omitempty"`
-	Search string `url:"search,omitempty" json:"search,omitempty"`
+	IIDs   []int   `url:"iids,omitempty" json:"iids,omitempty"`
+	Title  *string `url:"title,omitempty" json:"title,omitempty"`
+	State  string  `url:"state,omitempty" json:"state,omitempty"`
+	Search string  `url:"search,omitempty" json:"search,omitempty"`
 }
 
 // ListMilestones returns a list of project milestones.


### PR DESCRIPTION
Adding the field "title" to search project milestone by title as https://docs.gitlab.com/ce/api/milestones.html#list-project-milestones mentionned.

Also I was wondering why other fields are not pointers as in other go-gitlab options structures. But because of BC I didn't change it.