### PR TITLE
Add get a single group/project label

### DIFF
--- a/group_labels.go
+++ b/group_labels.go
@@ -51,6 +51,35 @@ func (s *GroupLabelsService) ListGroupLabels(gid interface{}, opt *ListGroupLabe
 	return l, resp, err
 }
 
+// GetGroupLabel get a single label for a given group.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/group_labels.html#get-a-single-group-label
+func (s *GroupLabelsService) GetGroupLabel(gid interface{}, labelID interface{}, options ...RequestOptionFunc) (*GroupLabel, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	label, err := parseID(labelID)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/labels/%s", pathEscape(group), label)
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var l *GroupLabel
+	resp, err := s.client.Do(req, &l)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return l, resp, err
+}
+
 // CreateGroupLabelOptions represents the available CreateGroupLabel() options.
 //
 // GitLab API docs:

--- a/group_labels_test.go
+++ b/group_labels_test.go
@@ -138,3 +138,23 @@ func TestListGroupLabels(t *testing.T) {
 		t.Errorf("GroupLabels.ListGroupLabels returned %+v, want %+v", label, want)
 	}
 }
+
+func TestGetGroupLabel(t *testing.T) {
+	mux, server, client := setup(t)
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v4/groups/1/labels/5", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{  "id" : 5, "name" : "bug", "color" : "#d9534f", "description": "Bug reported by user", "open_issues_count": 1, "closed_issues_count": 0, "open_merge_requests_count": 1, "subscribed": true,"priority": null}`)
+	})
+
+	label, _, err := client.GroupLabels.GetGroupLabel("1", 5)
+	if err != nil {
+		t.Log(err)
+	}
+
+	want := &GroupLabel{ID: 5, Name: "bug", Color: "#d9534f", Description: "Bug reported by user", OpenIssuesCount: 1, ClosedIssuesCount: 0, OpenMergeRequestsCount: 1, Subscribed: true}
+	if !reflect.DeepEqual(want, label) {
+		t.Errorf("GroupLabels.GetGroupLabel returned %+v, want %+v", label, want)
+	}
+}

--- a/labels.go
+++ b/labels.go
@@ -103,6 +103,34 @@ func (s *LabelsService) ListLabels(pid interface{}, opt *ListLabelsOptions, opti
 	return l, resp, err
 }
 
+// GetLabel get a single label for a given project.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/labels.html#get-a-single-project-label
+func (s *LabelsService) GetLabel(pid interface{}, labelID interface{}, options ...RequestOptionFunc) (*Label, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	label, err := parseID(labelID)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/labels/%s", pathEscape(project), label)
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var l *Label
+	resp, err := s.client.Do(req, &l)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return l, resp, err
+}
+
 // CreateLabelOptions represents the available CreateLabel() options.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/labels.html#create-a-new-label

--- a/labels_test.go
+++ b/labels_test.go
@@ -143,3 +143,23 @@ func TestListLabels(t *testing.T) {
 		t.Errorf("Labels.ListLabels returned %+v, want %+v", label, want)
 	}
 }
+
+func TestGetLabel(t *testing.T) {
+	mux, server, client := setup(t)
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v4/projects/1/labels/5", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{  "id" : 5, "name" : "bug", "color" : "#d9534f", "description": "Bug reported by user", "open_issues_count": 1, "closed_issues_count": 0, "open_merge_requests_count": 1, "subscribed": true,"priority": null}`)
+	})
+
+	label, _, err := client.Labels.GetLabel("1", 5)
+	if err != nil {
+		t.Log(err)
+
+	}
+	want := &Label{ID: 5, Name: "bug", Color: "#d9534f", Description: "Bug reported by user", OpenIssuesCount: 1, ClosedIssuesCount: 0, OpenMergeRequestsCount: 1, Subscribed: true}
+	if !reflect.DeepEqual(want, label) {
+		t.Errorf("Labels.GetLabel returned %+v, want %+v", label, want)
+	}
+}


### PR DESCRIPTION
Support to get group/project single label

https://docs.gitlab.com/ce/api/labels.html#get-a-single-project-label
https://docs.gitlab.com/ce/api/group_labels.html#get-a-single-group-label

sample:
```
	plabel, _, err := client.Labels.GetLabel(51, 321) // label_id
	log.Printf("xx %v", plabel)

		label, _, err := client.GroupLabels.GetGroupLabel(20, "ALabelName")
	log.Printf("xx %v", label)
```