### PR TITLE
Fix creating and updating project snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ func main() {
 	s := &gitlab.CreateProjectSnippetOptions{
 		Title:           gitlab.String("Dummy Snippet"),
 		FileName:        gitlab.String("snippet.go"),
-		Code:            gitlab.String("package main...."),
+		Content:         gitlab.String("package main...."),
 		Visibility:      gitlab.Visibility(gitlab.PublicVisibility),
 	}
 	_, _, err = git.ProjectSnippets.CreateSnippet(project.ID, s)

--- a/examples/projects.go
+++ b/examples/projects.go
@@ -29,7 +29,7 @@ func projectExample() {
 	s := &gitlab.CreateProjectSnippetOptions{
 		Title:      gitlab.String("Dummy Snippet"),
 		FileName:   gitlab.String("snippet.go"),
-		Code:       gitlab.String("package main...."),
+		Content:    gitlab.String("package main...."),
 		Visibility: gitlab.Visibility(gitlab.PublicVisibility),
 	}
 	_, _, err = git.ProjectSnippets.CreateSnippet(project.ID, s)

--- a/project_snippets.go
+++ b/project_snippets.go
@@ -91,7 +91,7 @@ type CreateProjectSnippetOptions struct {
 	Title       *string          `url:"title,omitempty" json:"title,omitempty"`
 	FileName    *string          `url:"file_name,omitempty" json:"file_name,omitempty"`
 	Description *string          `url:"description,omitempty" json:"description,omitempty"`
-	Code        *string          `url:"code,omitempty" json:"code,omitempty"`
+	Content     *string          `url:"content,omitempty" json:"content,omitempty"`
 	Visibility  *VisibilityValue `url:"visibility,omitempty" json:"visibility,omitempty"`
 }
 
@@ -129,7 +129,7 @@ type UpdateProjectSnippetOptions struct {
 	Title       *string          `url:"title,omitempty" json:"title,omitempty"`
 	FileName    *string          `url:"file_name,omitempty" json:"file_name,omitempty"`
 	Description *string          `url:"description,omitempty" json:"description,omitempty"`
-	Code        *string          `url:"code,omitempty" json:"code,omitempty"`
+	Content     *string          `url:"content,omitempty" json:"content,omitempty"`
 	Visibility  *VisibilityValue `url:"visibility,omitempty" json:"visibility,omitempty"`
 }
 


### PR DESCRIPTION
According to the documentation for [creating](https://docs.gitlab.com/ce/api/project_snippets.html#create-new-snippet) and [updating](https://docs.gitlab.com/ce/api/project_snippets.html#update-snippet) project snippets, `content` must be used instead of `code`.