### PR TITLE
Address linter feedback

### DIFF
--- a/groups.go
+++ b/groups.go
@@ -398,7 +398,7 @@ func (s *GroupsService) ListGroupLDAPLinks(gid interface{}, options ...RequestOp
 type AddGroupLDAPLinkOptions struct {
 	CN          *string `url:"cn,omitempty" json:"cn,omitempty"`
 	GroupAccess *int    `url:"group_access,omitempty" json:"group_access,omitempty"`
-	Provider    *string `url:"provider,omitempty" json:"provider,ommitempty"`
+	Provider    *string `url:"provider,omitempty" json:"provider,omitempty"`
 }
 
 // AddGroupLDAPLink creates a new group LDAP link. Available only for users who

--- a/instance_clusters.go
+++ b/instance_clusters.go
@@ -56,7 +56,7 @@ func (v InstanceCluster) String() string {
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/instance_clusters.html#list-instance-clusters
 func (s *InstanceClustersService) ListClusters(options ...RequestOptionFunc) ([]*InstanceCluster, *Response, error) {
-	u := fmt.Sprintf("admin/clusters")
+	u := "admin/clusters"
 
 	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
@@ -98,7 +98,7 @@ func (s *InstanceClustersService) GetCluster(cluster int, options ...RequestOpti
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/instance_clusters.html#add-existing-instance-cluster
 func (s *InstanceClustersService) AddCluster(opt *AddClusterOptions, options ...RequestOptionFunc) (*InstanceCluster, *Response, error) {
-	u := fmt.Sprintf("admin/clusters/add")
+	u := "admin/clusters/add"
 
 	req, err := s.client.NewRequest("POST", u, opt, options)
 	if err != nil {

--- a/instance_variables.go
+++ b/instance_variables.go
@@ -58,7 +58,7 @@ type ListInstanceVariablesOptions ListOptions
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/instance_level_ci_variables.html#list-all-instance-variables
 func (s *InstanceVariablesService) ListVariables(opt *ListInstanceVariablesOptions, options ...RequestOptionFunc) ([]*InstanceVariable, *Response, error) {
-	u := fmt.Sprintf("admin/ci/variables")
+	u := "admin/ci/variables"
 
 	req, err := s.client.NewRequest("GET", u, opt, options)
 	if err != nil {
@@ -113,7 +113,7 @@ type CreateInstanceVariableOptions struct {
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/instance_level_ci_variables.html#create-instance-variable
 func (s *InstanceVariablesService) CreateVariable(opt *CreateInstanceVariableOptions, options ...RequestOptionFunc) (*InstanceVariable, *Response, error) {
-	u := fmt.Sprintf("admin/ci/variables")
+	u := "admin/ci/variables"
 
 	req, err := s.client.NewRequest("POST", u, opt, options)
 	if err != nil {


### PR DESCRIPTION
I ran [`golangci-lint`](https://github.com/golangci/golangci-lint) against the code with the default linters and thought I'd address a subset of the returned feedback. Note, I didn't address the `errcheck` and test related `staticcheck` feedback:
```
gitlab.go:248:14: Error return value of `c.setBaseURL` is not checked (errcheck)
	c.setBaseURL(defaultBaseURL)
	            ^
gitlab.go:601:55: Error return value of `c.configureLimiter` is not checked (errcheck)
	c.configureLimiterOnce.Do(func() { c.configureLimiter() })
	                                                     ^
access_requests_test.go:59:2: SA4006: this value of `resp` is never used (staticcheck)
	requests, resp, err := client.AccessRequests.ListProjectAccessRequests(1, nil)
	^
access_requests_test.go:125:2: SA4006: this value of `resp` is never used (staticcheck)
	requests, resp, err := client.AccessRequests.ListGroupAccessRequests(1, nil)
	^
access_requests_test.go:171:2: SA4006: this value of `resp` is never used (staticcheck)
	accessRequest, resp, err := client.AccessRequests.RequestProjectAccess(1, nil)
	^
gitlab_test.go:158:49: SA1029: should not use built-in type string as key for value; define your own type to avoid collisions (staticcheck)
	ctx := context.WithValue(context.Background(), interface{}("myKey"), interface{}("myValue"))
```