### PR TITLE
Add `variable_type` to PipelineVariable and PipelineScheduleVariables

### DIFF
--- a/pipeline_schedules.go
+++ b/pipeline_schedules.go
@@ -236,8 +236,9 @@ func (s *PipelineSchedulesService) DeletePipelineSchedule(pid interface{}, sched
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/pipeline_schedules.html#create-a-new-pipeline-schedule
 type CreatePipelineScheduleVariableOptions struct {
-	Key   *string `url:"key" json:"key"`
-	Value *string `url:"value" json:"value"`
+	Key          *string `url:"key" json:"key"`
+	Value        *string `url:"value" json:"value"`
+	VariableType *string `url:"variable_type,omitempty" json:"variable_type,omitempty"`
 }
 
 // CreatePipelineScheduleVariable creates a pipeline schedule variable.
@@ -271,7 +272,8 @@ func (s *PipelineSchedulesService) CreatePipelineScheduleVariable(pid interface{
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/pipeline_schedules.html#edit-a-pipeline-schedule-variable
 type EditPipelineScheduleVariableOptions struct {
-	Value *string `url:"value" json:"value"`
+	Value        *string `url:"value" json:"value"`
+	VariableType *string `url:"variable_type,omitempty" json:"variable_type,omitempty"`
 }
 
 // EditPipelineScheduleVariable creates a pipeline schedule variable.

--- a/pipelines.go
+++ b/pipelines.go
@@ -33,8 +33,9 @@ type PipelinesService struct {
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/pipelines.html
 type PipelineVariable struct {
-	Key   string `json:"key"`
-	Value string `json:"value"`
+	Key          string `json:"key"`
+	Value        string `json:"value"`
+	VariableType string `json:"variable_type"`
 }
 
 // Pipeline represents a GitLab pipeline.

--- a/pipelines_test.go
+++ b/pipelines_test.go
@@ -62,7 +62,7 @@ func TestGetPipelineVariables(t *testing.T) {
 		t.Errorf("Pipelines.GetPipelineVariables returned error: %v", err)
 	}
 
-	want := []*PipelineVariable{{Key: "RUN_NIGHTLY_BUILD", Value: "true"}, {Key: "foo", Value: "bar"}}
+	want := []*PipelineVariable{{Key: "RUN_NIGHTLY_BUILD", Value: "true", VariableType: "env_var"}, {Key: "foo", Value: "bar"}}
 	if !reflect.DeepEqual(want, variables) {
 		t.Errorf("Pipelines.GetPipelineVariables returned %+v, want %+v", variables, want)
 	}


### PR DESCRIPTION
This PR adds `variable_type` to pipeline variable and pipeline schedule variables.

Docs for the attribute: https://docs.gitlab.com/ee/api/pipeline_schedules.html#create-a-new-pipeline-schedule-variable