### PR TITLE
JobEvent: Adds pipeline_id

### DIFF
--- a/event_types.go
+++ b/event_types.go
@@ -203,6 +203,7 @@ type JobEvent struct {
 	BuildFinishedAt   string  `json:"build_finished_at"`
 	BuildDuration     float64 `json:"build_duration"`
 	BuildAllowFailure bool    `json:"build_allow_failure"`
+	PipelineID        int     `json:"pipeline_id"`
 	ProjectID         int     `json:"project_id"`
 	ProjectName       string  `json:"project_name"`
 	User              struct {


### PR DESCRIPTION
Adds the `pipeline_id` field to Gitlab CI Webhook Events (`JobEvent`):

https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#job-events