### PR TITLE
Add support for marking Jira service active

### DIFF
--- a/services.go
+++ b/services.go
@@ -607,6 +607,7 @@ type SetJiraServiceOptions struct {
 	ProjectKey            *string `url:"project_key,omitempty" json:"project_key,omitempty" `
 	Username              *string `url:"username,omitempty" json:"username,omitempty" `
 	Password              *string `url:"password,omitempty" json:"password,omitempty" `
+	Active                *bool   `url:"active,omitempty" json:"active,omitempty"`
 	JiraIssueTransitionID *string `url:"jira_issue_transition_id,omitempty" json:"jira_issue_transition_id,omitempty"`
 	CommitEvents          *bool   `url:"commit_events,omitempty" json:"commit_events,omitempty"`
 	MergeRequestsEvents   *bool   `url:"merge_requests_events,omitempty" json:"merge_requests_events,omitempty"`

--- a/services_test.go
+++ b/services_test.go
@@ -131,6 +131,7 @@ func TestSetJiraService(t *testing.T) {
 		ProjectKey:            String("as"),
 		Username:              String("aas"),
 		Password:              String("asd"),
+		Active:                Bool(true),
 		JiraIssueTransitionID: String("2,3"),
 		CommitEvents:          Bool(true),
 		CommentOnEventEnabled: Bool(true),


### PR DESCRIPTION
This pull request adds the Active field to SetJiraServiceOptions, giving API users the ability to mark the Jira service as active or inactive.

Closes #816