### PR TITLE
Add support for creating a pipeline for a merge request

### DIFF
--- a/merge_requests.go
+++ b/merge_requests.go
@@ -449,6 +449,31 @@ func (s *MergeRequestsService) ListMergeRequestPipelines(pid interface{}, mergeR
 	return p, resp, err
 }
 
+// CreateMergeRequestPipeline creates a new pipeline for a merge request.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/merge_requests.html#create-mr-pipeline
+func (s *MergeRequestsService) CreateMergeRequestPipeline(pid interface{}, mergeRequest int, options ...RequestOptionFunc) (*PipelineInfo, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/merge_requests/%d/pipelines", pathEscape(project), mergeRequest)
+
+	req, err := s.client.NewRequest("POST", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	p := new(PipelineInfo)
+	resp, err := s.client.Do(req, p)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return p, resp, err
+}
+
 // GetIssuesClosedOnMergeOptions represents the available GetIssuesClosedOnMerge()
 // options.
 //

--- a/merge_requests_test.go
+++ b/merge_requests_test.go
@@ -1,6 +1,7 @@
 package gitlab
 
 import (
+	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -158,4 +159,23 @@ func TestListProjectMergeRequests(t *testing.T) {
 		assert.Nil(t, mr.HeadPipeline)
 		assert.Equal(t, "", mr.DiffRefs.HeadSha)
 	}
+}
+
+func TestCreateMergeRequestPipeline(t *testing.T) {
+	mux, server, client := setup(t)
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v4/projects/1/merge_requests/1/pipelines", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		fmt.Fprint(w, `{"id":1, "status":"pending"}`)
+	})
+
+	pipeline, _, err := client.MergeRequests.CreateMergeRequestPipeline(1, 1)
+
+	if err != nil {
+		t.Errorf("MergeRequests.CreateMergeRequestPipeline returned error: %v", err)
+	}
+
+	assert.Equal(t, 1, pipeline.ID)
+	assert.Equal(t, "pending", pipeline.Status)
 }


### PR DESCRIPTION
This pull request adds support for creating a pipeline for a merge request, see https://docs.gitlab.com/ce/api/merge_requests.html#create-mr-pipeline.