### PR TITLE
Rename pc to gc

### DIFF
--- a/group_clusters.go
+++ b/group_clusters.go
@@ -93,13 +93,13 @@ func (s *GroupClustersService) GetCluster(pid interface{}, cluster int, options 
 		return nil, nil, err
 	}
 
-	pc := new(GroupCluster)
-	resp, err := s.client.Do(req, &pc)
+	gc := new(GroupCluster)
+	resp, err := s.client.Do(req, &gc)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return pc, resp, err
+	return gc, resp, err
 }
 
 // AddGroupClusterOptions represents the available AddCluster() options.
@@ -141,13 +141,13 @@ func (s *GroupClustersService) AddCluster(pid interface{}, opt *AddGroupClusterO
 		return nil, nil, err
 	}
 
-	pc := new(GroupCluster)
-	resp, err := s.client.Do(req, pc)
+	gc := new(GroupCluster)
+	resp, err := s.client.Do(req, gc)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return pc, resp, err
+	return gc, resp, err
 }
 
 // EditGroupClusterOptions represents the available EditCluster() options.
@@ -185,13 +185,13 @@ func (s *GroupClustersService) EditCluster(pid interface{}, cluster int, opt *Ed
 		return nil, nil, err
 	}
 
-	pc := new(GroupCluster)
-	resp, err := s.client.Do(req, pc)
+	gc := new(GroupCluster)
+	resp, err := s.client.Do(req, gc)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return pc, resp, err
+	return gc, resp, err
 }
 
 // DeleteCluster deletes an existing group cluster.


### PR DESCRIPTION
It seems like group_clusters.go was made by search-and-replacing the project_clusters.go file. Some instances of pc (stands for project cluster)were left in the group_clusters file, so this small PR just changes a few instances of pc into gc (stands for group cluster)