### PR TITLE
support 'search' parameter in ListBranches method

### DIFF
--- a/branches.go
+++ b/branches.go
@@ -52,7 +52,7 @@ func (b Branch) String() string {
 // https://docs.gitlab.com/ce/api/branches.html#list-repository-branches
 type ListBranchesOptions struct {
 	ListOptions
-	Search string `url:"search,omitempty" json:"search,omitempty"`
+	Search *string `url:"search,omitempty" json:"search,omitempty"`
 }
 
 // ListBranches gets a list of repository branches from a project, sorted by

--- a/branches.go
+++ b/branches.go
@@ -50,7 +50,10 @@ func (b Branch) String() string {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/branches.html#list-repository-branches
-type ListBranchesOptions ListOptions
+type ListBranchesOptions struct {
+	ListOptions
+	Search string `url:"search,omitempty" json:"search,omitempty"`
+}
 
 // ListBranches gets a list of repository branches from a project, sorted by
 // name alphabetically.


### PR DESCRIPTION
gitlab has 'search' parameter in list reposiory branches method

https://docs.gitlab.com/ce/api/branches.html#list-repository-branches

This MR adds support of this parameter to the gi-gitlab client.