### PR TITLE
Add BranchesToBeNotified to Slack notification service properties

### DIFF
--- a/services.go
+++ b/services.go
@@ -401,6 +401,7 @@ type SetSlackServiceOptions struct {
 	Channel                   *string `url:"channel,omitempty" json:"channel,omitempty"`
 	NotifyOnlyBrokenPipelines *bool   `url:"notify_only_broken_pipelines,omitempty" json:"notify_only_broken_pipelines,omitempty"`
 	NotifyOnlyDefaultBranch   *bool   `url:"notify_only_default_branch,omitempty" json:"notify_only_default_branch,omitempty"`
+	BranchesToBeNotified      *string `url:"branches_to_be_notified,omitempty" json:"branches_to_be_notified,omitempty"`
 	ConfidentialIssueChannel  *string `url:"confidential_issue_channel,omitempty" json:"confidential_issue_channel,omitempty"`
 	ConfidentialIssuesEvents  *bool   `url:"confidential_issues_events,omitempty" json:"confidential_issues_events,omitempty"`
 	// TODO: Currently, GitLab ignores this option (not implemented yet?), so
@@ -424,7 +425,6 @@ type SetSlackServiceOptions struct {
 	PushEvents             *bool   `url:"push_events,omitempty" json:"push_events,omitempty"`
 	WikiPageChannel        *string `url:"wiki_page_channel,omitempty" json:"wiki_page_channel,omitempty"`
 	WikiPageEvents         *bool   `url:"wiki_page_events,omitempty" json:"wiki_page_events,omitempty"`
-	BranchesToBeNotified   *string `url:"branches_to_be_notified,omitempty" json:"branches_to_be_notified,omitempty"`
 }
 
 // SetSlackService sets Slack service for a project

--- a/services.go
+++ b/services.go
@@ -352,6 +352,7 @@ type SlackServiceProperties struct {
 	Channel                   string    `json:"channel,omitempty"`
 	NotifyOnlyBrokenPipelines BoolValue `json:"notify_only_broken_pipelines,omitempty"`
 	NotifyOnlyDefaultBranch   BoolValue `json:"notify_only_default_branch,omitempty"`
+	BranchesToBeNotified      string    `json:"branches_to_be_notified,omitempty"`
 	ConfidentialIssueChannel  string    `json:"confidential_issue_channel,omitempty"`
 	ConfidentialNoteChannel   string    `json:"confidential_note_channel,omitempty"`
 	DeploymentChannel         string    `json:"deployment_channel,omitempty"`

--- a/services.go
+++ b/services.go
@@ -424,7 +424,7 @@ type SetSlackServiceOptions struct {
 	PushEvents             *bool   `url:"push_events,omitempty" json:"push_events,omitempty"`
 	WikiPageChannel        *string `url:"wiki_page_channel,omitempty" json:"wiki_page_channel,omitempty"`
 	WikiPageEvents         *bool   `url:"wiki_page_events,omitempty" json:"wiki_page_events,omitempty"`
-	BranchesToBeNotified   *string `url:"branches_to_be_notified,omitempty"` `json:"branches_to_be_notified,omitempty"`
+	BranchesToBeNotified   *string `url:"branches_to_be_notified,omitempty" json:"branches_to_be_notified,omitempty"`
 }
 
 // SetSlackService sets Slack service for a project

--- a/services.go
+++ b/services.go
@@ -424,6 +424,7 @@ type SetSlackServiceOptions struct {
 	PushEvents             *bool   `url:"push_events,omitempty" json:"push_events,omitempty"`
 	WikiPageChannel        *string `url:"wiki_page_channel,omitempty" json:"wiki_page_channel,omitempty"`
 	WikiPageEvents         *bool   `url:"wiki_page_events,omitempty" json:"wiki_page_events,omitempty"`
+	BranchesToBeNotified   *string `url:"branches_to_be_notified,omitempty"` `json:"branches_to_be_notified,omitempty"`
 }
 
 // SetSlackService sets Slack service for a project


### PR DESCRIPTION
As per the [API documentation](https://docs.gitlab.com/ee/api/services.html#createedit-slack-service) this field is missing (and I need it)