### PR TITLE
Add additional group hook manipulations

### DIFF
--- a/group_hooks.go
+++ b/group_hooks.go
@@ -169,13 +169,13 @@ func (s *GroupsService) EditGroupHook(pid interface{}, hook int, opt *EditGroupH
 		return nil, nil, err
 	}
 
-	ph := &GroupHook{}
-	resp, err := s.client.Do(req, ph)
+	gh := new(GroupHook)
+	resp, err := s.client.Do(req, gh)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return ph, resp, err
+	return gh, resp, err
 }
 
 // DeleteGroupHook removes a hook from a group. This is an idempotent

--- a/group_hooks.go
+++ b/group_hooks.go
@@ -179,7 +179,7 @@ func (s *GroupsService) EditGroupHook(pid interface{}, hook int, opt *EditGroupH
 }
 
 // DeleteGroupHook removes a hook from a group. This is an idempotent
-// method and can be called multiple times. Either the hook is available or not.
+// method and can be called multiple times.
 //
 // GitLab API docs:
 // https://gitlab.com/help/api/groups.md#delete-group-hook

--- a/group_hooks.go
+++ b/group_hooks.go
@@ -81,7 +81,7 @@ func (s *GroupsService) GetGroupHook(pid interface{}, hook int, options ...Optio
 		return nil, nil, err
 	}
 
