### PR TITLE
Add 2 request parameters to list-projects-pipelines

### DIFF
--- a/examples/pipelines.go
+++ b/examples/pipelines.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log"
+	"time"
 
 	"github.com/xanzy/go-gitlab"
 )
@@ -11,14 +12,16 @@ func pipelineExample() {
 	git.SetBaseURL("https://gitlab.com/api/v4")
 
 	opt := &gitlab.ListProjectPipelinesOptions{
-		Scope:      gitlab.String("branches"),
-		Status:     gitlab.BuildState(gitlab.Running),
-		Ref:        gitlab.String("master"),
-		YamlErrors: gitlab.Bool(true),
-		Name:       gitlab.String("name"),
-		Username:   gitlab.String("username"),
-		OrderBy:    gitlab.String("status"),
-		Sort:       gitlab.String("asc"),
+		Scope:         gitlab.String("branches"),
+		Status:        gitlab.BuildState(gitlab.Running),
+		Ref:           gitlab.String("master"),
+		YamlErrors:    gitlab.Bool(true),
+		Name:          gitlab.String("name"),
+		Username:      gitlab.String("username"),
+		UpdatedAfter:  gitlab.Time(time.Now().Add(-24 * 365 * time.Hour)),
+		UpdatedBefore: gitlab.Time(time.Now().Add(-7 * 24 * time.Hour)),
+		OrderBy:       gitlab.String("status"),
+		Sort:          gitlab.String("asc"),
 	}
 
 	pipelines, _, err := git.Pipelines.ListProjectPipelines(2743054, opt)

--- a/pipelines.go
+++ b/pipelines.go
@@ -101,15 +101,17 @@ func (p PipelineInfo) String() string {
 // GitLab API docs: https://docs.gitlab.com/ce/api/pipelines.html#list-project-pipelines
 type ListProjectPipelinesOptions struct {
 	ListOptions
-	Scope      *string          `url:"scope,omitempty" json:"scope,omitempty"`
-	Status     *BuildStateValue `url:"status,omitempty" json:"status,omitempty"`
-	Ref        *string          `url:"ref,omitempty" json:"ref,omitempty"`
-	SHA        *string          `url:"sha,omitempty" json:"sha,omitempty"`
-	YamlErrors *bool            `url:"yaml_errors,omitempty" json:"yaml_errors,omitempty"`
-	Name       *string          `url:"name,omitempty" json:"name,omitempty"`
-	Username   *string          `url:"username,omitempty" json:"username,omitempty"`
-	OrderBy    *string          `url:"order_by,omitempty" json:"order_by,omitempty"`
-	Sort       *string          `url:"sort,omitempty" json:"sort,omitempty"`
+	Scope         *string          `url:"scope,omitempty" json:"scope,omitempty"`
+	Status        *BuildStateValue `url:"status,omitempty" json:"status,omitempty"`
+	Ref           *string          `url:"ref,omitempty" json:"ref,omitempty"`
+	SHA           *string          `url:"sha,omitempty" json:"sha,omitempty"`
+	YamlErrors    *bool            `url:"yaml_errors,omitempty" json:"yaml_errors,omitempty"`
+	Name          *string          `url:"name,omitempty" json:"name,omitempty"`
+	Username      *string          `url:"username,omitempty" json:"username,omitempty"`
+	UpdatedAfter  *time.Time       `url:"updated_after,omitempty" json:"updated_after,omitempty"`
+	UpdatedBefore *time.Time       `url:"update_before,omitempty" json:"updated_before,omitempty"`
+	OrderBy       *string          `url:"order_by,omitempty" json:"order_by,omitempty"`
+	Sort          *string          `url:"sort,omitempty" json:"sort,omitempty"`
 }
 
 // ListProjectPipelines gets a list of project piplines.


### PR DESCRIPTION
`/projects/<id>/pipelines` has two additional parameters `updated_before` and `updated-after`. 