### PR TITLE
Patch boolean json unmarshall error on slack service

### DIFF
--- a/gitlab_test.go
+++ b/gitlab_test.go
@@ -3,7 +3,6 @@ package gitlab
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"io"
 	"io/ioutil"
@@ -164,43 +163,6 @@ func TestRequestWithContext(t *testing.T) {
 
 	if req.Context() != ctx {
 		t.Fatal("Context was not set correctly")
-	}
-}
-
-func TestBoolValue(t *testing.T) {
-	testCases := map[string]struct {
-		data     []byte
-		expected bool
-	}{
-		"should unmarshal true as true": {
-			data:     []byte("true"),
-			expected: true,
-		},
-		"should unmarshal false as true": {
-			data:     []byte("false"),
-			expected: false,
-		},
-		"should unmarshal \"1\" as true": {
-			data:     []byte(`"1"`),
-			expected: true,
-		},
-		"should unmarshal \"0\" as false": {
-			data:     []byte(`"0"`),
-			expected: false,
-		},
-	}
-
-	for name, testCase := range testCases {
-		t.Run(name, func(t *testing.T) {
-			var b BoolValue
-			if err := json.Unmarshal(testCase.data, &b); err != nil {
-				t.Fatalf("Unexpected error: %v", err)
-			}
-
-			if bool(b) != testCase.expected {
-				t.Fatalf("Expected %v but got %v", testCase.expected, b)
-			}
-		})
 	}
 }
 

--- a/types.go
+++ b/types.go
@@ -402,14 +402,23 @@ func Time(v time.Time) *time.Time {
 // BoolValue is a boolean value with advanced json unmarshaling features.
 type BoolValue bool
 
-// UnmarshalJSON allows 1 and 0 to be considered as boolean values
-// Needed for https://gitlab.com/gitlab-org/gitlab-ce/issues/50122
+// UnmarshalJSON allows 1, 0, "true", and "false" to be considered as boolean values
+// Needed for:
+// https://gitlab.com/gitlab-org/gitlab-ce/issues/50122
+// https://gitlab.com/gitlab-org/gitlab/-/issues/233941
+// https://github.com/gitlabhq/terraform-provider-gitlab/issues/348
 func (t *BoolValue) UnmarshalJSON(b []byte) error {
 	switch string(b) {
 	case `"1"`:
 		*t = true
 		return nil
 	case `"0"`:
+		*t = false
+		return nil
+	case `"true"`:
+		*t = true
+		return nil
+	case `"false"`:
 		*t = false
 		return nil
 	default:

--- a/types_test.go
+++ b/types_test.go
@@ -1,0 +1,58 @@
+package gitlab
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestBoolValue(t *testing.T) {
+	testCases := []struct {
+		name     string
+		data     []byte
+		expected bool
+	}{
+		{
+			name:     "should unmarshal true as true",
+			data:     []byte("true"),
+			expected: true,
+		},
+		{
+			name:     "should unmarshal false as false",
+			data:     []byte("false"),
+			expected: false,
+		},
+		{
+			name:     "should unmarshal true as true",
+			data:     []byte(`"true"`),
+			expected: true,
+		},
+		{
+			name:     "should unmarshal false as false",
+			data:     []byte(`"false"`),
+			expected: false,
+		},
+		{
+			name:     "should unmarshal \"1\" as true",
+			data:     []byte(`"1"`),
+			expected: true,
+		},
+		{
+			name:     "should unmarshal \"0\" as false",
+			data:     []byte(`"0"`),
+			expected: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var b BoolValue
+			if err := json.Unmarshal(testCase.data, &b); err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			if bool(b) != testCase.expected {
+				t.Fatalf("Expected %v but got %v", testCase.expected, b)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR addresses these issues:
- GitLab Issue: https://gitlab.com/gitlab-org/gitlab/-/issues/233941
- Terraform Issue: https://github.com/gitlabhq/terraform-provider-gitlab/issues/348
- Move `TestBoolValue` func to `types_test.go` file and add test two new cases.