-	gh := &GroupHook{}
+	gh := new(GroupHook)
 	resp, err := s.client.Do(req, gh)
 	if err != nil {
 		return nil, resp, err

--- a/group_hooks.go
+++ b/group_hooks.go
@@ -182,7 +182,7 @@ func (s *GroupsService) EditGroupHook(pid interface{}, hook int, opt *EditGroupH
 // method and can be called multiple times.
 //
 // GitLab API docs:
-// https://gitlab.com/help/api/groups.md#delete-group-hook
+// https://docs.gitlab.com/ce/api/groups.html#delete-group-hook
 func (s *GroupsService) DeleteGroupHook(pid interface{}, hook int, options ...OptionFunc) (*Response, error) {
 	group, err := parseID(pid)
 	if err != nil {

--- a/group_hooks.go
+++ b/group_hooks.go
@@ -156,7 +156,7 @@ type EditGroupHookOptions struct {
 // EditGroupHook edits a hook for a specified group.
 //
 // Gitlab API docs:
-// https://gitlab.com/help/api/groups.md#edit-group-hook
+// https://docs.gitlab.com/ce/api/groups.html#edit-group-hook
 func (s *GroupsService) EditGroupHook(pid interface{}, hook int, opt *EditGroupHookOptions, options ...OptionFunc) (*GroupHook, *Response, error) {
 	group, err := parseID(pid)
 	if err != nil {

--- a/group_hooks.go
+++ b/group_hooks.go
@@ -65,6 +65,31 @@ func (s *GroupsService) ListGroupHooks(gid interface{}) ([]*GroupHook, *Response
 	return gh, resp, err
 }
 
+// GetGroupHook gets a specific hook for a group.
+//
+// GitLab API docs:
+// https://gitlab.com/help/api/groups.md#get-group-hook
+func (s *GroupsService) GetGroupHook(pid interface{}, hook int, options ...OptionFunc) (*GroupHook, *Response, error) {
+	group, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/hooks/%d", pathEscape(group), hook)
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	gh := &GroupHook{}
+	resp, err := s.client.Do(req, gh)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return gh, resp, err
+}
+
 // AddGroupHookOptions represents the available AddGroupHook() options.
 //
 // GitLab API docs: https://docs.gitlab.com/ee/api/groups.html#add-group-hook
@@ -106,4 +131,69 @@ func (s *GroupsService) AddGroupHook(gid interface{}, opt *AddGroupHookOptions, 
 	}
 
 	return gh, resp, err
+}
+
+// EditGroupHookOptions represents the available EditGroupHook() options.
+//
+// GitLab API docs:
+// https://gitlab.com/help/api/groups.md#edit-group-hook
+type EditGroupHookOptions struct {
+	URL                      *string `url:"url,omitempty" json:"url,omitempty"`
+	PushEvents               *bool   `url:"push_events,omitempty" json:"push_events,omitempty"`
+	IssuesEvents             *bool   `url:"issues_events,omitempty" json:"issues_events,omitempty"`
+	ConfidentialIssuesEvents *bool   `url:"confidential_issues_events,omitempty" json:"confidential_issues_events,omitempty"`
+	ConfidentialNoteEvents   *bool   `url:"confidential_note_events,omitempty" json:"confidential_note_events,omitempty"`
+	MergeRequestsEvents      *bool   `url:"merge_requests_events,omitempty" json:"merge_requests_events,omitempty"`
+	TagPushEvents            *bool   `url:"tag_push_events,omitempty" json:"tag_push_events,omitempty"`
+	NoteEvents               *bool   `url:"note_events,omitempty" json:"note_events,omitempty"`
+	JobEvents                *bool   `url:"job_events,omitempty" json:"job_events,omitempty"`
+	PipelineEvents           *bool   `url:"pipeline_events,omitempty" json:"pipeline_events,omitempty"`
+	WikiPageEvents           *bool   `url:"wiki_page_events,omitempty" json:"wiki_page_events,omitempty"`
+	EnableSSLVerification    *bool   `url:"enable_ssl_verification,omitempty" json:"enable_ssl_verification,omitempty"`
+	Token                    *string `url:"token,omitempty" json:"token,omitempty"`
+}
+
+// EditGroupHook edits a hook for a specified group.
+//
+// Gitlab API docs:
+// https://gitlab.com/help/api/groups.md#edit-group-hook
+func (s *GroupsService) EditGroupHook(pid interface{}, hook int, opt *EditGroupHookOptions, options ...OptionFunc) (*GroupHook, *Response, error) {
+	group, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/hooks/%d", pathEscape(group), hook)
+
+	req, err := s.client.NewRequest("PUT", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ph := &GroupHook{}
+	resp, err := s.client.Do(req, ph)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return ph, resp, err
+}
+
+// DeleteGroupHook removes a hook from a group. This is an idempotent
+// method and can be called multiple times. Either the hook is available or not.
+//
+// GitLab API docs:
+// https://gitlab.com/help/api/groups.md#delete-group-hook
+func (s *GroupsService) DeleteGroupHook(pid interface{}, hook int, options ...OptionFunc) (*Response, error) {
+	group, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("groups/%s/hooks/%d", pathEscape(group), hook)
+
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
 }

--- a/group_hooks.go
+++ b/group_hooks.go
@@ -68,7 +68,7 @@ func (s *GroupsService) ListGroupHooks(gid interface{}) ([]*GroupHook, *Response
 // GetGroupHook gets a specific hook for a group.
 //
 // GitLab API docs:
-// https://gitlab.com/help/api/groups.md#get-group-hook
+// https://docs.gitlab.com/ce/api/groups.html#get-group-hook
 func (s *GroupsService) GetGroupHook(pid interface{}, hook int, options ...OptionFunc) (*GroupHook, *Response, error) {
 	group, err := parseID(pid)
 	if err != nil {

--- a/group_hooks.go
+++ b/group_hooks.go
@@ -136,7 +136,7 @@ func (s *GroupsService) AddGroupHook(gid interface{}, opt *AddGroupHookOptions, 
 // EditGroupHookOptions represents the available EditGroupHook() options.
 //
 // GitLab API docs:
-// https://gitlab.com/help/api/groups.md#edit-group-hook
+// https://docs.gitlab.com/ce/api/groups.html#edit-group-hook
 type EditGroupHookOptions struct {
 	URL                      *string `url:"url,omitempty" json:"url,omitempty"`
 	PushEvents               *bool   `url:"push_events,omitempty" json:"push_events,omitempty"`

--- a/group_hooks_test.go
+++ b/group_hooks_test.go
@@ -79,6 +79,59 @@ func TestListGroupHooks(t *testing.T) {
 	}
 }
 
+func TestGetGroupHook(t *testing.T) {
+	mux, server, client := setup()
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v4/groups/1/hooks/1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `
+{
+	"id": 1,
+	"url": "http://example.com/hook",
+	"group_id": 3,
+	"push_events": true,
+	"issues_events": true,
+	"confidential_issues_events": true,
+	"merge_requests_events": true,
+	"tag_push_events": true,
+	"note_events": true,
+	"job_events": true,
+	"pipeline_events": true,
+	"wiki_page_events": true,
+	"enable_ssl_verification": true,
+	"created_at": "2012-10-12T17:04:47Z"
+}`)
+	})
+
+	groupHook, _, err := client.Groups.GetGroupHook(1, 1)
+	if err != nil {
+		t.Error(err)
+	}
+
+	datePointer := time.Date(2012, 10, 12, 17, 4, 47, 0, time.UTC)
+	want := &GroupHook{
+		ID:                       1,
+		URL:                      "http://example.com/hook",
+		GroupID:                  3,
+		PushEvents:               true,
+		IssuesEvents:             true,
+		ConfidentialIssuesEvents: true,
+		MergeRequestsEvents:      true,
+		TagPushEvents:            true,
+		NoteEvents:               true,
+		JobEvents:                true,
+		PipelineEvents:           true,
+		WikiPageEvents:           true,
+		EnableSSLVerification:    true,
+		CreatedAt:                &datePointer,
+	}
+
+	if !reflect.DeepEqual(groupHook, want) {
+		t.Errorf("getGroupHooks returned \ngot:\n%v\nwant:\n%v", Stringify(groupHook), Stringify(want))
+	}
+}
+
 func TestAddGroupHook(t *testing.T) {
 	mux, server, client := setup()
 	defer teardown(server)
@@ -135,5 +188,78 @@ func TestAddGroupHook(t *testing.T) {
 
 	if !reflect.DeepEqual(groupHooks, want) {
 		t.Errorf("AddGroupHook returned \ngot:\n%v\nwant:\n%v", Stringify(groupHooks), Stringify(want))
+	}
+}
+
+func TestEditGroupHook(t *testing.T) {
+	mux, server, client := setup()
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v4/groups/1/hooks/1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		fmt.Fprint(w, `
+{
+	"id": 1,
+	"url": "http://example.com/hook",
+	"group_id": 3,
+	"push_events": true,
+	"issues_events": true,
+	"confidential_issues_events": true,
+	"merge_requests_events": true,
+	"tag_push_events": true,
+	"note_events": true,
+	"job_events": true,
+	"pipeline_events": true,
+	"wiki_page_events": true,
+	"enable_ssl_verification": true,
+	"created_at": "2012-10-12T17:04:47Z"
+}`)
+	})
+
+	url := "http://www.example.com/hook"
+	opt := &EditGroupHookOptions{
+		URL: &url,
+	}
+
+	groupHooks, _, err := client.Groups.EditGroupHook(1, 1, opt)
+	if err != nil {
+		t.Error(err)
+	}
+
+	datePointer := time.Date(2012, 10, 12, 17, 4, 47, 0, time.UTC)
+	want := &GroupHook{
+		ID:                       1,
+		URL:                      "http://example.com/hook",
+		GroupID:                  3,
+		PushEvents:               true,
+		IssuesEvents:             true,
+		ConfidentialIssuesEvents: true,
+		ConfidentialNoteEvents:   false,
+		MergeRequestsEvents:      true,
+		TagPushEvents:            true,
+		NoteEvents:               true,
+		JobEvents:                true,
+		PipelineEvents:           true,
+		WikiPageEvents:           true,
+		EnableSSLVerification:    true,
+		CreatedAt:                &datePointer,
+	}
+
+	if !reflect.DeepEqual(groupHooks, want) {
+		t.Errorf("EditGroupHook returned \ngot:\n%v\nwant:\n%v", Stringify(groupHooks), Stringify(want))
+	}
+}
+
+func TestDeleteGroupHook(t *testing.T) {
+	mux, server, client := setup()
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v4/groups/1/hooks/1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+	})
+
+	_, err := client.Groups.DeleteGroupHook(1, 1)
+	if err != nil {
+		t.Error(err)
 	}
 }


### PR DESCRIPTION
This pull request adds the GetGroupHook, EditGroupHook, and DeleteGroupHook functions to GroupsService, modeling them on the GetProjectHook, EditProjectHook, and DeleteProjectHook functions from the ProjectsService.  This will allow manipulation of group-level webhooks, which is a recently added GitLab feature, and complements the ListGroupHooks method that was already present, as well as the AddGroupHook method which was added a little bit ago in response to #797.

Closes #797