### PR TITLE
Add labels.PromoteLabel

### DIFF
--- a/labels.go
+++ b/labels.go
@@ -73,7 +73,11 @@ func (l Label) String() string {
 // ListLabelsOptions represents the available ListLabels() options.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/labels.html#list-labels
-type ListLabelsOptions ListOptions
+type ListLabelsOptions struct {
+	ListOptions
+	WithCounts            *bool `url:"with_counts,omitempty" json:"with_counts,omitempty"`
+	IncludeAncestorGroups *bool `url:"include_ancestor_groups,omitempty" json:"include_ancestor_groups,omitempty"`
+}
 
 // ListLabels gets all labels for given project.
 //
@@ -242,6 +246,29 @@ func (s *LabelsService) UnsubscribeFromLabel(pid interface{}, labelID interface{
 	u := fmt.Sprintf("projects/%s/labels/%s/unsubscribe", pathEscape(project), label)
 
 	req, err := s.client.NewRequest("POST", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// PromoteLabel Promotes a project label to a group label.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/labels.html#promote-a-project-label-to-a-group-label
+func (s *LabelsService) PromoteLabel(pid interface{}, labelID interface{}, options ...RequestOptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	label, err := parseID(labelID)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/labels/%s/promote", pathEscape(project), label)
+
+	req, err := s.client.NewRequest("PUT", u, nil, options)
 	if err != nil {
 		return nil, err
 	}

--- a/labels_test.go
+++ b/labels_test.go
@@ -128,8 +128,10 @@ func TestListLabels(t *testing.T) {
 	})
 
 	o := &ListLabelsOptions{
-		Page:    1,
-		PerPage: 10,
+		ListOptions: ListOptions{
+			Page:    1,
+			PerPage: 10,
+		},
 	}
 	label, _, err := client.Labels.ListLabels("1", o)
 	if err != nil {


### PR DESCRIPTION
Add more labels filter and hability to promote project label to group one.

pseudo code sample
```
	opt := &gitlab.ListLabelsOptions{
		ListOptions: gitlab.ListOptions{
			Page:    page,
			PerPage: 100,
		},
		WithCounts:            gitlab.Bool(true),
		IncludeAncestorGroups: gitlab.Bool(true),
	}
	labels, resp, err = git.Labels.ListLabels(666, opt, nil)
	if err != nil {
		log.Fatalf("Error listing: %v (%v)", err.Error(), resp)
	}

	for _, label := range labels {
		if !label.IsProjectLabel {
			log.Print(label.Name)
			continue
		}
		log.Printf("Promote: %v", label.Name)
		git.Labels.PromoteLabel(666, label.ID)
	}
```