### PR TITLE
Add TagList attribute to list runner options

### DIFF
--- a/runners.go
+++ b/runners.go
@@ -74,15 +74,24 @@ type RunnerDetails struct {
 	MaximumTimeout int      `json:"maximum_timeout"`
 }
 
+// TagList is a custom type with specific marshaling characteristics.
+type TagList []string
+
+// MarshalJSON implements the json.Marshaler interface.
+func (l *TagList) MarshalJSON() ([]byte, error) {
+	return json.Marshal(strings.Join(*l, ","))
+}
+
 // ListRunnersOptions represents the available ListRunners() options.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/runners.html#list-owned-runners
 type ListRunnersOptions struct {
 	ListOptions
-	Scope  *string `url:"scope,omitempty" json:"scope,omitempty"`
-	Status *string `url:"status,omitempty" json:"status,omitempty"`
-	Type   *string `url:"type,omitempty" json:"type,omitempty"`
+	Scope   *string `url:"scope,omitempty" json:"scope,omitempty"`
+	Status  *string `url:"status,omitempty" json:"status,omitempty"`
+	TagList TagList `url:"tag_list,comma,omitempty" json:"type,omitempty"`
+	Type    *string `url:"type,omitempty" json:"type,omitempty"`
 }
 
 // ListRunners gets a list of runners accessible by the authenticated user.


### PR DESCRIPTION
Add `tag_list` params to list runner options. Necessary to filter runners by tags. Used `Labels` struct as reference. Let me know if there's anything to improve.

References:
- [List owner runners](https://docs.gitlab.com/ee/api/runners.html#list-owned-runners)
- [List all runners](https://docs.gitlab.com/ee/api/runners.html#list-all-runners)