### PR TITLE
Add support for missing project merge approval option

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -1249,6 +1249,7 @@ type ProjectApprovals struct {
 	ResetApprovalsOnPush                      bool                         `json:"reset_approvals_on_push"`
 	DisableOverridingApproversPerMergeRequest bool                         `json:"disable_overriding_approvers_per_merge_request"`
 	MergeRequestsAuthorApproval               bool                         `json:"merge_requests_author_approval"`
+	MergeRequestsDisableCommittersApproval    bool                         `json:"merge_requests_disable_committers_approval"`
 }
 
 // GetApprovalConfiguration get the approval configuration for a project.
@@ -1286,6 +1287,7 @@ type ChangeApprovalConfigurationOptions struct {
 	ResetApprovalsOnPush                      *bool `url:"reset_approvals_on_push,omitempty" json:"reset_approvals_on_push,omitempty"`
 	DisableOverridingApproversPerMergeRequest *bool `url:"disable_overriding_approvers_per_merge_request,omitempty" json:"disable_overriding_approvers_per_merge_request,omitempty"`
 	MergeRequestsAuthorApproval               *bool `url:"merge_requests_author_approval,omitempty" json:"merge_requests_author_approval,omitempty"`
+	MergeRequestsDisableCommittersApproval    *bool `url:"merge_requests_disable_committers_approval,omitempty" json:"merge_requests_disable_committers_approval,omitempty"`
 }
 
 // ChangeApprovalConfiguration updates the approval configuration for a project.

--- a/projects_test.go
+++ b/projects_test.go
@@ -400,7 +400,8 @@ func TestGetApprovalConfiguration(t *testing.T) {
 			"approvals_before_merge": 3,
 			"reset_approvals_on_push": false,
 			"disable_overriding_approvers_per_merge_request": false,
-			"merge_requests_author_approval": true
+			"merge_requests_author_approval": true,
+			"merge_requests_disable_committers_approval": true
 		}`)
 	})
 
@@ -416,6 +417,7 @@ func TestGetApprovalConfiguration(t *testing.T) {
 		ResetApprovalsOnPush: false,
 		DisableOverridingApproversPerMergeRequest: false,
 		MergeRequestsAuthorApproval:               true,
+		MergeRequestsDisableCommittersApproval:    true,
 	}
 
 	if !reflect.DeepEqual(want, approvals) {
@@ -436,7 +438,8 @@ func TestChangeApprovalConfiguration(t *testing.T) {
 			"approvals_before_merge": 3,
 			"reset_approvals_on_push": false,
 			"disable_overriding_approvers_per_merge_request": false,
-			"merge_requests_author_approval": true
+			"merge_requests_author_approval": true,
+			"merge_requests_disable_committers_approval": true
 		}`)
 	})
 
@@ -456,6 +459,7 @@ func TestChangeApprovalConfiguration(t *testing.T) {
 		ResetApprovalsOnPush: false,
 		DisableOverridingApproversPerMergeRequest: false,
 		MergeRequestsAuthorApproval:               true,
+		MergeRequestsDisableCommittersApproval:    true,
 	}
 
 	if !reflect.DeepEqual(want, approvals) {


### PR DESCRIPTION
The gitlab API has support for a boolean flag that controls whether committers for a given merge request are allowed to approve the merge request.  Support for this flag was missing in go-gitlab; this pull request adds the field to the ProjectApprovals and ChangeApprovalConfigurationOptions structures.