### PR TITLE
Types compare helpers

### DIFF
--- a/types.go
+++ b/types.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"reflect"
 	"time"
 )
 
@@ -30,6 +31,30 @@ func AccessControl(v AccessControlValue) *AccessControlValue {
 	p := new(AccessControlValue)
 	*p = v
 	return p
+}
+
+func (s *AccessControlValue) compareAccessControl(v AccessControlValue) bool {
+	return reflect.DeepEqual(s, AccessControl(v))
+}
+
+// IsDisabledAccessControl return true if is DisabledAccessControl
+func (s *AccessControlValue) IsDisabledAccessControl() bool {
+	return s.compareAccessControl(DisabledAccessControl)
+}
+
+// IsEnabledAccessControl return true if is EnabledAccessControl
+func (s *AccessControlValue) IsEnabledAccessControl() bool {
+	return s.compareAccessControl(EnabledAccessControl)
+}
+
+// IsPrivateAccessControl return true if is PrivateAccessControl
+func (s *AccessControlValue) IsPrivateAccessControl() bool {
+	return s.compareAccessControl(PrivateAccessControl)
+}
+
+// IsPublicAccessControl return true if is DisabledAccessControl
+func (s *AccessControlValue) IsPublicAccessControl() bool {
+	return s.compareAccessControl(PublicAccessControl)
 }
 
 // AccessLevelValue represents a permission level within GitLab.

--- a/types_test.go
+++ b/types_test.go
@@ -1,0 +1,25 @@
+package gitlab
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_compareAccessControl(t *testing.T) {
+
+	valueDisabledAccessControl := AccessControlValue(DisabledAccessControl)
+	valueEnabledAccessControl := AccessControlValue(EnabledAccessControl)
+	valuePrivateAccessControl := AccessControlValue(PrivateAccessControl)
+	valuePublicAccessControl := AccessControlValue(PublicAccessControl)
+
+	require.Equal(t, true, valueDisabledAccessControl.compareAccessControl(DisabledAccessControl))
+	require.Equal(t, true, valueEnabledAccessControl.compareAccessControl(EnabledAccessControl))
+	require.Equal(t, true, valuePrivateAccessControl.compareAccessControl(PrivateAccessControl))
+	require.Equal(t, true, valuePublicAccessControl.compareAccessControl(PublicAccessControl))
+
+	require.Equal(t, true, valuePublicAccessControl.IsPublicAccessControl())
+	require.Equal(t, true, valueEnabledAccessControl.IsEnabledAccessControl())
+	require.Equal(t, true, valuePrivateAccessControl.IsPrivateAccessControl())
+	require.Equal(t, true, valuePublicAccessControl.IsPublicAccessControl())
+}


### PR DESCRIPTION
It should be usefull to compare types easily

if #890 merged, a POC updating a project settings, only if needed:
```
	opt = &gitlab.EditProjectOptions{}

	aProject, _, _ := Client.Projects.GetProject(42, nil, nil)

	if !aProject.ForkingAccessLevel.IsDisabledAccessControl() {
		opt.ForkingAccessLevel = gitlab.AccessControl(gitlab.DisabledAccessControl)
		needUpdate = true
	}

	if needUpdate {
		client.Projects.EditProject(aProject.ID, opt)
	}
```

@svanharmelen Need some review if it's ok, before doing it to other types :wink: 