### PR TITLE
Add a `code_owner_approval_required` field to ProtectedBranches

### DIFF
--- a/protected_branches.go
+++ b/protected_branches.go
@@ -117,7 +117,7 @@ type ProtectRepositoryBranchesOptions struct {
 	Name                      *string           `url:"name,omitempty" json:"name,omitempty"`
 	PushAccessLevel           *AccessLevelValue `url:"push_access_level,omitempty" json:"push_access_level,omitempty"`
 	MergeAccessLevel          *AccessLevelValue `url:"merge_access_level,omitempty" json:"merge_access_level,omitempty"`
-	CodeOwnerApprovalRequired bool              `url:"code_owner_approval_required,omitempty" json:"code_owner_approval_required,omitempty"`
+	CodeOwnerApprovalRequired *bool             `url:"code_owner_approval_required,omitempty" json:"code_owner_approval_required,omitempty"`
 }
 
 // ProtectRepositoryBranches protects a single repository branch or several

--- a/protected_branches.go
+++ b/protected_branches.go
@@ -45,9 +45,10 @@ type BranchAccessDescription struct {
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/protected_branches.html#list-protected-branches
 type ProtectedBranch struct {
-	Name              string                     `json:"name"`
-	PushAccessLevels  []*BranchAccessDescription `json:"push_access_levels"`
-	MergeAccessLevels []*BranchAccessDescription `json:"merge_access_levels"`
+	Name                      string                     `json:"name"`
+	PushAccessLevels          []*BranchAccessDescription `json:"push_access_levels"`
+	MergeAccessLevels         []*BranchAccessDescription `json:"merge_access_levels"`
+	CodeOwnerApprovalRequired bool                       `json:"code_owner_approval_required"`
 }
 
 // ListProtectedBranchesOptions represents the available ListProtectedBranches()
@@ -113,9 +114,10 @@ func (s *ProtectedBranchesService) GetProtectedBranch(pid interface{}, branch st
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/protected_branches.html#protect-repository-branches
 type ProtectRepositoryBranchesOptions struct {
-	Name             *string           `url:"name,omitempty" json:"name,omitempty"`
-	PushAccessLevel  *AccessLevelValue `url:"push_access_level,omitempty" json:"push_access_level,omitempty"`
-	MergeAccessLevel *AccessLevelValue `url:"merge_access_level,omitempty" json:"merge_access_level,omitempty"`
+	Name                      *string           `url:"name,omitempty" json:"name,omitempty"`
+	PushAccessLevel           *AccessLevelValue `url:"push_access_level,omitempty" json:"push_access_level,omitempty"`
+	MergeAccessLevel          *AccessLevelValue `url:"merge_access_level,omitempty" json:"merge_access_level,omitempty"`
+	CodeOwnerApprovalRequired bool              `url:"code_owner_approval_required,omitempty" json:"code_owner_approval_required,omitempty"`
 }
 
 // ProtectRepositoryBranches protects a single repository branch or several
@@ -157,6 +159,34 @@ func (s *ProtectedBranchesService) UnprotectRepositoryBranches(pid interface{}, 
 	u := fmt.Sprintf("projects/%s/protected_branches/%s", pathEscape(project), url.PathEscape(branch))
 
 	req, err := s.client.NewRequest("DELETE", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// RequireCodeOwnerApprovalsOptions represents the available
+// RequireCodeOwnerApprovalsOptions() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/protected_branches.html#require-code-owner-approvals-for-a-single-branch
+type RequireCodeOwnerApprovalsOptions struct {
+	CodeOwnerApprovalRequired *bool `url:"code_owner_approval_required,omitempty" json:"code_owner_approval_required,omitempty"`
+}
+
+// RequireCodeOwnerApprovalsOptions updates the code owner approval
+//
+// Gitlab API docs:
+// https://docs.gitlab.com/ee/api/protected_branches.html#require-code-owner-approvals-for-a-single-branch
+func (s *ProtectedBranchesService) RequireCodeOwnerApprovals(pid interface{}, branch string, opt *RequireCodeOwnerApprovalsOptions, options ...OptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/protected_branches/%s", pathEscape(project), url.PathEscape(branch))
+
+	req, err := s.client.NewRequest("PATCH", u, opt, options)
 	if err != nil {
 		return nil, err
 	}

--- a/protected_branches_test.go
+++ b/protected_branches_test.go
@@ -1,0 +1,171 @@
+package gitlab
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestListProtectedBranches(t *testing.T) {
+	mux, server, client := setup()
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v4/projects/1/protected_branches", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `[{"id":1,
+                              "name":"master",
+                              "push_access_levels":[{
+                                "access_level":40,
+                                "access_level_description":"Maintainers"
+                              }],
+                              "merge_access_levels":[{
+                                "access_level":40,
+                                "access_level_description":"Maintainers"
+                               }],
+                              "code_owner_approval_required":false
+                            }]`)
+	})
+	opt := &ListProtectedBranchesOptions{}
+	protectedBranches, _, err := client.ProtectedBranches.ListProtectedBranches("1", opt)
+	if err != nil {
+		t.Errorf("ProtectedBranches.ListProtectedBranches returned error: %v", err)
+	}
+	want := []*ProtectedBranch{
+		{
+			Name: "master",
+			PushAccessLevels: []*BranchAccessDescription{
+				{
+					AccessLevel:            40,
+					AccessLevelDescription: "Maintainers",
+				},
+			},
+			MergeAccessLevels: []*BranchAccessDescription{
+				{
+					AccessLevel:            40,
+					AccessLevelDescription: "Maintainers",
+				},
+			},
+			CodeOwnerApprovalRequired: false,
+		},
+	}
+	if !reflect.DeepEqual(want, protectedBranches) {
+		t.Errorf("Projects.ListProjects returned %+v, want %+v", protectedBranches, want)
+	}
+}
+
+func TestListProtectedBranchesWithoutCodeOwnerApproval(t *testing.T) {
+	mux, server, client := setup()
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v4/projects/1/protected_branches", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `[{"id":1,
+                             "name":"master",
+                             "push_access_levels":[{
+                               "access_level":40,
+                               "access_level_description":"Maintainers"
+                             }],
+                             "merge_access_levels":[{
+                               "access_level":40,
+                               "access_level_description":"Maintainers"
+                             }]
+                           }]`)
+	})
+	opt := &ListProtectedBranchesOptions{}
+	protectedBranches, _, err := client.ProtectedBranches.ListProtectedBranches("1", opt)
+	if err != nil {
+		t.Errorf("ProtectedBranches.ListProtectedBranches returned error: %v", err)
+	}
+	want := []*ProtectedBranch{
+		{
+			Name: "master",
+			PushAccessLevels: []*BranchAccessDescription{
+				{
+					AccessLevel:            40,
+					AccessLevelDescription: "Maintainers",
+				},
+			},
+			MergeAccessLevels: []*BranchAccessDescription{
+				{
+					AccessLevel:            40,
+					AccessLevelDescription: "Maintainers",
+				},
+			},
+			CodeOwnerApprovalRequired: false,
+		},
+	}
+	if !reflect.DeepEqual(want, protectedBranches) {
+		t.Errorf("Projects.ListProjects returned %+v, want %+v", protectedBranches, want)
+	}
+}
+
+func TestProtectRepositoryBranches(t *testing.T) {
+	mux, server, client := setup()
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v4/projects/1/protected_branches", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		fmt.Fprint(w, `{"id":1,
+                             "name":"master",
+                             "push_access_levels":[{
+                               "access_level":40,
+                               "access_level_description":"Maintainers"
+                             }],
+                             "merge_access_levels":[{
+                               "access_level":40,
+                               "access_level_description":"Maintainers"
+                             }],
+                             "code_owner_approval_required":true
+                            }`)
+	})
+	opt := &ProtectRepositoryBranchesOptions{
+		Name:                      String("master"),
+		PushAccessLevel:           AccessLevel(MaintainerPermissions),
+		MergeAccessLevel:          AccessLevel(MaintainerPermissions),
+		CodeOwnerApprovalRequired: true,
+	}
+	projects, _, err := client.ProtectedBranches.ProtectRepositoryBranches("1", opt)
+	if err != nil {
+		t.Errorf("ProtectedBranches.ProtectRepositoryBranches returned error: %v", err)
+	}
+	want := &ProtectedBranch{
+		Name: "master",
+		PushAccessLevels: []*BranchAccessDescription{
+			{
+				AccessLevel:            40,
+				AccessLevelDescription: "Maintainers",
+			},
+		},
+		MergeAccessLevels: []*BranchAccessDescription{
+			{
+				AccessLevel:            40,
+				AccessLevelDescription: "Maintainers",
+			},
+		},
+		CodeOwnerApprovalRequired: true,
+	}
+	if !reflect.DeepEqual(want, projects) {
+		t.Errorf("Projects.ListProjects returned %+v, want %+v", projects, want)
+	}
+}
+
+func TestUpdateRepositoryBranches(t *testing.T) {
+	mux, server, client := setup()
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v4/projects/1/protected_branches/master", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PATCH")
+		codeApprovalQueryParam := r.URL.Query().Get("code_owner_approval_required")
+		if codeApprovalQueryParam != "true" {
+			t.Errorf("query param code_owner_approval_required should be true but was %s", codeApprovalQueryParam)
+		}
+	})
+	opt := &RequireCodeOwnerApprovalsOptions{
+		CodeOwnerApprovalRequired: Bool(true),
+	}
+	_, err := client.ProtectedBranches.RequireCodeOwnerApprovals("1", "master", opt)
+	if err != nil {
+		t.Errorf("ProtectedBranches.UpdateRepositoryBranchesOptions returned error: %v", err)
+	}
+}

--- a/protected_branches_test.go
+++ b/protected_branches_test.go
@@ -123,7 +123,7 @@ func TestProtectRepositoryBranches(t *testing.T) {
 		Name:                      String("master"),
 		PushAccessLevel:           AccessLevel(MaintainerPermissions),
 		MergeAccessLevel:          AccessLevel(MaintainerPermissions),
-		CodeOwnerApprovalRequired: true,
+		CodeOwnerApprovalRequired: Bool(true),
 	}
 	projects, _, err := client.ProtectedBranches.ProtectRepositoryBranches("1", opt)
 	if err != nil {


### PR DESCRIPTION
Added code_owner_approval_required field to

* ProtectedBranches.ListProtectedBranches
* ProtectedBranches.UpdateRepositoryBranches

and added new function 

* ProtectedBranches.UpdateRepositoryBranches (API only allows update of code_owner_approval_required field

See API https://docs.gitlab.com/ee/api/protected_branches.html#require-code-owner-approvals-for-a-single-branch