### PR TITLE
added new value about CreateBranchOptions

### DIFF
--- a/branches.go
+++ b/branches.go
@@ -176,8 +176,9 @@ func (s *BranchesService) UnprotectBranch(pid interface{}, branch string, option
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/branches.html#create-repository-branch
 type CreateBranchOptions struct {
-	Branch *string `url:"branch,omitempty" json:"branch,omitempty"`
-	Ref    *string `url:"ref,omitempty" json:"ref,omitempty"`
+	IssueIid *int    `url:"issue_iid,omitempty" json:"issue_iid,omitempty"`
+	Branch   *string `url:"branch,omitempty" json:"branch,omitempty"`
+	Ref      *string `url:"ref,omitempty" json:"ref,omitempty"`
 }
 
 // CreateBranch creates branch from commit SHA or existing branch.


### PR DESCRIPTION
Allows the ability to link issues when users create new branch.

sometimes `gitlab.Client` create a new branch in a project， you should binding with issue。 