### PR TITLE
Add function for sharing groups with groups

### DIFF
--- a/group_members.go
+++ b/group_members.go
@@ -176,6 +176,31 @@ func (s *GroupMembersService) AddGroupMember(gid interface{}, opt *AddGroupMembe
 	return gm, resp, err
 }
 
+// ShareWithGroup shares a group with the group.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/groups.html#share-groups-with-groups
+func (s *GroupMembersService) ShareWithGroup(gid interface{}, opt *ShareWithGroupOptions, options ...RequestOptionFunc) (*Group, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/share", pathEscape(group))
+
+	req, err := s.client.NewRequest("POST", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	g := new(Group)
+	resp, err := s.client.Do(req, g)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return g, resp, err
+}
+
 // EditGroupMemberOptions represents the available EditGroupMember()
 // options.
 //


### PR DESCRIPTION
As far as I could tell, sharing groups with groups is not implemented: https://docs.gitlab.com/ce/api/groups.html#share-groups-with-groups

This PR is a suggestion to add it, along with an example of how that could look.

The type for "Share-Groups-With-Groups"-options seems identical to "ShareWithGroupOptions", so that should be able to be reused.

I did not see any tests for group_members.go