### PR TITLE
Add applications support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ incompatible changes that were needed to fully support the V4 Gitlab API.
 This API client package covers most of the existing Gitlab API calls and is updated regularly
 to add new and/or missing endpoints. Currently the following services are supported:
 
+- [ ] Applications
 - [x] Award Emojis
 - [x] Branches
 - [x] Broadcast Messages

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ incompatible changes that were needed to fully support the V4 Gitlab API.
 This API client package covers most of the existing Gitlab API calls and is updated regularly
 to add new and/or missing endpoints. Currently the following services are supported:
 
-- [ ] Applications
+- [x] Applications
 - [x] Award Emojis
 - [x] Branches
 - [x] Broadcast Messages

--- a/applications.go
+++ b/applications.go
@@ -1,0 +1,53 @@
+//
+// Copyright 2017, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package gitlab
+
+// ApplicationsService handles communication with administrables applications
+// of the Gitlab API.
+
+// Gitlab API docs : https://docs.gitlab.com/ee/api/applications.html
+type ApplicationsService struct {
+	client *Client
+}
+
+type ListApplicationsOptions struct {
+}
+
+type Application struct {
+	ID              int    `json:"id"`
+	ApplicationID   string `json:"application_id"`
+	ApplicationName string `json:"application_name"`
+	CallbackURL     string `json:"callback_url"`
+	Confidential    bool   `json:"confidential"`
+}
+
+// ListApplications get a list of administrables applications by the authenticated user
+func (s *ApplicationsService) ListApplications(opts *ListApplicationsOptions, options ...OptionFunc) ([]*Application, *Response, error) {
+
+	req, err := s.client.NewRequest("GET", "applications", opts, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var a []*Application
+	resp, err := s.client.Do(req, &a)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return a, resp, err
+}

--- a/applications.go
+++ b/applications.go
@@ -26,25 +26,24 @@ type ApplicationsService struct {
 	client *Client
 }
 
-// CreateApplicationOptions represents the available CreateApplication() options.
-//
-// GitLab API docs: https://docs.gitlab.com/ce/api/applications.html#create-an-application
-type CreateApplicationOptions struct {
-	Name         string `json:"name,omitempty"`
-	RedirectURI  string `json:"redirect_uri,omitempty"`
-	Scopes       string `json:"scopes,omitempty"`
-	Confidential bool   `json:"confidential,omitempty"`
-}
-
-type ListApplicationsOptions struct {
-}
-
 type Application struct {
 	ID              int    `json:"id"`
 	ApplicationID   string `json:"application_id"`
 	ApplicationName string `json:"application_name"`
+	Secret          string `json:"secret"`
 	CallbackURL     string `json:"callback_url"`
 	Confidential    bool   `json:"confidential"`
+}
+
+// CreateApplicationOptions represents the available CreateApplication() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/applications.html#create-an-application
+type CreateApplicationOptions struct {
+	Name         *string `url:"name,omitempty" json:"name,omitempty"`
+	RedirectURI  *string `url:"redirect_uri,omitempty" json:"redirect_uri,omitempty"`
+	Scopes       *string `url:"scopes,omitempty" json:"scopes,omitempty"`
+	Confidential *bool   `url:"confidential,omitempty" json:"confidential,omitempty"`
 }
 
 // CreateApplication creates a new application owned by the authenticated user.
@@ -65,35 +64,32 @@ func (s *ApplicationsService) CreateApplication(opt *CreateApplicationOptions, o
 	return a, resp, err
 }
 
+type ListApplicationsOptions ListOptions
+
 // ListApplications get a list of administrables applications by the authenticated user
 //
 // Gitlab API docs : https://docs.gitlab.com/ce/api/applications.html#list-all-applications
-func (s *ApplicationsService) ListApplications(options ...OptionFunc) ([]*Application, *Response, error) {
-
-	req, err := s.client.NewRequest("GET", "applications", &ListApplicationsOptions{}, options)
+func (s *ApplicationsService) ListApplications(opt *ListApplicationsOptions, options ...OptionFunc) ([]*Application, *Response, error) {
+	req, err := s.client.NewRequest("GET", "applications", opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	var a []*Application
-	resp, err := s.client.Do(req, &a)
+	var as []*Application
+	resp, err := s.client.Do(req, &as)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return a, resp, err
+	return as, resp, err
 }
 
-// DeleteApplication removes a specific application
+// DeleteApplication removes a specific application.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/applications.html#delete-an-application
-func (s *ApplicationsService) DeleteApplication(id interface{}, options ...OptionFunc) (*Response, error) {
-	application, err := parseID(id)
-	if err != nil {
-		return nil, err
-	}
-
-	u := fmt.Sprintf("applications/%s", pathEscape(application))
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/applications.html#delete-an-application
+func (s *ApplicationsService) DeleteApplication(application int, options ...OptionFunc) (*Response, error) {
+	u := fmt.Sprintf("applications/%d", application)
 
 	req, err := s.client.NewRequest("DELETE", u, nil, options)
 	if err != nil {

--- a/applications.go
+++ b/applications.go
@@ -26,6 +26,16 @@ type ApplicationsService struct {
 	client *Client
 }
 
+// CreateApplicationOptions represents the available CreateApplication() options.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/applications.html#create-an-application
+type CreateApplicationOptions struct {
+	Name         string `json:"name,omitempty"`
+	RedirectURI  string `json:"redirect_uri,omitempty"`
+	Scopes       string `json:"scopes,omitempty"`
+	Confidential bool   `json:"confidential,omitempty"`
+}
+
 type ListApplicationsOptions struct {
 }
 
@@ -35,6 +45,24 @@ type Application struct {
 	ApplicationName string `json:"application_name"`
 	CallbackURL     string `json:"callback_url"`
 	Confidential    bool   `json:"confidential"`
+}
+
+// CreateApplication creates a new application owned by the authenticated user.
+//
+// Gitlab API docs : https://docs.gitlab.com/ce/api/applications.html#create-an-application
+func (s *ApplicationsService) CreateApplication(opt *CreateApplicationOptions, options ...OptionFunc) (*Application, *Response, error) {
+	req, err := s.client.NewRequest("POST", "applications", opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	a := new(Application)
+	resp, err := s.client.Do(req, a)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return a, resp, err
 }
 
 // ListApplications get a list of administrables applications by the authenticated user

--- a/applications.go
+++ b/applications.go
@@ -16,9 +16,11 @@
 
 package gitlab
 
+import "fmt"
+
 // ApplicationsService handles communication with administrables applications
 // of the Gitlab API.
-
+//
 // Gitlab API docs : https://docs.gitlab.com/ee/api/applications.html
 type ApplicationsService struct {
 	client *Client
@@ -36,9 +38,11 @@ type Application struct {
 }
 
 // ListApplications get a list of administrables applications by the authenticated user
-func (s *ApplicationsService) ListApplications(opts *ListApplicationsOptions, options ...OptionFunc) ([]*Application, *Response, error) {
+//
+// Gitlab API docs : https://docs.gitlab.com/ce/api/applications.html#list-all-applications
+func (s *ApplicationsService) ListApplications(options ...OptionFunc) ([]*Application, *Response, error) {
 
-	req, err := s.client.NewRequest("GET", "applications", opts, options)
+	req, err := s.client.NewRequest("GET", "applications", &ListApplicationsOptions{}, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -50,4 +54,23 @@ func (s *ApplicationsService) ListApplications(opts *ListApplicationsOptions, op
 	}
 
 	return a, resp, err
+}
+
+// DeleteApplication removes a specific application
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/applications.html#delete-an-application
+func (s *ApplicationsService) DeleteApplication(id interface{}, options ...OptionFunc) (*Response, error) {
+	application, err := parseID(id)
+	if err != nil {
+		return nil, err
+	}
+
+	u := fmt.Sprintf("applications/%s", pathEscape(application))
+
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
 }

--- a/applications_test.go
+++ b/applications_test.go
@@ -7,23 +7,71 @@ import (
 	"testing"
 )
 
-func TestListApplications(t *testing.T) {
-	mux, server, client := setup()
-	defer teardown(server)
+func TestCreateApplication(t *testing.T) {
+	m, s, c := setup()
+	defer teardown(s)
 
-	mux.HandleFunc("/api/v4/applications",
+	m.HandleFunc("/api/v4/applications",
+		func(w http.ResponseWriter, r *http.Request) {
+			testMethod(t, r, "POST")
+			fmt.Fprint(w, `{"id":1, "application_name":"testApplication"}`)
+		},
+	)
+
+	posted := CreateApplicationOptions{
+		Name: "testApplication",
+	}
+	a, _, err := c.Applications.CreateApplication(&posted)
+	if err != nil {
+		t.Errorf("Applications.CreateApplication returned error : %v", err)
+	}
+	want := Application{ID: 1, ApplicationName: "testApplication"}
+	if reflect.DeepEqual(want, a) {
+		t.Errorf("Applications.CreateApplication returned %v, want %v", a, want)
+	}
+}
+
+func TestListApplications(t *testing.T) {
+	m, s, c := setup()
+	defer teardown(s)
+
+	m.HandleFunc("/api/v4/applications",
 		func(w http.ResponseWriter, r *http.Request) {
 			testMethod(t, r, "GET")
 			fmt.Fprint(w, `[{"id":1},{"id":2}]`)
-		})
+		},
+	)
 
-	apps, _, err := client.Applications.ListApplications()
+	apps, _, err := c.Applications.ListApplications()
 	if err != nil {
 		t.Errorf("Applications.ListApplications returned error: %v", err)
 	}
 
 	want := []*Application{{ID: 1}, {ID: 2}}
 	if !reflect.DeepEqual(want, apps) {
-		t.Errorf("Groups.ListGroups returned %+v, want %+v", apps, want)
+		t.Errorf("Applications.ListApplications returned %+v, want %+v", apps, want)
+	}
+}
+
+func TestDeleteApplication(t *testing.T) {
+	m, s, c := setup()
+	defer teardown(s)
+
+	m.HandleFunc("/api/v4/applications/4",
+		func(w http.ResponseWriter, r *http.Request) {
+			testMethod(t, r, "DELETE")
+			w.WriteHeader(http.StatusAccepted)
+		},
+	)
+
+	r, err := c.Applications.DeleteApplication(4)
+	if err != nil {
+		t.Errorf("Applications.DeleteApplication returned error : %v", err)
+	}
+
+	want := http.StatusAccepted
+	got := r.StatusCode
+	if got != want {
+		t.Errorf("Applications.DeleteApplication returned %d, want %d", got, want)
 	}
 }

--- a/applications_test.go
+++ b/applications_test.go
@@ -1,0 +1,29 @@
+package gitlab
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestListApplications(t *testing.T) {
+	mux, server, client := setup()
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v4/applications",
+		func(w http.ResponseWriter, r *http.Request) {
+			testMethod(t, r, "GET")
+			fmt.Fprint(w, `[{"id":1},{"id":2}]`)
+		})
+
+	apps, _, err := client.Applications.ListApplications()
+	if err != nil {
+		t.Errorf("Applications.ListApplications returned error: %v", err)
+	}
+
+	want := []*Application{{ID: 1}, {ID: 2}}
+	if !reflect.DeepEqual(want, apps) {
+		t.Errorf("Groups.ListGroups returned %+v, want %+v", apps, want)
+	}
+}

--- a/examples/applications.go
+++ b/examples/applications.go
@@ -7,10 +7,20 @@ import (
 func applicationsExample() {
 	git := gitlab.NewClient(nil, "yourtokengoeshere")
 	git.SetBaseURL("https://gitlab.com/api/v4")
+	// Create an application
+	opts := gitlab.CreateApplicationOptions{
+		Name:        "Travis",
+		RedirectURI: "http://example.org",
+		Scopes:      "api",
+	}
+	created, _, err := git.Applications.CreateApplication(&opts)
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("Last created application : %v", created)
 
 	// List all applications
 	applications, _, err := git.Applications.ListApplications()
-
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -20,7 +30,7 @@ func applicationsExample() {
 	}
 
 	// Delete an application
-	resp, err := git.Applications.DeleteApplication(2)
+	resp, err := git.Applications.DeleteApplication(created.ID)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/applications.go
+++ b/examples/applications.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"log"
+)
+
+func applicationsExample() {
+	git := gitlab.NewClient(nil, "yourtokengoeshere")
+	git.SetBaseURL("https://gitlab.com/api/v4")
+
+	applications, _, err := git.Applications.ListApplications()
+
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("Found %d applications :", len(applications))
+	for _, app := range applications {
+		log.Printf("Found app : %v", app)
+	}
+}

--- a/examples/applications.go
+++ b/examples/applications.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"log"
+
+	"github.com/xanzy/go-gitlab"
 )
 
 func applicationsExample() {

--- a/examples/applications.go
+++ b/examples/applications.go
@@ -8,25 +8,25 @@ import (
 
 func applicationsExample() {
 	git := gitlab.NewClient(nil, "yourtokengoeshere")
-	git.SetBaseURL("https://gitlab.com/api/v4")
+
 	// Create an application
-	opts := gitlab.CreateApplicationOptions{
-		Name:        "Travis",
-		RedirectURI: "http://example.org",
-		Scopes:      "api",
+	opts := &gitlab.CreateApplicationOptions{
+		Name:        gitlab.String("Travis"),
+		RedirectURI: gitlab.String("http://example.org"),
+		Scopes:      gitlab.String("api"),
 	}
-	created, _, err := git.Applications.CreateApplication(&opts)
+	created, _, err := git.Applications.CreateApplication(opts)
 	if err != nil {
 		log.Fatal(err)
 	}
 	log.Printf("Last created application : %v", created)
 
 	// List all applications
-	applications, _, err := git.Applications.ListApplications()
+	applications, _, err := git.Applications.ListApplications(&gitlab.ListApplicationsOptions{})
 	if err != nil {
 		log.Fatal(err)
 	}
-	log.Printf("Found %d applications :", len(applications))
+
 	for _, app := range applications {
 		log.Printf("Found app : %v", app)
 	}

--- a/examples/applications.go
+++ b/examples/applications.go
@@ -8,6 +8,7 @@ func applicationsExample() {
 	git := gitlab.NewClient(nil, "yourtokengoeshere")
 	git.SetBaseURL("https://gitlab.com/api/v4")
 
+	// List all applications
 	applications, _, err := git.Applications.ListApplications()
 
 	if err != nil {
@@ -17,4 +18,11 @@ func applicationsExample() {
 	for _, app := range applications {
 		log.Printf("Found app : %v", app)
 	}
+
+	// Delete an application
+	resp, err := git.Applications.DeleteApplication(2)
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("Status code response : %d", resp.StatusCode)
 }

--- a/gitlab.go
+++ b/gitlab.go
@@ -352,6 +352,7 @@ type Client struct {
 
 	// Services used for talking to different parts of the GitLab API.
 	AccessRequests        *AccessRequestsService
+	Applications          *ApplicationsService
 	AwardEmoji            *AwardEmojiService
 	Boards                *IssueBoardsService
 	Branches              *BranchesService
@@ -513,6 +514,7 @@ func newClient(httpClient *http.Client) *Client {
 
 	// Create all the public services.
 	c.AccessRequests = &AccessRequestsService{client: c}
+	c.Applications = &ApplicationsService{client: c}
 	c.AwardEmoji = &AwardEmojiService{client: c}
 	c.Boards = &IssueBoardsService{client: c}
 	c.Branches = &BranchesService{client: c}


### PR DESCRIPTION
Fix #764 

Admin applications weren't supported yet so I added this feature.
One can test these new functionnalities with a [specific example](https://github.com/prytoegrian/go-gitlab/blob/pry/applications/examples/applications.go) and [a docker image](https://docs.gitlab.com/omnibus/docker/).

