### PR TITLE
Add masked attribute to group variables

### DIFF
--- a/group_variables.go
+++ b/group_variables.go
@@ -39,6 +39,7 @@ type GroupVariable struct {
 	Value        string            `json:"value"`
 	VariableType VariableTypeValue `json:"variable_type"`
 	Protected    bool              `json:"protected"`
+	Masked       bool              `json:"masked"`
 }
 
 func (v GroupVariable) String() string {
@@ -112,6 +113,7 @@ type CreateGroupVariableOptions struct {
 	Value        *string            `url:"value,omitempty" json:"value,omitempty"`
 	VariableType *VariableTypeValue `url:"variable_type,omitempty" json:"variable_type,omitempty"`
 	Protected    *bool              `url:"protected,omitempty" json:"protected,omitempty"`
+	Masked       *bool              `url:"masked,omitempty" json:"masked,omitempty"`
 }
 
 // CreateVariable creates a new group variable.
@@ -148,6 +150,7 @@ type UpdateGroupVariableOptions struct {
 	Value        *string            `url:"value,omitempty" json:"value,omitempty"`
 	VariableType *VariableTypeValue `url:"variable_type,omitempty" json:"variable_type,omitempty"`
 	Protected    *bool              `url:"protected,omitempty" json:"protected,omitempty"`
+	Masked       *bool              `url:"masked,omitempty" json:"masked,omitempty"`
 }
 
 // UpdateVariable updates the position of an existing

--- a/group_variables_test.go
+++ b/group_variables_test.go
@@ -1,0 +1,130 @@
+package gitlab
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestListGroupVariabless(t *testing.T) {
+	mux, server, client := setup()
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v4/groups/1/variables",
+		func(w http.ResponseWriter, r *http.Request) {
+			testMethod(t, r, "GET")
+			fmt.Fprint(w, `[{"key": "TEST_VARIABLE_1","value": "test1","protected": false,"masked": true}]`)
+		})
+
+	variables, _, err := client.GroupVariables.ListVariables(1, &ListGroupVariablesOptions{})
+	if err != nil {
+		t.Errorf("GroupVariables.ListVariables returned error: %v", err)
+	}
+
+	want := []*GroupVariable{
+		{
+			Key:       "TEST_VARIABLE_1",
+			Value:     "test1",
+			Protected: false,
+			Masked:    true,
+		},
+	}
+
+	if !reflect.DeepEqual(want, variables) {
+		t.Errorf("GroupVariables.ListVariablesreturned %+v, want %+v", variables, want)
+	}
+}
+
+func TestGetGroupVariable(t *testing.T) {
+	mux, server, client := setup()
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v4/groups/1/variables/TEST_VARIABLE_1",
+		func(w http.ResponseWriter, r *http.Request) {
+			testMethod(t, r, "GET")
+			fmt.Fprint(w, `{"key": "TEST_VARIABLE_1","value": "test1","protected": false,"masked": true}`)
+		})
+
+	variable, _, err := client.GroupVariables.GetVariable(1, "TEST_VARIABLE_1")
+
+	if err != nil {
+		t.Errorf("GroupVariables.GetVariable returned error: %v", err)
+	}
+
+	want := &GroupVariable{Key: "TEST_VARIABLE_1", Value: "test1", Protected: false, Masked: true}
+	if !reflect.DeepEqual(want, variable) {
+		t.Errorf("GroupVariables.GetVariable returned %+v, want %+v", variable, want)
+	}
+}
+
+func TestCreateGroupVariable(t *testing.T) {
+	mux, server, client := setup()
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v4/groups/1/variables",
+		func(w http.ResponseWriter, r *http.Request) {
+			testMethod(t, r, "POST")
+			fmt.Fprint(w, `{"key": "TEST_VARIABLE_1","value": "test1","protected": false,"masked": true}`)
+		})
+
+	opt := &CreateGroupVariableOptions{
+		Key:       String("TEST_VARIABLE_1"),
+		Value:     String("test1"),
+		Protected: Bool(false),
+		Masked:    Bool(true),
+	}
+
+	variable, _, err := client.GroupVariables.CreateVariable(1, opt, nil)
+	if err != nil {
+		t.Errorf("GroupVariables.CreateVariable returned error: %v", err)
+	}
+
+	want := &GroupVariable{Key: "TEST_VARIABLE_1", Value: "test1", Protected: false, Masked: true}
+	if !reflect.DeepEqual(want, variable) {
+		t.Errorf("GroupVariables.CreateVariable returned %+v, want %+v", variable, want)
+	}
+}
+
+func TestDeleteGroupVariable(t *testing.T) {
+	mux, server, client := setup()
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v4/groups/1/variables/TEST_VARIABLE_1",
+		func(w http.ResponseWriter, r *http.Request) {
+			testMethod(t, r, "DELETE")
+			w.WriteHeader(http.StatusAccepted)
+		})
+
+	resp, err := client.GroupVariables.RemoveVariable(1, "TEST_VARIABLE_1")
+	if err != nil {
+		t.Errorf("GroupVariables.RemoveVariable returned error: %v", err)
+	}
+
+	want := http.StatusAccepted
+	got := resp.StatusCode
+	if got != want {
+		t.Errorf("GroupVariables.RemoveVariable returned %d, want %d", got, want)
+	}
+}
+
+func TestUpdateGroupVariable(t *testing.T) {
+	mux, server, client := setup()
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v4/groups/1/variables/TEST_VARIABLE_1",
+		func(w http.ResponseWriter, r *http.Request) {
+			testMethod(t, r, "PUT")
+			fmt.Fprint(w, `{"key": "TEST_VARIABLE_1","value": "test1","protected": false,"masked": true}`)
+		})
+
+	variable, _, err := client.GroupVariables.UpdateVariable(1, "TEST_VARIABLE_1", &UpdateGroupVariableOptions{})
+	if err != nil {
+		t.Errorf("GroupVariables.UpdateVariable returned error: %v", err)
+	}
+
+	want := &GroupVariable{Key: "TEST_VARIABLE_1", Value: "test1", Protected: false, Masked: true}
+	if !reflect.DeepEqual(want, variable) {
+		t.Errorf("Groups.UpdatedGroup returned %+v, want %+v", variable, want)
+	}
+}


### PR DESCRIPTION
This PR adds recently added `masked` property for group variables.

https://docs.gitlab.com/ee/api/group_level_variables.html#create-variable

Also I noticed missing tests for group vars so I have added some.