### PR TITLE
Add build type manual

### DIFF
--- a/gitlab.go
+++ b/gitlab.go
@@ -87,6 +87,7 @@ const (
 	Failed   BuildStateValue = "failed"
 	Canceled BuildStateValue = "canceled"
 	Skipped  BuildStateValue = "skipped"
+	Manual   BuildStateValue = "manual"
 )
 
 // ISOTime represents an ISO 8601 formatted date


### PR DESCRIPTION
`ListProjectPipelinesOptions... Status: gitlab.BuildState(gitlab.Manual)`
for CI jobs with
```
  when: manual
```