### PR TITLE
Fix EditProject MergeRequestAccessLevel url

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -458,7 +458,7 @@ type CreateProjectOptions struct {
 	Description                               *string             `url:"description,omitempty" json:"description,omitempty"`
 	IssuesAccessLevel                         *AccessControlValue `url:"issues_access_level,omitempty" json:"issues_access_level,omitempty"`
 	RepositoryAccessLevel                     *AccessControlValue `url:"repository_access_level,omitempty" json:"repository_access_level,omitempty"`
-	MergeRequestAccessLevel                   *AccessControlValue `url:"merge_request_access_level,omitempty" json:"merge_request_access_level,omitempty"`
+	MergeRequestsAccessLevel                  *AccessControlValue `url:"merge_requests_access_level,omitempty" json:"merge_requests_access_level,omitempty"`
 	ForkingAccessLevel                        *AccessControlValue `url:"forking_access_level,omitempty" json:"forking_access_level,omitempty"`
 	BuildsAccessLevel                         *AccessControlValue `url:"builds_access_level,omitempty" json:"builds_access_level,omitempty"`
 	WikiAccessLevel                           *AccessControlValue `url:"wiki_access_level,omitempty" json:"wiki_access_level,omitempty"`

--- a/projects.go
+++ b/projects.go
@@ -561,7 +561,7 @@ type EditProjectOptions struct {
 	Description                               *string             `url:"description,omitempty" json:"description,omitempty"`
 	IssuesAccessLevel                         *AccessControlValue `url:"issues_access_level,omitempty" json:"issues_access_level,omitempty"`
 	RepositoryAccessLevel                     *AccessControlValue `url:"repository_access_level,omitempty" json:"repository_access_level,omitempty"`
-	MergeRequestAccessLevel                   *AccessControlValue `url:"merge_request_access_level,omitempty" json:"merge_request_access_level,omitempty"`
+	MergeRequestAccessLevel                   *AccessControlValue `url:"merge_requests_access_level,omitempty" json:"merge_requests_access_level,omitempty"`
 	ForkingAccessLevel                        *AccessControlValue `url:"forking_access_level,omitempty" json:"forking_access_level,omitempty"`
 	BuildsAccessLevel                         *AccessControlValue `url:"builds_access_level,omitempty" json:"builds_access_level,omitempty"`
 	WikiAccessLevel                           *AccessControlValue `url:"wiki_access_level,omitempty" json:"wiki_access_level,omitempty"`

--- a/projects.go
+++ b/projects.go
@@ -561,7 +561,7 @@ type EditProjectOptions struct {
 	Description                               *string             `url:"description,omitempty" json:"description,omitempty"`
 	IssuesAccessLevel                         *AccessControlValue `url:"issues_access_level,omitempty" json:"issues_access_level,omitempty"`
 	RepositoryAccessLevel                     *AccessControlValue `url:"repository_access_level,omitempty" json:"repository_access_level,omitempty"`
-	MergeRequestAccessLevel                   *AccessControlValue `url:"merge_requests_access_level,omitempty" json:"merge_requests_access_level,omitempty"`
+	MergeRequestsAccessLevel                  *AccessControlValue `url:"merge_requests_access_level,omitempty" json:"merge_requests_access_level,omitempty"`
 	ForkingAccessLevel                        *AccessControlValue `url:"forking_access_level,omitempty" json:"forking_access_level,omitempty"`
 	BuildsAccessLevel                         *AccessControlValue `url:"builds_access_level,omitempty" json:"builds_access_level,omitempty"`
 	WikiAccessLevel                           *AccessControlValue `url:"wiki_access_level,omitempty" json:"wiki_access_level,omitempty"`


### PR DESCRIPTION
For code like this:

```
		projOpt := &gitlab.EditProjectOptions{
			MergeRequestAccessLevel: gitlab.AccessControl(gitlab.DisabledAccessControl),
		}
		_, resp, err := git.Projects.EditProject(project.ID, projOpt, nil)
```

Before:

`Error: 400 Bad Request => PUT https://gilab.xyz/api/v4/projects/82: 400 {error: autoclose_referenced_issues, auto_devops_enabled, auto_devops_deploy_strategy, auto_cancel_pending_pipelines, build_coverage_regex, build_git_strategy, build_timeout, builds_access_level, ci_config_path, ci_default_git_depth, container_registry_enabled, container_expiration_policy_attributes, default_branch, description, emails_disabled, forking_access_level, issues_access_level, lfs_enabled, merge_requests_access_level, merge_method, name, only_allow_merge_if_all_discussions_are_resolved, only_allow_merge_if_pipeline_succeeds, pages_access_level, path, printing_merge_request_link_enabled, public_builds, remove_source_branch_after_merge, repository_access_level, request_access_enabled, resolve_outdated_diff_discussions, shared_runners_enabled, snippets_access_level, tag_list, visibility, wiki_access_level, avatar, suggestion_commit_message, repository_storage, compliance_framework_setting, issues_enabled, jobs_enabled, merge_requests_enabled, wiki_enabled, snippets_enabled are missing, at least one parameter must be provided}`

After:
`Result: 200 OK`
