### PR TITLE
Add avatar and web URL fields to ProjectMember

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -797,6 +797,8 @@ type ProjectMember struct {
 	CreatedAt   *time.Time       `json:"created_at"`
 	ExpiresAt   *ISOTime         `json:"expires_at"`
 	AccessLevel AccessLevelValue `json:"access_level"`
+	WebURL      string           `json:"web_url"`
+	AvatarURL   string           `json:"avatar_url"`
 }
 
 // ProjectHook represents a project hook.


### PR DESCRIPTION
I noticed the `ProjectMember` struct was missing a couple of fields: "web_url" and "avatar_url". Docs: https://docs.gitlab.com/ee/api/members.html

It also appears that there are a few fields here not mentioned in the docs:

* `Email`
* `CreatedAt`

I also verified that these fields don't come from gitlab when I issue the request via curl (either querying a list of members or a single member). I didn't want to remove them because maybe they were used at some point, so I let them be.