### PR TITLE
Fix merge_requests_events and comment_on_event_enabled missing on properties

### DIFF
--- a/services.go
+++ b/services.go
@@ -43,7 +43,9 @@ type Service struct {
 	PushEvents               bool       `json:"push_events"`
 	IssuesEvents             bool       `json:"issues_events"`
 	ConfidentialIssuesEvents bool       `json:"confidential_issues_events"`
+	CommitEvents             bool       `json:"commit_events"`
 	MergeRequestsEvents      bool       `json:"merge_requests_events"`
+	CommentOnEventEnabled    bool       `json:"comment_on_event_enabled"`
 	TagPushEvents            bool       `json:"tag_push_events"`
 	NoteEvents               bool       `json:"note_events"`
 	ConfidentialNoteEvents   bool       `json:"confidential_note_events"`
@@ -536,9 +538,6 @@ type JiraServiceProperties struct {
 	Username              string `json:"username,omitempty" `
 	Password              string `json:"password,omitempty" `
 	JiraIssueTransitionID string `json:"jira_issue_transition_id,omitempty"`
-	CommitEvents          bool   `json:"commit_events,omitempty" `
-	MergeRequestsEvents   bool   `json:"merge_requests_events,omitempty" `
-	CommentOnEventEnabled bool   `json:"comment_on_event_enabled,omitempty" `
 }
 
 // UnmarshalJSON decodes the Jira Service Properties.


### PR DESCRIPTION
This fixes my previous PR  #817 where I made the mistake of marking these options are jira specific. If you look closely at the https://docs.gitlab.com/ce/api/services.html#list-all-active-services you can see clearly that the options are actually global.

I fixed this by settings `merge_requests_events` and `comment_on_event_enabled` on the global `Service` level in my PR. 

```
 curl --header "Authorization: Bearer xxx" https://x/api/v4/projects/x/services/jira | jq
{
  "id": 3333,
  "title": "Jira",
  "slug": "jira",
  "created_at": "2020-04-03T12:51:03.258Z",
  "updated_at": "2020-04-03T13:54:05.712Z",
  "active": true,
  "commit_events": false,
  "push_events": true,
  "issues_events": true,
  "confidential_issues_events": true,
  "merge_requests_events": false,
  "tag_push_events": true,
  "note_events": true,
  "confidential_note_events": true,
  "pipeline_events": true,
  "wiki_page_events": true,
  "job_events": true,
  "comment_on_event_enabled": false,
  "properties": {
    "url": "https://xx",
    "api_url": null,
    "username": "x@xxx",
    "jira_issue_transition_id": ""
  }
}
```