### PR TITLE
Add support for ci_default_git_depth

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -92,10 +92,11 @@ type Project struct {
 		GroupName        string `json:"group_name"`
 		GroupAccessLevel int    `json:"group_access_level"`
 	} `json:"shared_with_groups"`
-	Statistics       *ProjectStatistics `json:"statistics"`
-	Links            *Links             `json:"_links,omitempty"`
-	CIConfigPath     *string            `json:"ci_config_path"`
-	CustomAttributes []*CustomAttribute `json:"custom_attributes"`
+	Statistics        *ProjectStatistics `json:"statistics"`
+	Links             *Links             `json:"_links,omitempty"`
+	CIConfigPath      *string            `json:"ci_config_path"`
+	CIDefaultGitDepth int                `json:"ci_default_git_depth"`
+	CustomAttributes  []*CustomAttribute `json:"custom_attributes"`
 }
 
 // Repository represents a repository.
@@ -550,6 +551,7 @@ type EditProjectOptions struct {
 	TagList                                   *[]string         `url:"tag_list,omitempty" json:"tag_list,omitempty"`
 	BuildCoverageRegex                        *string           `url:"build_coverage_regex,omitempty" json:"build_coverage_regex,omitempty"`
 	CIConfigPath                              *string           `url:"ci_config_path,omitempty" json:"ci_config_path,omitempty"`
+	CIDefaultGitDepth                         *int              `url:"ci_default_git_depth,omitempty" json:"ci_default_git_depth,omitempty"`
 	ApprovalsBeforeMerge                      *int              `url:"approvals_before_merge,omitempty" json:"approvals_before_merge,omitempty"`
 	ExternalAuthorizationClassificationLabel  *string           `url:"external_authorization_classification_label,omitempty" json:"external_authorization_classification_label,omitempty"`
 	Mirror                                    *bool             `url:"mirror,omitempty" json:"mirror,omitempty"`


### PR DESCRIPTION
GitLab started exposing a `ci_default_git_depth` attribute for projects via their API a few months back ([this MR](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/14061)), which maps to the "Git shallow clone"-settings under the CI/CD configuration for the project.

This PR adds support for that field when retrieving projects and when updating projects - I've tested that this works as expected on a local project here. I haven't added support for this to project creation as I'm not sure it even is exposed via the API and it wasn't part of the functionality I needed for my project here. If you'd like to add this as well, let me know and I can do a quick test of it before this gets merged.

Thanks!