### PR TITLE
Pipeline emails

### DIFF
--- a/services.go
+++ b/services.go
@@ -778,6 +778,7 @@ type PipelinesEmailProperties struct {
 	Recipients                string    `json:"recipients,omitempty"`
 	NotifyOnlyBrokenPipelines BoolValue `json:"notify_only_broken_pipelines,omitempty"`
 	NotifyOnlyDefaultBranch   BoolValue `json:"notify_only_default_branch,omitempty"`
+	BranchesToBeNotified      string    `json:"branches_to_be_notified,omitempty"`
 }
 
 // GetPipelinesEmailService gets Pipelines Email service settings for a project.

--- a/services.go
+++ b/services.go
@@ -676,7 +676,6 @@ type MicrosoftTeamsServiceProperties struct {
 	ConfidentialNoteEvents    BoolValue `json:"confidential_note_events"`
 	PipelineEvents            BoolValue `json:"pipeline_events"`
 	WikiPageEvents            BoolValue `json:"wiki_page_events"`
-
 }
 
 // GetMicrosoftTeamsService gets MicrosoftTeams service settings for a project.


### PR DESCRIPTION
Add a missing field in the Pipelines Email properties. The API is not well documented: https://docs.gitlab.com/ee/api/services.html#get-pipeline-emails-service-settings but from testing, the field is indeed present.