### PR TITLE
Service to manage deploy tokens

### DIFF
--- a/deploy_tokens.go
+++ b/deploy_tokens.go
@@ -1,0 +1,221 @@
+package gitlab
+
+import (
+	"fmt"
+	"time"
+)
+
+// DeployTokensService handles communication with the deploy tokens related methods
+// of the GitLab API.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/deploy_tokens.html
+type DeployTokensService struct {
+	client *Client
+}
+
+// DeployToken represents a GitLab deploy token.
+type DeployToken struct {
+	ID        int        `json:"id"`
+	Name      string     `json:"name"`
+	Username  string     `json:"username"`
+	ExpiresAt *time.Time `json:"expires_at"`
+	Token     string     `json:"token,omitempty"`
+	Scopes    []string   `json:"scopes"`
+}
+
+func (k DeployToken) String() string {
+	return Stringify(k)
+}
+
+// ListAllDeployTokens gets a list of all deploy tokens.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/deploy_tokens.html#list-all-deploy-tokens
+func (s *DeployTokensService) ListAllDeployTokens(options ...OptionFunc) ([]*DeployToken, *Response, error) {
+	req, err := s.client.NewRequest("GET", "deploy_tokens", nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var ts []*DeployToken
+	resp, err := s.client.Do(req, &ts)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return ts, resp, err
+}
+
+// ListProjectDeployTokensOptions represents the available ListProjectDeployTokens()
+// options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/deploy_tokens.html#list-project-deploy-tokens
+type ListProjectDeployTokensOptions ListOptions
+
+// ListProjectDeployTokens gets a list of a project's deploy tokens.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/deploy_tokens.html#list-project-deploy-tokens
+func (s *DeployTokensService) ListProjectDeployTokens(pid interface{}, opt *ListProjectDeployTokensOptions, options ...OptionFunc) ([]*DeployToken, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/deploy_tokens", pathEscape(project))
+
+	req, err := s.client.NewRequest("GET", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var ts []*DeployToken
+	resp, err := s.client.Do(req, &ts)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return ts, resp, err
+}
+
+// CreateProjectDeployTokenOptions represents the available CreateProjectDeployToken() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/deploy_tokens.html#create-a-project-deploy-token
+type CreateProjectDeployTokenOptions struct {
+	Name      *string    `url:"name,omitempty" json:"name,omitempty"`
+	ExpiresAt *time.Time `url:"expires_at,omitempty" json:"expires_at,omitempty"`
+	Username  *string    `url:"username,omitempty" json:"username,omitempty"`
+	Scopes    []string   `url:"scopes,omitempty" json:"scopes,omitempty"`
+}
+
+// CreateProjectDeployToken creates a new deploy token for a project.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/deploy_tokens.html#create-a-project-deploy-token
+func (s *DeployTokensService) CreateProjectDeployToken(pid interface{}, opt *CreateProjectDeployTokenOptions, options ...OptionFunc) (*DeployToken, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/deploy_tokens", pathEscape(project))
+
+	req, err := s.client.NewRequest("POST", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	t := new(DeployToken)
+	resp, err := s.client.Do(req, t)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return t, resp, err
+}
+
+// DeleteProjectDeployToken removes a deploy token from the project.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/deploy_tokens.html#delete-a-project-deploy-token
+func (s *DeployTokensService) DeleteProjectDeployToken(pid interface{}, deployToken int, options ...OptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/deploy_tokens/%d", pathEscape(project), deployToken)
+
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// ListGroupDeployTokensOptions represents the available ListGroupDeployTokens()
+// options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/deploy_tokens.html#list-group-deploy-deploy-tokens
+type ListGroupDeployTokensOptions ListOptions
+
+// ListGroupDeployTokens gets a list of a group’s deploy tokens.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/deploy_tokens.html#list-project-deploy-tokens
+func (s *DeployTokensService) ListGroupDeployTokens(gid interface{}, opt *ListGroupDeployTokensOptions, options ...OptionFunc) ([]*DeployToken, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/deploy_tokens", pathEscape(group))
+
+	req, err := s.client.NewRequest("GET", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var ts []*DeployToken
+	resp, err := s.client.Do(req, &ts)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return ts, resp, err
+}
+
+// CreateGroupDeployTokenOptions represents the available CreateGroupDeployToken() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/deploy_tokens.html#create-a-group-deploy-token
+type CreateGroupDeployTokenOptions struct {
+	Name      *string    `url:"name,omitempty" json:"name,omitempty"`
+	ExpiresAt *time.Time `url:"expires_at,omitempty" json:"expires_at,omitempty"`
+	Username  *string    `url:"username,omitempty" json:"username,omitempty"`
+	Scopes    []string   `url:"scopes,omitempty" json:"scopes,omitempty"`
+}
+
+// CreateGroupDeployToken creates a new deploy token for a group.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/deploy_tokens.html#create-a-group-deploy-token
+func (s *DeployTokensService) CreateGroupDeployToken(gid interface{}, opt *CreateGroupDeployTokenOptions, options ...OptionFunc) (*DeployToken, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/deploy_tokens", pathEscape(group))
+
+	req, err := s.client.NewRequest("POST", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	t := new(DeployToken)
+	resp, err := s.client.Do(req, t)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return t, resp, err
+}
+
+// DeleteGroupDeployToken removes a deploy token from the group.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/deploy_tokens.html#delete-a-group-deploy-token
+func (s *DeployTokensService) DeleteGroupDeployToken(gid interface{}, deployToken int, options ...OptionFunc) (*Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("groups/%s/deploy_tokens/%d", pathEscape(group), deployToken)
+
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}

--- a/deploy_tokens_test.go
+++ b/deploy_tokens_test.go
@@ -1,0 +1,294 @@
+package gitlab
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestListAllDeployTokens(t *testing.T) {
+	mux, server, client := setup()
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v4/deploy_tokens", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `
+[
+	{
+		"id": 1,
+		"name": "MyToken",
+		"username": "gitlab+deploy-token-1",
+		"expires_at": "2020-02-14T00:00:00.000Z",
+		"scopes": [
+			"read_repository",
+			"read_registry"
+		]
+	}
+]
+`)
+	})
+
+	deployTokens, _, err := client.DeployTokens.ListAllDeployTokens()
+	if err != nil {
+		t.Errorf("DeployTokens.ListAllDeployTokens returned an error: %v", err)
+	}
+
+	wantExpiresAt := time.Date(2020, 02, 14, 0, 0, 0, 0, time.UTC)
+
+	want := []*DeployToken{
+		{
+			ID:        1,
+			Name:      "MyToken",
+			Username:  "gitlab+deploy-token-1",
+			ExpiresAt: &wantExpiresAt,
+			Scopes: []string{
+				"read_repository",
+				"read_registry",
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(want, deployTokens) {
+		t.Errorf("DeployTokens.ListAllDeployTokens returned %+v, want %+v", deployTokens, want)
+	}
+}
+
+func TestListProjectDeployTokens(t *testing.T) {
+	mux, server, client := setup()
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v4/projects/1/deploy_tokens", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `
+[
+  {
+    "id": 1,
+    "name": "MyToken",
+    "username": "gitlab+deploy-token-1",
+    "expires_at": "2020-02-14T00:00:00.000Z",
+    "scopes": [
+      "read_repository",
+      "read_registry"
+    ]
+  }
+]
+`)
+	})
+
+	deployTokens, _, err := client.DeployTokens.ListProjectDeployTokens(1, nil)
+	if err != nil {
+		t.Errorf("DeployTokens.ListProjectDeployTokens returned an error: %v", err)
+	}
+
+	wantExpiresAt := time.Date(2020, 02, 14, 0, 0, 0, 0, time.UTC)
+
+	want := []*DeployToken{
+		{
+			ID:        1,
+			Name:      "MyToken",
+			Username:  "gitlab+deploy-token-1",
+			ExpiresAt: &wantExpiresAt,
+			Scopes: []string{
+				"read_repository",
+				"read_registry",
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(want, deployTokens) {
+		t.Errorf("DeployTokens.ListProjectDeployTokens returned %+v, want %+v", deployTokens, want)
+	}
+}
+
+func TestCreateProjectDeployToken(t *testing.T) {
+	mux, server, client := setup()
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v4/projects/5/deploy_tokens", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		fmt.Fprint(w, `
+{
+	"id": 1,
+	"name": "My deploy token",
+	"username": "custom-user",
+	"expires_at": "2021-01-01T00:00:00.000Z",
+	"token": "jMRvtPNxrn3crTAGukpZ",
+	"scopes": [
+		"read_repository"
+	]
+}
+`)
+	})
+
+	expiresAt := time.Date(2021, 01, 01, 0, 0, 0, 0, time.UTC)
+
+	deployToken, _, err := client.DeployTokens.CreateProjectDeployToken(5, &CreateProjectDeployTokenOptions{
+		Name:      String("My deploy token"),
+		Username:  String("custom-user"),
+		ExpiresAt: &expiresAt,
+		Scopes: []string{
+			"read_repository",
+		},
+	})
+	if err != nil {
+		t.Errorf("DeployTokens.CreateProjectDeployToken returned an error: %v", err)
+	}
+
+	want := &DeployToken{
+		ID:        1,
+		Name:      "My deploy token",
+		Username:  "custom-user",
+		ExpiresAt: &expiresAt,
+		Token:     "jMRvtPNxrn3crTAGukpZ",
+		Scopes: []string{
+			"read_repository",
+		},
+	}
+
+	if !reflect.DeepEqual(want, deployToken) {
+		t.Errorf("DeployTokens.CreateProjectDeployToken returned %+v, want %+v", deployToken, want)
+	}
+}
+
+func TestDeleteProjectDeployToken(t *testing.T) {
+	mux, server, client := setup()
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v4/projects/5/deploy_tokens/13", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		w.WriteHeader(http.StatusAccepted)
+	})
+
+	resp, err := client.DeployTokens.DeleteProjectDeployToken(5, 13)
+	if err != nil {
+		t.Errorf("DeployTokens.DeleteProjectDeployToken returned an error: %v", err)
+	}
+
+	want := http.StatusAccepted
+	got := resp.StatusCode
+
+	if want != got {
+		t.Errorf("DeployTokens.DeleteProjectDeployToken returned %+v, want %+v", got, want)
+	}
+}
+
+func TestListGroupDeployTokens(t *testing.T) {
+	mux, server, client := setup()
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v4/groups/1/deploy_tokens", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `
+[
+  {
+    "id": 1,
+    "name": "MyToken",
+    "username": "gitlab+deploy-token-1",
+    "expires_at": "2020-02-14T00:00:00.000Z",
+    "scopes": [
+      "read_repository",
+      "read_registry"
+    ]
+  }
+]
+`)
+	})
+
+	deployTokens, _, err := client.DeployTokens.ListGroupDeployTokens(1, nil)
+	if err != nil {
+		t.Errorf("DeployTokens.ListGroupDeployTokens returned an error: %v", err)
+	}
+
+	wantExpiresAt := time.Date(2020, 02, 14, 0, 0, 0, 0, time.UTC)
+
+	want := []*DeployToken{
+		{
+			ID:        1,
+			Name:      "MyToken",
+			Username:  "gitlab+deploy-token-1",
+			ExpiresAt: &wantExpiresAt,
+			Scopes: []string{
+				"read_repository",
+				"read_registry",
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(want, deployTokens) {
+		t.Errorf("DeployTokens.ListGroupDeployTokens returned %+v, want %+v", deployTokens, want)
+	}
+}
+
+func TestCreateGroupDeployToken(t *testing.T) {
+	mux, server, client := setup()
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v4/groups/5/deploy_tokens", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		fmt.Fprint(w, `
+{
+	"id": 1,
+	"name": "My deploy token",
+	"username": "custom-user",
+	"expires_at": "2021-01-01T00:00:00.000Z",
+	"token": "jMRvtPNxrn3crTAGukpZ",
+	"scopes": [
+		"read_repository"
+	]
+}
+`)
+	})
+
+	expiresAt := time.Date(2021, 01, 01, 0, 0, 0, 0, time.UTC)
+
+	deployToken, _, err := client.DeployTokens.CreateGroupDeployToken(5, &CreateGroupDeployTokenOptions{
+		Name:      String("My deploy token"),
+		Username:  String("custom-user"),
+		ExpiresAt: &expiresAt,
+		Scopes: []string{
+			"read_repository",
+		},
+	})
+	if err != nil {
+		t.Errorf("DeployTokens.CreateGroupDeployToken returned an error: %v", err)
+	}
+
+	want := &DeployToken{
+		ID:        1,
+		Name:      "My deploy token",
+		Username:  "custom-user",
+		ExpiresAt: &expiresAt,
+		Token:     "jMRvtPNxrn3crTAGukpZ",
+		Scopes: []string{
+			"read_repository",
+		},
+	}
+
+	if !reflect.DeepEqual(want, deployToken) {
+		t.Errorf("DeployTokens.CreateGroupDeployToken returned %+v, want %+v", deployToken, want)
+	}
+}
+
+func TestDeleteGroupDeployToken(t *testing.T) {
+	mux, server, client := setup()
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v4/groups/5/deploy_tokens/13", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		w.WriteHeader(http.StatusAccepted)
+	})
+
+	resp, err := client.DeployTokens.DeleteGroupDeployToken(5, 13)
+	if err != nil {
+		t.Errorf("DeployTokens.DeleteGroupDeployToken returned an error: %v", err)
+	}
+
+	want := http.StatusAccepted
+	got := resp.StatusCode
+
+	if want != got {
+		t.Errorf("DeployTokens.DeleteGroupDeployToken returned %+v, want %+v", got, want)
+	}
+}

--- a/gitlab.go
+++ b/gitlab.go
@@ -351,6 +351,7 @@ type Client struct {
 	ContainerRegistry     *ContainerRegistryService
 	CustomAttribute       *CustomAttributesService
 	DeployKeys            *DeployKeysService
+	DeployTokens          *DeployTokensService
 	Deployments           *DeploymentsService
 	Discussions           *DiscussionsService
 	Environments          *EnvironmentsService
@@ -501,6 +502,7 @@ func newClient(httpClient *http.Client) *Client {
 	c.ContainerRegistry = &ContainerRegistryService{client: c}
 	c.CustomAttribute = &CustomAttributesService{client: c}
 	c.DeployKeys = &DeployKeysService{client: c}
+	c.DeployTokens = &DeployTokensService{client: c}
 	c.Deployments = &DeploymentsService{client: c}
 	c.Discussions = &DiscussionsService{client: c}
 	c.Environments = &EnvironmentsService{client: c}


### PR DESCRIPTION
Fixes #801 

A new service to manage deploy tokens, in projects and groups.
API reference here:
https://docs.gitlab.com/ce/api/deploy_tokens.html