### PR TITLE
Fixed missing d in pipeline api param

### DIFF
--- a/pipelines.go
+++ b/pipelines.go
@@ -109,7 +109,7 @@ type ListProjectPipelinesOptions struct {
 	Name          *string          `url:"name,omitempty" json:"name,omitempty"`
 	Username      *string          `url:"username,omitempty" json:"username,omitempty"`
 	UpdatedAfter  *time.Time       `url:"updated_after,omitempty" json:"updated_after,omitempty"`
-	UpdatedBefore *time.Time       `url:"update_before,omitempty" json:"updated_before,omitempty"`
+	UpdatedBefore *time.Time       `url:"updated_before,omitempty" json:"updated_before,omitempty"`
 	OrderBy       *string          `url:"order_by,omitempty" json:"order_by,omitempty"`
 	Sort          *string          `url:"sort,omitempty" json:"sort,omitempty"`
 }


### PR DESCRIPTION
UpdatedBefore in pipeline api was not url encoded correctly and missed a
`d`. This could be very bad as there is no error from Gitlab to prompt
user that this is an invalid param.