### PR TITLE
Fix HTTP client context injection

### DIFF
--- a/gitlab.go
+++ b/gitlab.go
@@ -492,7 +492,7 @@ func (c *Client) requestOAuthToken(ctx context.Context) error {
 			TokenURL: fmt.Sprintf("%s://%s/oauth/token", c.BaseURL().Scheme, c.BaseURL().Host),
 		},
 	}
-	ctx = context.WithValue(ctx, oauth2.HTTPClient, c.client)
+	ctx = context.WithValue(ctx, oauth2.HTTPClient, c.client.HTTPClient)
 	t, err := config.PasswordCredentialsToken(ctx, c.username, c.password)
 	if err != nil {
 		return err


### PR DESCRIPTION
When retrieving an OAuth token via Basic Auth, the HTTP Client is not properly added to the context. This modification resolves this issue.