### PR TITLE
Add last_commit_id field to create commit action

### DIFF
--- a/commits.go
+++ b/commits.go
@@ -124,6 +124,7 @@ type CommitAction struct {
 	PreviousPath string     `url:"previous_path,omitempty" json:"previous_path,omitempty"`
 	Content      string     `url:"content,omitempty" json:"content,omitempty"`
 	Encoding     string     `url:"encoding,omitempty" json:"encoding,omitempty"`
+	LastCommitID string     `url:"last_commit_id,omitempty" json:"last_commit_id,omitempty"`
 }
 
 // CommitRef represents the reference of branches/tags in a commit.

--- a/commits.go
+++ b/commits.go
@@ -119,12 +119,13 @@ const (
 
 // CommitAction represents a single file action within a commit.
 type CommitAction struct {
-	Action       FileAction `url:"action" json:"action"`
-	FilePath     string     `url:"file_path" json:"file_path"`
-	PreviousPath string     `url:"previous_path,omitempty" json:"previous_path,omitempty"`
-	Content      string     `url:"content,omitempty" json:"content,omitempty"`
-	Encoding     string     `url:"encoding,omitempty" json:"encoding,omitempty"`
-	LastCommitID string     `url:"last_commit_id,omitempty" json:"last_commit_id,omitempty"`
+	Action          FileAction `url:"action" json:"action"`
+	FilePath        string     `url:"file_path" json:"file_path"`
+	PreviousPath    string     `url:"previous_path,omitempty" json:"previous_path,omitempty"`
+	Content         string     `url:"content,omitempty" json:"content,omitempty"`
+	Encoding        string     `url:"encoding,omitempty" json:"encoding,omitempty"`
+	LastCommitID    string     `url:"last_commit_id,omitempty" json:"last_commit_id,omitempty"`
+	ExecuteFilemode bool       `url:"execute_filemode,omitempty" json:"execute_filemode,omitempty"`
 }
 
 // CommitRef represents the reference of branches/tags in a commit.


### PR DESCRIPTION
This field seems to be missing from the struct. Adding it should be safe. https://docs.gitlab.com/ee/api/commits.html#create-a-commit-with-multiple-files-and-actions