### PR TITLE
Add template values to CreateProjectOptions

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -449,6 +449,9 @@ type CreateProjectOptions struct {
 	Mirror                                    *bool             `url:"mirror,omitempty" json:"mirror,omitempty"`
 	MirrorTriggerBuilds                       *bool             `url:"mirror_trigger_builds,omitempty" json:"mirror_trigger_builds,omitempty"`
 	InitializeWithReadme                      *bool             `url:"initialize_with_readme,omitempty" json:"initialize_with_readme,omitempty"`
+	TemplateName                              *string           `url:"template_name,omitempty" json:"template_name,omitempty"`
+	UseCustomTemplate                         *bool             `url:"use_custom_template,omitempty" json:"use_custom_template,omitempty"`
+	GroupWithProjectTemplatesID               *int              `url:"group_with_project_templates_id,omitempty" json:"group_with_project_templates_id,omitempty"`
 }
 
 // CreateProject creates a new project owned by the authenticated user.


### PR DESCRIPTION
It enables the creation of a new project from a built-in or custom template.
The feature is available in GitLab Premium, GitLab.com Silver, and higher tiers.

Reference: https://docs.gitlab.com/ce/api/projects.html#create-project