### PR TITLE
Add merge request participants api

### DIFF
--- a/merge_requests.go
+++ b/merge_requests.go
@@ -399,6 +399,31 @@ func (s *MergeRequestsService) GetMergeRequestChanges(pid interface{}, mergeRequ
 	return m, resp, err
 }
 
+// GetMergeRequestParticipants gets a list of merge request participants
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/merge_requests.html#get-single-mr-participants
+func (s *MergeRequestsService) GetMergeRequestParticipants(pid interface{}, mergeRequest int, options ...RequestOptionFunc) ([]*BasicUser, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/merge_requests/%d/participants", pathEscape(project), mergeRequest)
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var p []*BasicUser
+	resp, err := s.client.Do(req, &p)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return p, resp, err
+}
+
 // ListMergeRequestPipelines gets all pipelines for the provided merge request.
 //
 // GitLab API docs:

--- a/merge_requests.go
+++ b/merge_requests.go
@@ -415,13 +415,13 @@ func (s *MergeRequestsService) GetMergeRequestParticipants(pid interface{}, merg
 		return nil, nil, err
 	}
 
-	var p []*BasicUser
-	resp, err := s.client.Do(req, &p)
+	var ps []*BasicUser
+	resp, err := s.client.Do(req, &ps)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return p, resp, err
+	return ps, resp, err
 }
 
 // ListMergeRequestPipelines gets all pipelines for the provided merge request.

--- a/merge_requests.go
+++ b/merge_requests.go
@@ -399,7 +399,7 @@ func (s *MergeRequestsService) GetMergeRequestChanges(pid interface{}, mergeRequ
 	return m, resp, err
 }
 
-// GetMergeRequestParticipants gets a list of merge request participants
+// GetMergeRequestParticipants gets a list of merge request participants.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/merge_requests.html#get-single-mr-participants


### PR DESCRIPTION
Add new `GetMergeRequestParticipants` method in `MergeRequestsService` to retreive merge request participants from API as described in https://docs.gitlab.com/ee/api/merge_requests.html#get-single-mr-participants