### PR TITLE
Add OrderBy and Sort parameters to ListContributorsOptions

### DIFF
--- a/repositories.go
+++ b/repositories.go
@@ -266,7 +266,11 @@ func (c Contributor) String() string {
 // ListContributorsOptions represents the available ListContributors() options.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/repositories.html#contributors
-type ListContributorsOptions ListOptions
+type ListContributorsOptions struct {
+	ListOptions
+	OrderBy *string `url:"order_by,omitempty" json:"order_by,omitempty"`
+	Sort    *string `url:"sort,omitempty" json:"sort,omitempty"`
+}
 
 // Contributors gets the repository contributors list.
 //


### PR DESCRIPTION
Reference: https://docs.gitlab.com/ce/api/repositories.html#contributors

```
Parameters:

- id (required) - The ID or URL-encoded path of the project owned by the authenticated user
- order_by (optional) - Return contributors ordered by name, email, or commits (orders by commit date) fields. Default is commits
- sort (optional) - Return contributors sorted in asc or desc order. Default is asc
```