### PR TITLE
Add order and sort by to runner jobs options

### DIFF
--- a/runners.go
+++ b/runners.go
@@ -217,7 +217,7 @@ func (s *RunnersService) RemoveRunner(rid interface{}, options ...OptionFunc) (*
 // options. Status can be one of: running, success, failed, canceled.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/runners.html#list-runner-39-s-jobs
+// https://docs.gitlab.com/ce/api/runners.html#list-runners-jobs
 type ListRunnerJobsOptions struct {
 	ListOptions
 	Status  *string `url:"status,omitempty" json:"status,omitempty"`

--- a/runners.go
+++ b/runners.go
@@ -220,7 +220,9 @@ func (s *RunnersService) RemoveRunner(rid interface{}, options ...OptionFunc) (*
 // https://docs.gitlab.com/ce/api/runners.html#list-runner-39-s-jobs
 type ListRunnerJobsOptions struct {
 	ListOptions
-	Status *string `url:"status,omitempty" json:"status,omitempty"`
+	Status  *string `url:"status,omitempty" json:"status,omitempty"`
+	OrderBy *string `url:"order_by,omitempty" json:"order_by,omitempty"`
+	Sort    *string `url:"sort,omitempty" json:"sort,omitempty"`
 }
 
 // ListRunnerJobs gets a list of jobs that are being processed or were processed by specified Runner.


### PR DESCRIPTION
This allows runner jobs sort order to be changed from descending to ascending.

References:
- [List runner jobs](https://docs.gitlab.com/ee/api/runners.html#list-runners-jobs)