### PR TITLE
Add ID to IssueEvent.Project

### DIFF
--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -128,6 +128,7 @@ type IssueEvent struct {
 	ObjectKind string `json:"object_kind"`
 	User       *User  `json:"user"`
 	Project    struct {
+		ID                int             `json:"id"`
 		Name              string          `json:"name"`
 		Description       string          `json:"description"`
 		AvatarURL         string          `json:"avatar_url"`


### PR DESCRIPTION
The IssueEvent.Project struct is missing the ID field. This is documented as being one of the fields returned. See: https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#issue-events