### PR TITLE
Handle merge request level approval rules

### DIFF
--- a/merge_request_approvals.go
+++ b/merge_request_approvals.go
@@ -65,15 +65,15 @@ type MergeRequestApproverGroup struct {
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/merge_request_approvals.html#get-merge-request-level-rules
 type MergeRequestApprovalRule struct {
-	ID                   int                        `json:"id,omitempty""`
-	Name                 string                     `json:"name,omitempty""`
-	RuleType             string                     `json:"rule_type,omitempty""`
-	EligibleApprovers    []*BasicUser               `json:"eligible_approvers,omitempty""`
-	ApprovalsRequired    int                        `json:"approvals_required,omitempty""`
-	SourceRule           *CreateApprovalRuleOptions `json:"source_rule,omitempty""`
-	Users                []*BasicUser               `json:"users,omitempty""`
-	Groups               []*Group                   `json:"groups,omitempty""`
-	ContainsHiddenGroups bool                       `json:"contains_hidden_groups,omitempty""`
+	ID                   int                        `json:"id,omitempty"`
+	Name                 string                     `json:"name,omitempty"`
+	RuleType             string                     `json:"rule_type,omitempty"`
+	EligibleApprovers    []*BasicUser               `json:"eligible_approvers,omitempty"`
+	ApprovalsRequired    int                        `json:"approvals_required,omitempty"`
+	SourceRule           *CreateApprovalRuleOptions `json:"source_rule,omitempty"`
+	Users                []*BasicUser               `json:"users,omitempty"`
+	Groups               []*Group                   `json:"groups,omitempty"`
+	ContainsHiddenGroups bool                       `json:"contains_hidden_groups,omitempty"`
 }
 
 func (s MergeRequestApprovalRule) String() string {
@@ -241,11 +241,11 @@ func (s *MergeRequestApprovalsService) GetApprovalRules(pid interface{}, mergeRe
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/merge_request_approvals.html#create-merge-request-level-rule
 type CreateApprovalRuleOptions struct {
-	Name                  string `url:"name,omitempty" json:"name,omitempty"`
-	ApprovalsRequired     int    `url:"approvals_required,omitempty" json:"approvals_required,omitempty"`
-	ApprovalProjectRuleID int    `url:"approval_project_rule_id,omitempty" json:"approval_project_rule_id,omitempty"`
-	UserIDs               []int  `url:"user_ids,omitempty" json:"user_ids,omitempty"`
-	GroupIDs              []int  `url:"group_ids,omitempty" json:"group_ids,omitempty"`
+	Name                  *string `url:"name,omitempty" json:"name,omitempty"`
+	ApprovalsRequired     *int    `url:"approvals_required,omitempty" json:"approvals_required,omitempty"`
+	ApprovalProjectRuleID *int    `url:"approval_project_rule_id,omitempty" json:"approval_project_rule_id,omitempty"`
+	UserIDs               []int   `url:"user_ids,omitempty" json:"user_ids,omitempty"`
+	GroupIDs              []int   `url:"group_ids,omitempty" json:"group_ids,omitempty"`
 }
 
 // CreateApprovalRule creates a new MR level approval rule.

--- a/merge_request_approvals.go
+++ b/merge_request_approvals.go
@@ -65,15 +65,15 @@ type MergeRequestApproverGroup struct {
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/merge_request_approvals.html#get-merge-request-level-rules
 type MergeRequestApprovalRule struct {
-	ID                   int                        `json:"id,omitempty"`
-	Name                 string                     `json:"name,omitempty"`
-	RuleType             string                     `json:"rule_type,omitempty"`
-	EligibleApprovers    []*BasicUser               `json:"eligible_approvers,omitempty"`
-	ApprovalsRequired    int                        `json:"approvals_required,omitempty"`
-	SourceRule           *CreateApprovalRuleOptions `json:"source_rule,omitempty"`
-	Users                []*BasicUser               `json:"users,omitempty"`
-	Groups               []*Group                   `json:"groups,omitempty"`
-	ContainsHiddenGroups bool                       `json:"contains_hidden_groups,omitempty"`
+	ID                   int                                    `json:"id,omitempty"`
+	Name                 string                                 `json:"name,omitempty"`
+	RuleType             string                                 `json:"rule_type,omitempty"`
+	EligibleApprovers    []*BasicUser                           `json:"eligible_approvers,omitempty"`
+	ApprovalsRequired    int                                    `json:"approvals_required,omitempty"`
+	SourceRule           *CreateMergeRequestApprovalRuleOptions `json:"source_rule,omitempty"`
+	Users                []*BasicUser                           `json:"users,omitempty"`
+	Groups               []*Group                               `json:"groups,omitempty"`
+	ContainsHiddenGroups bool                                   `json:"contains_hidden_groups,omitempty"`
 }
 
 func (s MergeRequestApprovalRule) String() string {

--- a/merge_request_approvals.go
+++ b/merge_request_approvals.go
@@ -235,12 +235,12 @@ func (s *MergeRequestApprovalsService) GetApprovalRules(pid interface{}, mergeRe
 	return par, resp, err
 }
 
-// CreateApprovalRuleOptions represents the available CreateApprovalRule()
+// CreateMergeRequestApprovalRuleOptions represents the available CreateApprovalRule()
 // options.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/merge_request_approvals.html#create-merge-request-level-rule
-type CreateApprovalRuleOptions struct {
+type CreateMergeRequestApprovalRuleOptions struct {
 	Name                  *string `url:"name,omitempty" json:"name,omitempty"`
 	ApprovalsRequired     *int    `url:"approvals_required,omitempty" json:"approvals_required,omitempty"`
 	ApprovalProjectRuleID *int    `url:"approval_project_rule_id,omitempty" json:"approval_project_rule_id,omitempty"`
@@ -252,7 +252,7 @@ type CreateApprovalRuleOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/merge_request_approvals.html#create-merge-request-level-rule
-func (s *MergeRequestApprovalsService) CreateApprovalRule(pid interface{}, mergeRequestIID int, opt *CreateApprovalRuleOptions, options ...OptionFunc) (*MergeRequestApprovalRule, *Response, error) {
+func (s *MergeRequestApprovalsService) CreateApprovalRule(pid interface{}, mergeRequestIID int, opt *CreateMergeRequestApprovalRuleOptions, options ...OptionFunc) (*MergeRequestApprovalRule, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
@@ -273,12 +273,12 @@ func (s *MergeRequestApprovalsService) CreateApprovalRule(pid interface{}, merge
 	return par, resp, err
 }
 
-// UpdateApprovalRuleOptions represents the available UpdateApprovalRule()
+// UpdateMergeRequestApprovalRuleOptions represents the available UpdateApprovalRule()
 // options.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/merge_request_approvals.html#update-merge-request-level-rule
-type UpdateApprovalRuleOptions struct {
+type UpdateMergeRequestApprovalRuleOptions struct {
 	Name              *string `url:"name,omitempty" json:"name,omitempty"`
 	ApprovalsRequired *int    `url:"approvals_required,omitempty" json:"approvals_required,omitempty"`
 	UserIDs           []int   `url:"user_ids,omitempty" json:"user_ids,omitempty"`
@@ -289,7 +289,7 @@ type UpdateApprovalRuleOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/merge_request_approvals.html#update-merge-request-level-rule
-func (s *MergeRequestApprovalsService) UpdateApprovalRule(pid interface{}, mergeRequestIID int, approvalRule int, opt *UpdateProjectLevelRuleOptions, options ...OptionFunc) (*MergeRequestApprovalRule, *Response, error) {
+func (s *MergeRequestApprovalsService) UpdateApprovalRule(pid interface{}, mergeRequestIID int, approvalRule int, opt *UpdateMergeRequestApprovalRuleOptions, options ...OptionFunc) (*MergeRequestApprovalRule, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err

--- a/merge_request_approvals.go
+++ b/merge_request_approvals.go
@@ -60,6 +60,26 @@ type MergeRequestApproverGroup struct {
 	}
 }
 
+// MergeRequestApprovalRule represents a GitLab merge request approval rule.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/merge_request_approvals.html#get-merge-request-level-rules
+type MergeRequestApprovalRule struct {
+	ID                   int                        `json:"id,omitempty""`
+	Name                 string                     `json:"name,omitempty""`
+	RuleType             string                     `json:"rule_type,omitempty""`
+	EligibleApprovers    []*BasicUser               `json:"eligible_approvers,omitempty""`
+	ApprovalsRequired    int                        `json:"approvals_required,omitempty""`
+	SourceRule           *CreateApprovalRuleOptions `json:"source_rule,omitempty""`
+	Users                []*BasicUser               `json:"users,omitempty""`
+	Groups               []*Group                   `json:"groups,omitempty""`
+	ContainsHiddenGroups bool                       `json:"contains_hidden_groups,omitempty""`
+}
+
+func (s MergeRequestApprovalRule) String() string {
+	return Stringify(s)
+}
+
 // MergeRequestApproverUser  represents GitLab project level merge request approver user.
 //
 // GitLab API docs:
@@ -188,4 +208,123 @@ func (s *MergeRequestApprovalsService) ChangeAllowedApprovers(pid interface{}, m
 	}
 
 	return m, resp, err
+}
+
+// GetApprovalRules requests information about a merge request’s approval rules
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/merge_request_approvals.html#get-merge-request-level-rules
+func (s *MergeRequestApprovalsService) GetApprovalRules(pid interface{}, mergeRequestIID int, options ...OptionFunc) ([]*MergeRequestApprovalRule, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/merge_requests/%d/approval_rules", pathEscape(project), mergeRequestIID)
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var par []*MergeRequestApprovalRule
+	resp, err := s.client.Do(req, &par)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return par, resp, err
+}
+
+// CreateApprovalRuleOptions represents the available CreateApprovalRule()
+// options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/merge_request_approvals.html#create-merge-request-level-rule
+type CreateApprovalRuleOptions struct {
+	Name                  string `url:"name,omitempty" json:"name,omitempty"`
+	ApprovalsRequired     int    `url:"approvals_required,omitempty" json:"approvals_required,omitempty"`
+	ApprovalProjectRuleID int    `url:"approval_project_rule_id,omitempty" json:"approval_project_rule_id,omitempty"`
+	UserIDs               []int  `url:"user_ids,omitempty" json:"user_ids,omitempty"`
+	GroupIDs              []int  `url:"group_ids,omitempty" json:"group_ids,omitempty"`
+}
+
+// CreateApprovalRule creates a new MR level approval rule.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/merge_request_approvals.html#create-merge-request-level-rule
+func (s *MergeRequestApprovalsService) CreateApprovalRule(pid interface{}, mergeRequestIID int, opt *CreateApprovalRuleOptions, options ...OptionFunc) (*MergeRequestApprovalRule, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/merge_requests/%d/approval_rules", pathEscape(project), mergeRequestIID)
+
+	req, err := s.client.NewRequest("POST", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	par := new(MergeRequestApprovalRule)
+	resp, err := s.client.Do(req, &par)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return par, resp, err
+}
+
+// UpdateApprovalRuleOptions represents the available UpdateApprovalRule()
+// options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/merge_request_approvals.html#update-merge-request-level-rule
+type UpdateApprovalRuleOptions struct {
+	Name              *string `url:"name,omitempty" json:"name,omitempty"`
+	ApprovalsRequired *int    `url:"approvals_required,omitempty" json:"approvals_required,omitempty"`
+	UserIDs           []int   `url:"user_ids,omitempty" json:"user_ids,omitempty"`
+	GroupIDs          []int   `url:"group_ids,omitempty" json:"group_ids,omitempty"`
+}
+
+// UpdateApprovalRule updates an existing approval rule with new options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/merge_request_approvals.html#update-merge-request-level-rule
+func (s *MergeRequestApprovalsService) UpdateApprovalRule(pid interface{}, mergeRequestIID int, approvalRule int, opt *UpdateProjectLevelRuleOptions, options ...OptionFunc) (*MergeRequestApprovalRule, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/merge_requests/%d/approval_rules/%d", pathEscape(project), mergeRequestIID, approvalRule)
+
+	req, err := s.client.NewRequest("PUT", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	par := new(MergeRequestApprovalRule)
+	resp, err := s.client.Do(req, &par)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return par, resp, err
+}
+
+// DeleteApprovalRule deletes a mr level approval rule.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/merge_request_approvals.html#delete-merge-request-level-rule
+func (s *MergeRequestApprovalsService) DeleteApprovalRule(pid interface{}, mergeRequestIID int, approvalRule int, options ...OptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/merge_requests/%d/approval_rules/%d", pathEscape(project), mergeRequestIID, approvalRule)
+
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
 }

--- a/merge_request_approvals.go
+++ b/merge_request_approvals.go
@@ -65,17 +65,18 @@ type MergeRequestApproverGroup struct {
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/merge_request_approvals.html#get-merge-request-level-rules
 type MergeRequestApprovalRule struct {
-	ID                   int                                    `json:"id,omitempty"`
-	Name                 string                                 `json:"name,omitempty"`
-	RuleType             string                                 `json:"rule_type,omitempty"`
-	EligibleApprovers    []*BasicUser                           `json:"eligible_approvers,omitempty"`
-	ApprovalsRequired    int                                    `json:"approvals_required,omitempty"`
-	SourceRule           *CreateMergeRequestApprovalRuleOptions `json:"source_rule,omitempty"`
-	Users                []*BasicUser                           `json:"users,omitempty"`
-	Groups               []*Group                               `json:"groups,omitempty"`
-	ContainsHiddenGroups bool                                   `json:"contains_hidden_groups,omitempty"`
+	ID                   int                  `json:"id"`
+	Name                 string               `json:"name"`
+	RuleType             string               `json:"rule_type"`
+	EligibleApprovers    []*BasicUser         `json:"eligible_approvers"`
+	ApprovalsRequired    int                  `json:"approvals_required"`
+	SourceRule           *ProjectApprovalRule `json:"source_rule"`
+	Users                []*BasicUser         `json:"users"`
+	Groups               []*Group             `json:"groups"`
+	ContainsHiddenGroups bool                 `json:"contains_hidden_groups"`
 }
 
+// String is a stringify for MergeRequestApprovalRule
 func (s MergeRequestApprovalRule) String() string {
 	return Stringify(s)
 }

--- a/merge_request_approvals_test.go
+++ b/merge_request_approvals_test.go
@@ -1,0 +1,263 @@
+package gitlab
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestGetApprovalRules(t *testing.T) {
+	mux, server, client := setup()
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v4/projects/1/merge_requests/1/approval_rules", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `[
+			{
+				"id": 1,
+				"name": "security",
+				"rule_type": "regular",
+				"eligible_approvers": [
+					{
+						"id": 5,
+						"name": "John Doe",
+						"username": "jdoe",
+						"state": "active",
+						"avatar_url": "https://www.gravatar.com/avatar/0?s=80&d=identicon",
+						"web_url": "http://localhost/jdoe"
+					},
+					{
+						"id": 50,
+						"name": "Group Member 1",
+						"username": "group_member_1",
+						"state": "active",
+						"avatar_url": "https://www.gravatar.com/avatar/0?s=80&d=identicon",
+						"web_url": "http://localhost/group_member_1"
+					}
+				],
+				"approvals_required": 3,
+				"source_rule": null,
+				"users": [
+					{
+						"id": 5,
+						"name": "John Doe",
+						"username": "jdoe",
+						"state": "active",
+						"avatar_url": "https://www.gravatar.com/avatar/0?s=80&d=identicon",
+						"web_url": "http://localhost/jdoe"
+					}
+				],
+				"groups": [
+					{
+						"id": 5,
+						"name": "group1",
+						"path": "group1",
+						"description": "",
+						"visibility": "public",
+						"lfs_enabled": false,
+						"avatar_url": null,
+						"web_url": "http://localhost/groups/group1",
+						"request_access_enabled": false,
+						"full_name": "group1",
+						"full_path": "group1",
+						"parent_id": null,
+						"ldap_cn": null,
+						"ldap_access": null
+					}
+				],
+				"contains_hidden_groups": false
+			}
+		]`)
+	})
+
+	approvals, _, err := client.MergeRequestApprovals.GetApprovalRules(1, 1)
+	if err != nil {
+		t.Errorf("MergeRequestApprovals.GetApprovalRules returned error: %v", err)
+	}
+
+	want := []*MergeRequestApprovalRule{
+		&MergeRequestApprovalRule{
+			ID:       1,
+			Name:     "security",
+			RuleType: "regular",
+			EligibleApprovers: []*BasicUser{
+				&BasicUser{
+					ID:        5,
+					Name:      "John Doe",
+					Username:  "jdoe",
+					State:     "active",
+					AvatarURL: "https://www.gravatar.com/avatar/0?s=80&d=identicon",
+					WebURL:    "http://localhost/jdoe",
+				},
+				&BasicUser{
+					ID:        50,
+					Name:      "Group Member 1",
+					Username:  "group_member_1",
+					State:     "active",
+					AvatarURL: "https://www.gravatar.com/avatar/0?s=80&d=identicon",
+					WebURL:    "http://localhost/group_member_1",
+				},
+			},
+			ApprovalsRequired: 3,
+			Users: []*BasicUser{
+				&BasicUser{
+					ID:        5,
+					Name:      "John Doe",
+					Username:  "jdoe",
+					State:     "active",
+					AvatarURL: "https://www.gravatar.com/avatar/0?s=80&d=identicon",
+					WebURL:    "http://localhost/jdoe",
+				},
+			},
+			Groups: []*Group{
+				&Group{
+					ID:                   5,
+					Name:                 "group1",
+					Path:                 "group1",
+					Description:          "",
+					Visibility:           Visibility(PublicVisibility),
+					LFSEnabled:           false,
+					AvatarURL:            "",
+					WebURL:               "http://localhost/groups/group1",
+					RequestAccessEnabled: false,
+					FullName:             "group1",
+					FullPath:             "group1",
+				},
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(want, approvals) {
+		t.Errorf("MergeRequestApprovals.GetApprovalRules returned %+v, want %+v", approvals, want)
+	}
+}
+
+func TestCreateApprovalRules(t *testing.T) {
+	mux, server, client := setup()
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v4/projects/1/merge_requests/1/approval_rules", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		fmt.Fprint(w, `{
+			"id": 1,
+			"name": "security",
+			"rule_type": "regular",
+			"eligible_approvers": [
+				{
+					"id": 5,
+					"name": "John Doe",
+					"username": "jdoe",
+					"state": "active",
+					"avatar_url": "https://www.gravatar.com/avatar/0?s=80&d=identicon",
+					"web_url": "http://localhost/jdoe"
+				},
+				{
+					"id": 50,
+					"name": "Group Member 1",
+					"username": "group_member_1",
+					"state": "active",
+					"avatar_url": "https://www.gravatar.com/avatar/0?s=80&d=identicon",
+					"web_url": "http://localhost/group_member_1"
+				}
+			],
+			"approvals_required": 3,
+			"source_rule": null,
+			"users": [
+				{
+					"id": 5,
+					"name": "John Doe",
+					"username": "jdoe",
+					"state": "active",
+					"avatar_url": "https://www.gravatar.com/avatar/0?s=80&d=identicon",
+					"web_url": "http://localhost/jdoe"
+				}
+			],
+			"groups": [
+				{
+					"id": 5,
+					"name": "group1",
+					"path": "group1",
+					"description": "",
+					"visibility": "public",
+					"lfs_enabled": false,
+					"avatar_url": null,
+					"web_url": "http://localhost/groups/group1",
+					"request_access_enabled": false,
+					"full_name": "group1",
+					"full_path": "group1",
+					"parent_id": null,
+					"ldap_cn": null,
+					"ldap_access": null
+				}
+			],
+			"contains_hidden_groups": false
+		}`)
+	})
+
+	opt := &CreateApprovalRuleOptions{
+		Name:              String("security"),
+		ApprovalsRequired: Int(3),
+		UserIDs:           []int{5, 50},
+		GroupIDs:          []int{5},
+	}
+
+	rule, _, err := client.MergeRequestApprovals.CreateApprovalRule(1, 1, opt)
+	if err != nil {
+		t.Errorf("MergeRequestApprovals.CreateApprovalRule returned error: %v", err)
+	}
+
+	want := &MergeRequestApprovalRule{
+		ID:       1,
+		Name:     "security",
+		RuleType: "regular",
+		EligibleApprovers: []*BasicUser{
+			&BasicUser{
+				ID:        5,
+				Name:      "John Doe",
+				Username:  "jdoe",
+				State:     "active",
+				AvatarURL: "https://www.gravatar.com/avatar/0?s=80&d=identicon",
+				WebURL:    "http://localhost/jdoe",
+			},
+			&BasicUser{
+				ID:        50,
+				Name:      "Group Member 1",
+				Username:  "group_member_1",
+				State:     "active",
+				AvatarURL: "https://www.gravatar.com/avatar/0?s=80&d=identicon",
+				WebURL:    "http://localhost/group_member_1",
+			},
+		},
+		ApprovalsRequired: 3,
+		Users: []*BasicUser{
+			&BasicUser{
+				ID:        5,
+				Name:      "John Doe",
+				Username:  "jdoe",
+				State:     "active",
+				AvatarURL: "https://www.gravatar.com/avatar/0?s=80&d=identicon",
+				WebURL:    "http://localhost/jdoe",
+			},
+		},
+		Groups: []*Group{
+			&Group{
+				ID:                   5,
+				Name:                 "group1",
+				Path:                 "group1",
+				Description:          "",
+				Visibility:           Visibility(PublicVisibility),
+				LFSEnabled:           false,
+				AvatarURL:            "",
+				WebURL:               "http://localhost/groups/group1",
+				RequestAccessEnabled: false,
+				FullName:             "group1",
+				FullPath:             "group1",
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(want, rule) {
+		t.Errorf("MergeRequestApprovals.CreateApprovalRule returned %+v, want %+v", rule, want)
+	}
+}

--- a/merge_request_approvals_test.go
+++ b/merge_request_approvals_test.go
@@ -195,7 +195,7 @@ func TestCreateApprovalRules(t *testing.T) {
 		}`)
 	})
 
-	opt := &CreateApprovalRuleOptions{
+	opt := &CreateMergeRequestApprovalRuleOptions{
 		Name:              String("security"),
 		ApprovalsRequired: Int(3),
 		UserIDs:           []int{5, 50},


### PR DESCRIPTION
Hello! I added support of MR level approval rules (https://docs.gitlab.com/ee/api/merge_request_approvals.html#get-merge-request-level-rules). For the base I used the project level implementation.

Btw I have a question - at the moment MR approval related methods moved to separated service.  But project approval methods stay in the project service. 
I wonder about consistency :(

Thanks!