### PR TITLE
Add management_project_id support to Group and Project Cluster

### DIFF
--- a/group_clusters.go
+++ b/group_clusters.go
@@ -44,8 +44,8 @@ type GroupCluster struct {
 	ClusterType        string              `json:"cluster_type"`
 	User               *User               `json:"user"`
 	PlatformKubernetes *PlatformKubernetes `json:"platform_kubernetes"`
-	Group              *Group              `json:"group"`
 	ManagementProject  *ManagementProject  `json:"management_project"`
+	Group              *Group              `json:"group"`
 }
 
 func (v GroupCluster) String() string {
@@ -109,11 +109,11 @@ func (s *GroupClustersService) GetCluster(pid interface{}, cluster int, options 
 type AddGroupClusterOptions struct {
 	Name                *string                            `url:"name,omitempty" json:"name,omitempty"`
 	Domain              *string                            `url:"domain,omitempty" json:"domain,omitempty"`
+	ManagementProjectID *string                            `url:"management_project_id,omitempty" json:"management_project_id,omitempty"`
 	Enabled             *bool                              `url:"enabled,omitempty" json:"enabled,omitempty"`
 	Managed             *bool                              `url:"managed,omitempty" json:"managed,omitempty"`
 	EnvironmentScope    *string                            `url:"environment_scope,omitempty" json:"environment_scope,omitempty"`
 	PlatformKubernetes  *AddGroupPlatformKubernetesOptions `url:"platform_kubernetes_attributes,omitempty" json:"platform_kubernetes_attributes,omitempty"`
-	ManagementProjectID *string                            `url:"management_project_id,omitempty" json:"management_project_id,omitempty"`
 }
 
 // AddGroupPlatformKubernetesOptions represents the available PlatformKubernetes options for adding.

--- a/group_clusters.go
+++ b/group_clusters.go
@@ -34,17 +34,18 @@ type GroupClustersService struct {
 //
 // GitLab API docs: https://docs.gitlab.com/ee/api/group_clusters.html
 type GroupCluster struct {
-	ID                 int                 `json:"id"`
-	Name               string              `json:"name"`
-	Domain             string              `json:"domain"`
-	CreatedAt          *time.Time          `json:"created_at"`
-	ProviderType       string              `json:"provider_type"`
-	PlatformType       string              `json:"platform_type"`
-	EnvironmentScope   string              `json:"environment_scope"`
-	ClusterType        string              `json:"cluster_type"`
-	User               *User               `json:"user"`
-	PlatformKubernetes *PlatformKubernetes `json:"platform_kubernetes"`
-	Group              *Group              `json:"group"`
+	ID                  int                 `json:"id"`
+	Name                string              `json:"name"`
+	Domain              string              `json:"domain"`
+	CreatedAt           *time.Time          `json:"created_at"`
+	ProviderType        string              `json:"provider_type"`
+	PlatformType        string              `json:"platform_type"`
+	EnvironmentScope    string              `json:"environment_scope"`
+	ClusterType         string              `json:"cluster_type"`
+	User                *User               `json:"user"`
+	PlatformKubernetes  *PlatformKubernetes `json:"platform_kubernetes"`
+	Group               *Group              `json:"group"`
+	ManagementProjectId string              `json:"management_project_id"`
 }
 
 func (v GroupCluster) String() string {
@@ -92,6 +93,7 @@ func (s *GroupClustersService) GetCluster(pid interface{}, cluster int, options 
 		return nil, nil, err
 	}
 
+	// TO DO: Map Response from "management_project":{"id":int} to "management_project_id"
 	pc := new(GroupCluster)
 	resp, err := s.client.Do(req, &pc)
 	if err != nil {
@@ -106,12 +108,13 @@ func (s *GroupClustersService) GetCluster(pid interface{}, cluster int, options 
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/group_clusters.html#add-existing-cluster-to-group
 type AddGroupClusterOptions struct {
-	Name               *string                            `url:"name,omitempty" json:"name,omitempty"`
-	Domain             *string                            `url:"domain,omitempty" json:"domain,omitempty"`
-	Enabled            *bool                              `url:"enabled,omitempty" json:"enabled,omitempty"`
-	Managed            *bool                              `url:"managed,omitempty" json:"managed,omitempty"`
-	EnvironmentScope   *string                            `url:"environment_scope,omitempty" json:"environment_scope,omitempty"`
-	PlatformKubernetes *AddGroupPlatformKubernetesOptions `url:"platform_kubernetes_attributes,omitempty" json:"platform_kubernetes_attributes,omitempty"`
+	Name                *string                            `url:"name,omitempty" json:"name,omitempty"`
+	Domain              *string                            `url:"domain,omitempty" json:"domain,omitempty"`
+	Enabled             *bool                              `url:"enabled,omitempty" json:"enabled,omitempty"`
+	Managed             *bool                              `url:"managed,omitempty" json:"managed,omitempty"`
+	EnvironmentScope    *string                            `url:"environment_scope,omitempty" json:"environment_scope,omitempty"`
+	ManagementProjectId *string                            `url:"management_project_id,omitempty" json:"management_project_id,omitempty"`
+	PlatformKubernetes  *AddGroupPlatformKubernetesOptions `url:"platform_kubernetes_attributes,omitempty" json:"platform_kubernetes_attributes,omitempty"`
 }
 
 // AddGroupPlatformKubernetesOptions represents the available PlatformKubernetes options for adding.
@@ -153,10 +156,11 @@ func (s *GroupClustersService) AddCluster(pid interface{}, opt *AddGroupClusterO
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/group_clusters.html#edit-group-cluster
 type EditGroupClusterOptions struct {
-	Name               *string                             `url:"name,omitempty" json:"name,omitempty"`
-	Domain             *string                             `url:"domain,omitempty" json:"domain,omitempty"`
-	EnvironmentScope   *string                             `url:"environment_scope,omitempty" json:"environment_scope,omitempty"`
-	PlatformKubernetes *EditGroupPlatformKubernetesOptions `url:"platform_kubernetes_attributes,omitempty" json:"platform_kubernetes_attributes,omitempty"`
+	Name                *string                             `url:"name,omitempty" json:"name,omitempty"`
+	Domain              *string                             `url:"domain,omitempty" json:"domain,omitempty"`
+	EnvironmentScope    *string                             `url:"environment_scope,omitempty" json:"environment_scope,omitempty"`
+	ManagementProjectId *string                             `url:"management_project_id,omitempty" json:"management_project_id,omitempty"`
+	PlatformKubernetes  *EditGroupPlatformKubernetesOptions `url:"platform_kubernetes_attributes,omitempty" json:"platform_kubernetes_attributes,omitempty"`
 }
 
 // EditGroupPlatformKubernetesOptions represents the available PlatformKubernetes options for editing.

--- a/group_clusters.go
+++ b/group_clusters.go
@@ -112,8 +112,8 @@ type AddGroupClusterOptions struct {
 	Enabled             *bool                              `url:"enabled,omitempty" json:"enabled,omitempty"`
 	Managed             *bool                              `url:"managed,omitempty" json:"managed,omitempty"`
 	EnvironmentScope    *string                            `url:"environment_scope,omitempty" json:"environment_scope,omitempty"`
-	ManagementProjectID *string                            `url:"management_project_id,omitempty" json:"management_project_id,omitempty"`
 	PlatformKubernetes  *AddGroupPlatformKubernetesOptions `url:"platform_kubernetes_attributes,omitempty" json:"platform_kubernetes_attributes,omitempty"`
+	ManagementProjectID *string                            `url:"management_project_id,omitempty" json:"management_project_id,omitempty"`
 }
 
 // AddGroupPlatformKubernetesOptions represents the available PlatformKubernetes options for adding.
@@ -158,8 +158,8 @@ type EditGroupClusterOptions struct {
 	Name                *string                             `url:"name,omitempty" json:"name,omitempty"`
 	Domain              *string                             `url:"domain,omitempty" json:"domain,omitempty"`
 	EnvironmentScope    *string                             `url:"environment_scope,omitempty" json:"environment_scope,omitempty"`
-	ManagementProjectID *string                             `url:"management_project_id,omitempty" json:"management_project_id,omitempty"`
 	PlatformKubernetes  *EditGroupPlatformKubernetesOptions `url:"platform_kubernetes_attributes,omitempty" json:"platform_kubernetes_attributes,omitempty"`
+	ManagementProjectID *string                             `url:"management_project_id,omitempty" json:"management_project_id,omitempty"`
 }
 
 // EditGroupPlatformKubernetesOptions represents the available PlatformKubernetes options for editing.

--- a/group_clusters.go
+++ b/group_clusters.go
@@ -34,18 +34,18 @@ type GroupClustersService struct {
 //
 // GitLab API docs: https://docs.gitlab.com/ee/api/group_clusters.html
 type GroupCluster struct {
-	ID                  int                 `json:"id"`
-	Name                string              `json:"name"`
-	Domain              string              `json:"domain"`
-	CreatedAt           *time.Time          `json:"created_at"`
-	ProviderType        string              `json:"provider_type"`
-	PlatformType        string              `json:"platform_type"`
-	EnvironmentScope    string              `json:"environment_scope"`
-	ClusterType         string              `json:"cluster_type"`
-	User                *User               `json:"user"`
-	PlatformKubernetes  *PlatformKubernetes `json:"platform_kubernetes"`
-	Group               *Group              `json:"group"`
-	ManagementProjectId string              `json:"management_project_id"`
+	ID                 int                 `json:"id"`
+	Name               string              `json:"name"`
+	Domain             string              `json:"domain"`
+	CreatedAt          *time.Time          `json:"created_at"`
+	ProviderType       string              `json:"provider_type"`
+	PlatformType       string              `json:"platform_type"`
+	EnvironmentScope   string              `json:"environment_scope"`
+	ClusterType        string              `json:"cluster_type"`
+	User               *User               `json:"user"`
+	PlatformKubernetes *PlatformKubernetes `json:"platform_kubernetes"`
+	Group              *Group              `json:"group"`
+	ManagementProject  *ManagementProject  `json:"management_project"`
 }
 
 func (v GroupCluster) String() string {
@@ -113,7 +113,7 @@ type AddGroupClusterOptions struct {
 	Enabled             *bool                              `url:"enabled,omitempty" json:"enabled,omitempty"`
 	Managed             *bool                              `url:"managed,omitempty" json:"managed,omitempty"`
 	EnvironmentScope    *string                            `url:"environment_scope,omitempty" json:"environment_scope,omitempty"`
-	ManagementProjectId *string                            `url:"management_project_id,omitempty" json:"management_project_id,omitempty"`
+	ManagementProjectID *string                            `url:"management_project_id,omitempty" json:"management_project_id,omitempty"`
 	PlatformKubernetes  *AddGroupPlatformKubernetesOptions `url:"platform_kubernetes_attributes,omitempty" json:"platform_kubernetes_attributes,omitempty"`
 }
 
@@ -159,7 +159,7 @@ type EditGroupClusterOptions struct {
 	Name                *string                             `url:"name,omitempty" json:"name,omitempty"`
 	Domain              *string                             `url:"domain,omitempty" json:"domain,omitempty"`
 	EnvironmentScope    *string                             `url:"environment_scope,omitempty" json:"environment_scope,omitempty"`
-	ManagementProjectId *string                             `url:"management_project_id,omitempty" json:"management_project_id,omitempty"`
+	ManagementProjectID *string                             `url:"management_project_id,omitempty" json:"management_project_id,omitempty"`
 	PlatformKubernetes  *EditGroupPlatformKubernetesOptions `url:"platform_kubernetes_attributes,omitempty" json:"platform_kubernetes_attributes,omitempty"`
 }
 

--- a/group_clusters.go
+++ b/group_clusters.go
@@ -93,7 +93,6 @@ func (s *GroupClustersService) GetCluster(pid interface{}, cluster int, options 
 		return nil, nil, err
 	}
 
-	// TO DO: Map Response from "management_project":{"id":int} to "management_project_id"
 	pc := new(GroupCluster)
 	resp, err := s.client.Do(req, &pc)
 	if err != nil {

--- a/project_clusters.go
+++ b/project_clusters.go
@@ -44,8 +44,8 @@ type ProjectCluster struct {
 	ClusterType        string              `json:"cluster_type"`
 	User               *User               `json:"user"`
 	PlatformKubernetes *PlatformKubernetes `json:"platform_kubernetes"`
-	Project            *Project            `json:"project"`
 	ManagementProject  *ManagementProject  `json:"management_project"`
+	Project            *Project            `json:"project"`
 }
 
 func (v ProjectCluster) String() string {
@@ -61,7 +61,7 @@ type PlatformKubernetes struct {
 	AuthorizationType string `json:"authorization_type"`
 }
 
-// ManagementProject represents a GitLab Project Cluster management_project
+// ManagementProject represents a GitLab Project Cluster management_project.
 type ManagementProject struct {
 	ID                int        `json:"id"`
 	Description       string     `json:"description"`
@@ -178,8 +178,8 @@ type EditClusterOptions struct {
 	Name                *string                        `url:"name,omitempty" json:"name,omitempty"`
 	Domain              *string                        `url:"domain,omitempty" json:"domain,omitempty"`
 	EnvironmentScope    *string                        `url:"environment_scope,omitempty" json:"environment_scope,omitempty"`
-	PlatformKubernetes  *EditPlatformKubernetesOptions `url:"platform_kubernetes_attributes,omitempty" json:"platform_kubernetes_attributes,omitempty"`
 	ManagementProjectID *string                        `url:"management_project_id,omitempty" json:"management_project_id,omitempty"`
+	PlatformKubernetes  *EditPlatformKubernetesOptions `url:"platform_kubernetes_attributes,omitempty" json:"platform_kubernetes_attributes,omitempty"`
 }
 
 // EditPlatformKubernetesOptions represents the available PlatformKubernetes options for editing.

--- a/project_clusters.go
+++ b/project_clusters.go
@@ -45,6 +45,7 @@ type ProjectCluster struct {
 	User               *User               `json:"user"`
 	PlatformKubernetes *PlatformKubernetes `json:"platform_kubernetes"`
 	Project            *Project            `json:"project"`
+	ManagementProject  *ManagementProject  `json:"management_project"`
 }
 
 func (v ProjectCluster) String() string {
@@ -58,6 +59,17 @@ type PlatformKubernetes struct {
 	CaCert            string `json:"ca_cert"`
 	Namespace         string `json:"namespace"`
 	AuthorizationType string `json:"authorization_type"`
+}
+
+// ManagementProject represents a GitLab Project Cluster management_project
+type ManagementProject struct {
+	ID                int        `json:"id"`
+	Description       string     `json:"description"`
+	Name              string     `json:"name"`
+	NameWithNamespace string     `json:"name_with_namespace"`
+	Path              string     `json:"path"`
+	PathWithNamespace string     `json:"path_with_namespace"`
+	CreatedAt         *time.Time `json:"created_at"`
 }
 
 // ListClusters gets a list of all clusters in a project.

--- a/project_clusters.go
+++ b/project_clusters.go
@@ -127,12 +127,13 @@ func (s *ProjectClustersService) GetCluster(pid interface{}, cluster int, option
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/project_clusters.html#add-existing-cluster-to-project
 type AddClusterOptions struct {
-	Name               *string                       `url:"name,omitempty" json:"name,omitempty"`
-	Domain             *string                       `url:"domain,omitempty" json:"domain,omitempty"`
-	Enabled            *bool                         `url:"enabled,omitempty" json:"enabled,omitempty"`
-	Managed            *bool                         `url:"managed,omitempty" json:"managed,omitempty"`
-	EnvironmentScope   *string                       `url:"environment_scope,omitempty" json:"environment_scope,omitempty"`
-	PlatformKubernetes *AddPlatformKubernetesOptions `url:"platform_kubernetes_attributes,omitempty" json:"platform_kubernetes_attributes,omitempty"`
+	Name                *string                       `url:"name,omitempty" json:"name,omitempty"`
+	Domain              *string                       `url:"domain,omitempty" json:"domain,omitempty"`
+	Enabled             *bool                         `url:"enabled,omitempty" json:"enabled,omitempty"`
+	Managed             *bool                         `url:"managed,omitempty" json:"managed,omitempty"`
+	EnvironmentScope    *string                       `url:"environment_scope,omitempty" json:"environment_scope,omitempty"`
+	PlatformKubernetes  *AddPlatformKubernetesOptions `url:"platform_kubernetes_attributes,omitempty" json:"platform_kubernetes_attributes,omitempty"`
+	ManagementProjectID *string                       `url:"management_project_id,omitempty" json:"management_project_id,omitempty"`
 }
 
 // AddPlatformKubernetesOptions represents the available PlatformKubernetes options for adding.
@@ -174,10 +175,11 @@ func (s *ProjectClustersService) AddCluster(pid interface{}, opt *AddClusterOpti
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/project_clusters.html#edit-project-cluster
 type EditClusterOptions struct {
-	Name               *string                        `url:"name,omitempty" json:"name,omitempty"`
-	Domain             *string                        `url:"domain,omitempty" json:"domain,omitempty"`
-	EnvironmentScope   *string                        `url:"environment_scope,omitempty" json:"environment_scope,omitempty"`
-	PlatformKubernetes *EditPlatformKubernetesOptions `url:"platform_kubernetes_attributes,omitempty" json:"platform_kubernetes_attributes,omitempty"`
+	Name                *string                        `url:"name,omitempty" json:"name,omitempty"`
+	Domain              *string                        `url:"domain,omitempty" json:"domain,omitempty"`
+	EnvironmentScope    *string                        `url:"environment_scope,omitempty" json:"environment_scope,omitempty"`
+	PlatformKubernetes  *EditPlatformKubernetesOptions `url:"platform_kubernetes_attributes,omitempty" json:"platform_kubernetes_attributes,omitempty"`
+	ManagementProjectID *string                        `url:"management_project_id,omitempty" json:"management_project_id,omitempty"`
 }
 
 // EditPlatformKubernetesOptions represents the available PlatformKubernetes options for editing.


### PR DESCRIPTION
Update Project and Group Cluster to include management_project_id structure on update and get of cluster.


Closes https://github.com/xanzy/go-gitlab/issues/809