### PR TITLE
Add support for 'external' attribute in list-users

### DIFF
--- a/users.go
+++ b/users.go
@@ -112,6 +112,7 @@ type ListUsersOptions struct {
 	CreatedAfter         *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
 	OrderBy              *string    `url:"order_by,omitempty" json:"order_by,omitempty"`
 	Sort                 *string    `url:"sort,omitempty" json:"sort,omitempty"`
+	External             *bool      `url:"external,omitempty" json:"external,omitempty"`
 	WithCustomAttributes *bool      `url:"with_custom_attributes,omitempty" json:"with_custom_attributes,omitempty"`
 }
 


### PR DESCRIPTION
Gitlab provides support for searching external users (different than the external auth), as per : 

https://docs.gitlab.com/ee/api/users.html#for-admins

`You can search for users who are external with: /users?external=true `

This PR simply adds the `external` attribute in the ListUsers options