### PR TITLE
An Issue Epic || Inheritance: GetEpicLinks & Parent

### DIFF
--- a/epics.go
+++ b/epics.go
@@ -31,7 +31,7 @@ type Epic struct {
 	IID                     int         `json:"iid"`
 	GroupID                 int         `json:"group_id"`
 	Author                  *EpicAuthor `json:"author"`
-        ParentID		int	    `json:"parent_id"`
+	ParentID                int         `json:"parent_id"`
 	Description             string      `json:"description"`
 	State                   string      `json:"state"`
 	WebURL                  string      `json:"web_url"`
@@ -50,6 +50,7 @@ type Epic struct {
 	DueDateIsFixed          bool        `json:"due_date_is_fixed"`
 	DueDateFixed            *ISOTime    `json:"due_date_fixed"`
 	DueDateFromMilestones   *ISOTime    `json:"due_date_from_milestones"`
+	URL                     string      `json:"url"`
 }
 
 func (e Epic) String() string {

--- a/epics.go
+++ b/epics.go
@@ -30,18 +30,12 @@ type Epic struct {
 	ID                      int         `json:"id"`
 	IID                     int         `json:"iid"`
 	GroupID                 int         `json:"group_id"`
-	Author                  *EpicAuthor `json:"author"`
 	ParentID                int         `json:"parent_id"`
+	Title                   string      `json:"title"`
 	Description             string      `json:"description"`
 	State                   string      `json:"state"`
 	WebURL                  string      `json:"web_url"`
-	Upvotes                 int         `json:"upvotes"`
-	Downvotes               int         `json:"downvotes"`
-	Labels                  []string    `json:"labels"`
-	Title                   string      `json:"title"`
-	UpdatedAt               *time.Time  `json:"updated_at"`
-	CreatedAt               *time.Time  `json:"created_at"`
-	UserNotesCount          int         `json:"user_notes_count"`
+	Author                  *EpicAuthor `json:"author"`
 	StartDate               *ISOTime    `json:"start_date"`
 	StartDateIsFixed        bool        `json:"start_date_is_fixed"`
 	StartDateFixed          *ISOTime    `json:"start_date_fixed"`
@@ -50,6 +44,12 @@ type Epic struct {
 	DueDateIsFixed          bool        `json:"due_date_is_fixed"`
 	DueDateFixed            *ISOTime    `json:"due_date_fixed"`
 	DueDateFromMilestones   *ISOTime    `json:"due_date_from_milestones"`
+	CreatedAt               *time.Time  `json:"created_at"`
+	UpdatedAt               *time.Time  `json:"updated_at"`
+	Labels                  []string    `json:"labels"`
+	Upvotes                 int         `json:"upvotes"`
+	Downvotes               int         `json:"downvotes"`
+	UserNotesCount          int         `json:"user_notes_count"`
 	URL                     string      `json:"url"`
 }
 

--- a/epics.go
+++ b/epics.go
@@ -31,8 +31,10 @@ type Epic struct {
 	IID                     int         `json:"iid"`
 	GroupID                 int         `json:"group_id"`
 	Author                  *EpicAuthor `json:"author"`
+        ParentID		int	    `json:"parent_id"`
 	Description             string      `json:"description"`
 	State                   string      `json:"state"`
+	WebURL                  string      `json:"web_url"`
 	Upvotes                 int         `json:"upvotes"`
 	Downvotes               int         `json:"downvotes"`
 	Labels                  []string    `json:"labels"`
@@ -124,6 +126,30 @@ func (s *EpicsService) GetEpic(gid interface{}, epic int, options ...RequestOpti
 	return e, resp, err
 }
 
+// GetEpicLinks gets all child epics of an epic.
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/epic_links.html
+func (s *EpicsService) GetEpicLinks(gid interface{}, epic int, options ...RequestOptionFunc) ([]*Epic, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/epics/%d/epics", pathEscape(group), epic)
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var e []*Epic
+	resp, err := s.client.Do(req, &e)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return e, resp, err
+}
+
 // CreateEpicOptions represents the available CreateEpic() options.
 //
 // GitLab API docs: https://docs.gitlab.com/ee/api/epics.html#new-epic
@@ -199,6 +225,28 @@ func (s *EpicsService) UpdateEpic(gid interface{}, epic int, opt *UpdateEpicOpti
 
 	return e, resp, err
 }
+
+func (s *EpicsService) GetEpicLinks(gid interface{}, epic int, options ...RequestOptionFunc) ([]*Epic, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/epics/%d/epics", pathEscape(group), epic)
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var e []*Epic
+	resp, err := s.client.Do(req, &e)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return e, resp, err
+}
+
 
 // DeleteEpic deletes a single group epic.
 //

--- a/epics.go
+++ b/epics.go
@@ -226,28 +226,6 @@ func (s *EpicsService) UpdateEpic(gid interface{}, epic int, opt *UpdateEpicOpti
 	return e, resp, err
 }
 
-func (s *EpicsService) GetEpicLinks(gid interface{}, epic int, options ...RequestOptionFunc) ([]*Epic, *Response, error) {
-	group, err := parseID(gid)
-	if err != nil {
-		return nil, nil, err
-	}
-	u := fmt.Sprintf("groups/%s/epics/%d/epics", pathEscape(group), epic)
-
-	req, err := s.client.NewRequest("GET", u, nil, options)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	var e []*Epic
-	resp, err := s.client.Do(req, &e)
-	if err != nil {
-		return nil, resp, err
-	}
-
-	return e, resp, err
-}
-
-
 // DeleteEpic deletes a single group epic.
 //
 // GitLab API docs: https://docs.gitlab.com/ee/api/epics.html#delete-epic

--- a/issues.go
+++ b/issues.go
@@ -113,7 +113,8 @@ type Issue struct {
 	Links                *IssueLinks      `json:"_links"`
 	IssueLinkID          int              `json:"issue_link_id"`
 	MergeRequestCount    int              `json:"merge_requests_count"`
-	EpicIssueID          int              `json:"epic_issue_id"`
+	EpicIssueID          int              `json:"epic_issue_id"` 
+	Epic                 *Epic            `json:"epic"`
 	TaskCompletionStatus struct {
 		Count          int `json:"count"`
 		CompletedCount int `json:"completed_count"`


### PR DESCRIPTION
Changes:
______________________
1st Part:
Epic Structure: Includes WebURL; ParentID
Epic Class: GetEpicLinks

Second Part - additional Changes:
View: https://github.com/xanzy/go-gitlab/pull/917#issuecomment-675539389
______________________
What this enables:
- Getting WebURL for Epics.
- Inheritance: able to find ParentEpic's
- Issues report epic structure
  - Uses URL instead of WebURL.  Epics structure updated to have both WebURL and URL. (See part 2 for more info)
Example of usage:
So if you have a structure of One Epic -> Many Epics, you can write a function to update multiple Epic milestones, labels, etc. at once. And if you have a bunch of issues and want to list their epic URLs, this will allow you to easily do that.
Very nice. :)
______________________
1st Part:
I have no public tests for this unfortunately, but these do work. These were tested and implemented into a private gitlab. They are within the example responses (see below). They are also in order of the Gitlab JSON.

View examples:
https://docs.gitlab.com/ee/api/epics.html#single-epic
https://docs.gitlab.com/ee/api/epic_links.html