### PR TITLE
Add function to transfer project to a namespace

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -1517,7 +1517,7 @@ func (s *ProjectsService) StartMirroringProject(pid interface{}, options ...Opti
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#transfer-a-project-to-a-new-namespace
 type TransferProjectOptions struct {
-	NamespaceID *int `url:"namespace,omitempty" json:"namespace,omitempty"`
+	Namespace interface{} `url:"namespace,omitempty" json:"namespace,omitempty"`
 }
 
 // TransferProject transfer a project into the specified namespace

--- a/projects.go
+++ b/projects.go
@@ -1512,3 +1512,34 @@ func (s *ProjectsService) StartMirroringProject(pid interface{}, options ...Opti
 
 	return resp, err
 }
+
+// TransferProjectOptions represents the available TransferProject() options.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#transfer-a-project-to-a-new-namespace
+type TransferProjectOptions struct {
+	NamespaceID *int `url:"namespace,omitempty" json:"namespace,omitempty"`
+}
+
+// TransferProject transfer a project into the specified namespace
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#transfer-a-project-to-a-new-namespace
+func (s *ProjectsService) TransferProject(pid interface{}, opt *TransferProjectOptions, options ...OptionFunc) (*Project, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/transfer", pathEscape(project))
+
+	req, err := s.client.NewRequest("PUT", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	p := new(Project)
+	resp, err := s.client.Do(req, p)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return p, resp, err
+}


### PR DESCRIPTION
This adds the TransferProject function to move projects to a namespace

### Example
```golang
if projects[p].ID == 10 {
	_, resp, _ := _gitlab.Projects.TransferProject(10, &gitlab.TransferProjectOptions{NamespaceID:gitlab.Int(5)})
	// Check status code
	if resp.StatusCode == 200 {
		//
	}
}
```