### PR TITLE
Support retrieving blame information #798

### DIFF
--- a/examples/repository_files.go
+++ b/examples/repository_files.go
@@ -43,4 +43,14 @@ func repositoryFileExample() {
 	}
 
 	log.Printf("File contains: %s", f.Content)
+
+	gfb := &gitlab.GetFileBlameOptions{
+		Ref: gitlab.String("master"),
+	}
+	fb, _, err := git.RepositoryFiles.GetFileBlame("myname/myproject", file.FilePath, gfb)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Printf("Found %d blame ranges", len(fb))
 }

--- a/repository_files.go
+++ b/repository_files.go
@@ -145,7 +145,7 @@ func (s *RepositoryFilesService) GetFileMetaData(pid interface{}, fileName strin
 
 // FileBlameRange represents one item of blame information.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/repository_files.html#get-file-blame-from-repository
+// GitLab API docs: https://docs.gitlab.com/ce/api/repository_files.html
 type FileBlameRange struct {
 	Commit struct {
 		ID             string     `json:"id"`
@@ -173,12 +173,12 @@ type GetFileBlameOptions struct {
 	Ref *string `url:"ref,omitempty" json:"ref,omitempty"`
 }
 
-// GetFileBlame allows you to receive blame information.
-// Each blame range contains lines and corresponding commit info.
+// GetFileBlame allows you to receive blame information. Each blame range
+// contains lines and corresponding commit info.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/repository_files.html#get-file-blame-from-repository
-func (s *RepositoryFilesService) GetFileBlame(pid interface{}, fileName string, opt *GetFileBlameOptions, options ...OptionFunc) ([]*FileBlameRange, *Response, error) {
+func (s *RepositoryFilesService) GetFileBlame(pid interface{}, file string, opt *GetFileBlameOptions, options ...RequestOptionFunc) ([]*FileBlameRange, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
@@ -186,7 +186,7 @@ func (s *RepositoryFilesService) GetFileBlame(pid interface{}, fileName string, 
 	u := fmt.Sprintf(
 		"projects/%s/repository/files/%s/blame",
 		pathEscape(project),
-		url.PathEscape(fileName),
+		url.PathEscape(file),
 	)
 
 	req, err := s.client.NewRequest("GET", u, opt, options)
@@ -194,13 +194,13 @@ func (s *RepositoryFilesService) GetFileBlame(pid interface{}, fileName string, 
 		return nil, nil, err
 	}
 
-	var b []*FileBlameRange
-	resp, err := s.client.Do(req, &b)
+	var br []*FileBlameRange
+	resp, err := s.client.Do(req, &br)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return b, resp, err
+	return br, resp, err
 }
 
 // GetRawFileOptions represents the available GetRawFile() options.

--- a/repository_files.go
+++ b/repository_files.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/url"
 	"strconv"
+	"time"
 )
 
 // RepositoryFilesService handles communication with the repository files
@@ -140,6 +141,66 @@ func (s *RepositoryFilesService) GetFileMetaData(pid interface{}, fileName strin
 	}
 
 	return f, resp, err
+}
+
+// FileBlameRange represents one item of blame information.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/repository_files.html#get-file-blame-from-repository
+type FileBlameRange struct {
+	Commit struct {
+		ID             string     `json:"id"`
+		ParentIDs      []string   `json:"parent_ids"`
+		Message        string     `json:"message"`
+		AuthoredDate   *time.Time `json:"authored_date"`
+		AuthorName     string     `json:"author_name"`
+		AuthorEmail    string     `json:"author_email"`
+		CommittedDate  *time.Time `json:"committed_date"`
+		CommitterName  string     `json:"committer_name"`
+		CommitterEmail string     `json:"committer_email"`
+	} `json:"commit"`
+	Lines []string `json:"lines"`
+}
+
+func (b FileBlameRange) String() string {
+	return Stringify(b)
+}
+
+// GetFileBlameOptions represents the available GetFileBlame() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/repository_files.html#get-file-blame-from-repository
+type GetFileBlameOptions struct {
+	Ref *string `url:"ref,omitempty" json:"ref,omitempty"`
+}
+
+// GetFileBlame allows you to receive blame information.
+// Each blame range contains lines and corresponding commit info.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/repository_files.html#get-file-blame-from-repository
+func (s *RepositoryFilesService) GetFileBlame(pid interface{}, fileName string, opt *GetFileBlameOptions, options ...OptionFunc) ([]*FileBlameRange, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf(
+		"projects/%s/repository/files/%s/blame",
+		pathEscape(project),
+		url.PathEscape(fileName),
+	)
+
+	req, err := s.client.NewRequest("GET", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var b []*FileBlameRange
+	resp, err := s.client.Do(req, &b)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return b, resp, err
 }
 
 // GetRawFileOptions represents the available GetRawFile() options.


### PR DESCRIPTION
This patch allows to get blame data over [the file blame API](https://docs.gitlab.com/ce/api/repository_files.html#get-file-blame-from-repository).