### PR TITLE
Add `Locked` to `RunnerDetails` struct

### DIFF
--- a/runners.go
+++ b/runners.go
@@ -77,6 +77,7 @@ type RunnerDetails struct {
 		Name   string `json:"name"`
 		WebURL string `json:"web_url"`
 	} `json:"groups"`
+	Locked         bool `json:"locked"`
 }
 
 // ListRunnersOptions represents the available ListRunners() options.

--- a/runners.go
+++ b/runners.go
@@ -70,6 +70,7 @@ type RunnerDetails struct {
 	Revision       string   `json:"revision"`
 	TagList        []string `json:"tag_list"`
 	Version        string   `json:"version"`
+	Locked         bool `json:"locked"`
 	AccessLevel    string   `json:"access_level"`
 	MaximumTimeout int      `json:"maximum_timeout"`
 	Groups         []struct {
@@ -77,7 +78,6 @@ type RunnerDetails struct {
 		Name   string `json:"name"`
 		WebURL string `json:"web_url"`
 	} `json:"groups"`
-	Locked         bool `json:"locked"`
 }
 
 // ListRunnersOptions represents the available ListRunners() options.

--- a/runners_test.go
+++ b/runners_test.go
@@ -105,7 +105,7 @@ const exampleDetailRsp = `{
 	"version": null,
 	"access_level": "ref_protected",
 	"maximum_timeout": 3600,
-        "locked": false
+	"locked": false
 }`
 
 func TestUpdateRunnersDetails(t *testing.T) {
@@ -179,7 +179,7 @@ func expectedParsedDetails() *RunnerDetails {
 			PathWithNamespace string `json:"path_with_namespace"`
 		}{proj},
 		MaximumTimeout: 3600,
-                Locked: false,
+		Locked:         false,
 	}
 }
 

--- a/runners_test.go
+++ b/runners_test.go
@@ -104,7 +104,8 @@ const exampleDetailRsp = `{
 	],
 	"version": null,
 	"access_level": "ref_protected",
-	"maximum_timeout": 3600
+	"maximum_timeout": 3600,
+        "locked": false
 }`
 
 func TestUpdateRunnersDetails(t *testing.T) {
@@ -178,6 +179,7 @@ func expectedParsedDetails() *RunnerDetails {
 			PathWithNamespace string `json:"path_with_namespace"`
 		}{proj},
 		MaximumTimeout: 3600,
+                Locked: false,
 	}
 }
 


### PR DESCRIPTION
It's available in the API, but not exposed until now.