### PR TITLE
Support NotLabels for MergeRequestOptions and New Get Inherited Member Function

### DIFF
--- a/group_milestones.go
+++ b/group_milestones.go
@@ -59,7 +59,7 @@ type ListGroupMilestonesOptions struct {
 	IIDs                    []int  `url:"iids,omitempty" json:"iids,omitempty"`
 	State                   string `url:"state,omitempty" json:"state,omitempty"`
 	Search                  string `url:"search,omitempty" json:"search,omitempty"`
-	IncludeParentMilestones bool   `url:"include_parent_milestones,omitempty" json:"include_parent_milestones,omitempty"
+	IncludeParentMilestones bool   `url:"include_parent_milestones,omitempty" json:"include_parent_milestones,omitempty"`
 }
 
 // ListGroupMilestones returns a list of group milestones.

--- a/group_milestones.go
+++ b/group_milestones.go
@@ -41,9 +41,9 @@ type GroupMilestone struct {
 	StartDate   *ISOTime   `json:"start_date"`
 	DueDate     *ISOTime   `json:"due_date"`
 	State       string     `json:"state"`
-	Expired     bool       `json:"expired"`
 	UpdatedAt   *time.Time `json:"updated_at"`
 	CreatedAt   *time.Time `json:"created_at"`
+	Expired     *bool      `json:"expired"`
 }
 
 func (m GroupMilestone) String() string {
@@ -57,10 +57,11 @@ func (m GroupMilestone) String() string {
 // https://docs.gitlab.com/ce/api/group_milestones.html#list-group-milestones
 type ListGroupMilestonesOptions struct {
 	ListOptions
-	IIDs                    []int  `url:"iids,omitempty" json:"iids,omitempty"`
-	State                   string `url:"state,omitempty" json:"state,omitempty"`
-	Search                  string `url:"search,omitempty" json:"search,omitempty"`
-	IncludeParentMilestones bool   `url:"include_parent_milestones,omitempty" json:"include_parent_milestones,omitempty"`
+	IIDs                    []int   `url:"iids,omitempty" json:"iids,omitempty"`
+	State                   *string `url:"state,omitempty" json:"state,omitempty"`
+	Title                   *string `url:"title,omitempty" json:"title,omitempty"`
+	Search                  *string `url:"search,omitempty" json:"search,omitempty"`
+	IncludeParentMilestones *bool   `url:"include_parent_milestones,omitempty" json:"include_parent_milestones,omitempty"`
 }
 
 // ListGroupMilestones returns a list of group milestones.

--- a/group_milestones.go
+++ b/group_milestones.go
@@ -56,9 +56,10 @@ func (m GroupMilestone) String() string {
 // https://docs.gitlab.com/ce/api/group_milestones.html#list-group-milestones
 type ListGroupMilestonesOptions struct {
 	ListOptions
-	IIDs   []int  `url:"iids,omitempty" json:"iids,omitempty"`
-	State  string `url:"state,omitempty" json:"state,omitempty"`
-	Search string `url:"search,omitempty" json:"search,omitempty"`
+	IIDs                    []int  `url:"iids,omitempty" json:"iids,omitempty"`
+	State                   string `url:"state,omitempty" json:"state,omitempty"`
+	Search                  string `url:"search,omitempty" json:"search,omitempty"`
+	IncludeParentMilestones bool   `url:"include_parent_milestones,omitempty" json:"include_parent_milestones,omitempty"
 }
 
 // ListGroupMilestones returns a list of group milestones.

--- a/group_milestones.go
+++ b/group_milestones.go
@@ -41,6 +41,7 @@ type GroupMilestone struct {
 	StartDate   *ISOTime   `json:"start_date"`
 	DueDate     *ISOTime   `json:"due_date"`
 	State       string     `json:"state"`
+	Expired     bool       `json:"expired"`
 	UpdatedAt   *time.Time `json:"updated_at"`
 	CreatedAt   *time.Time `json:"created_at"`
 }

--- a/merge_requests.go
+++ b/merge_requests.go
@@ -139,6 +139,7 @@ type ListMergeRequestsOptions struct {
 	Milestone       *string    `url:"milestone,omitempty" json:"milestone,omitempty"`
 	View            *string    `url:"view,omitempty" json:"view,omitempty"`
 	Labels          Labels     `url:"labels,comma,omitempty" json:"labels,omitempty"`
+	NotLabels       Labels     `url:"not[labels],comma,omitempty" json:"not[labels],omitempty"`
 	CreatedAfter    *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
 	CreatedBefore   *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
 	UpdatedAfter    *time.Time `url:"updated_after,omitempty" json:"updated_after,omitempty"`
@@ -189,6 +190,7 @@ type ListGroupMergeRequestsOptions struct {
 	Milestone       *string    `url:"milestone,omitempty" json:"milestone,omitempty"`
 	View            *string    `url:"view,omitempty" json:"view,omitempty"`
 	Labels          Labels     `url:"labels,omitempty" json:"labels,omitempty"`
+	NotLabels       Labels     `url:"not[labels],comma,omitempty" json:"not[labels],omitempty"`
 	CreatedAfter    *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
 	CreatedBefore   *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
 	UpdatedAfter    *time.Time `url:"updated_after,omitempty" json:"updated_after,omitempty"`
@@ -241,6 +243,7 @@ type ListProjectMergeRequestsOptions struct {
 	Milestone       *string    `url:"milestone,omitempty" json:"milestone,omitempty"`
 	View            *string    `url:"view,omitempty" json:"view,omitempty"`
 	Labels          Labels     `url:"labels,comma,omitempty" json:"labels,omitempty"`
+	NotLabels       Labels     `url:"not[labels],comma,omitempty" json:"not[labels],omitempty"`
 	CreatedAfter    *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
 	CreatedBefore   *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
 	UpdatedAfter    *time.Time `url:"updated_after,omitempty" json:"updated_after,omitempty"`

--- a/milestones.go
+++ b/milestones.go
@@ -41,10 +41,10 @@ type Milestone struct {
 	StartDate   *ISOTime   `json:"start_date"`
 	DueDate     *ISOTime   `json:"due_date"`
 	State       string     `json:"state"`
-	Expired     bool       `json:"expired"`
 	WebURL      string     `json:"web_url"`
 	UpdatedAt   *time.Time `json:"updated_at"`
 	CreatedAt   *time.Time `json:"created_at"`
+	Expired     *bool      `json:"expired"`
 }
 
 func (m Milestone) String() string {

--- a/milestones.go
+++ b/milestones.go
@@ -41,6 +41,7 @@ type Milestone struct {
 	StartDate   *ISOTime   `json:"start_date"`
 	DueDate     *ISOTime   `json:"due_date"`
 	State       string     `json:"state"`
+	Expired     bool       `json:"expired"`
 	WebURL      string     `json:"web_url"`
 	UpdatedAt   *time.Time `json:"updated_at"`
 	CreatedAt   *time.Time `json:"created_at"`

--- a/project_members.go
+++ b/project_members.go
@@ -121,7 +121,7 @@ func (s *ProjectMembersService) GetProjectMember(pid interface{}, user int, opti
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/members.html#get-a-member-of-a-group-or-project-including-inherited-members
-func (s *ProjectMembersService) GetAllProjectMember(pid interface{}, user int, options ...RequestOptionFunc) (*ProjectMember, *Response, error) {
+func (s *ProjectMembersService) GetInheritedProjectMember(pid interface{}, user int, options ...RequestOptionFunc) (*ProjectMember, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err

--- a/project_members.go
+++ b/project_members.go
@@ -117,7 +117,7 @@ func (s *ProjectMembersService) GetProjectMember(pid interface{}, user int, opti
 	return pm, resp, err
 }
 
-// GetAllProjectMember gets a project team member, including inherited
+// GetInheritedProjectMember gets a project team member, including inherited
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/members.html#get-a-member-of-a-group-or-project-including-inherited-members

--- a/project_members.go
+++ b/project_members.go
@@ -117,6 +117,31 @@ func (s *ProjectMembersService) GetProjectMember(pid interface{}, user int, opti
 	return pm, resp, err
 }
 
+// GetAllProjectMember gets a project team member, including inherited
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/members.html#get-a-member-of-a-group-or-project-including-inherited-members
+func (s *ProjectMembersService) GetAllProjectMember(pid interface{}, user int, options ...RequestOptionFunc) (*ProjectMember, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/members/all/%d", pathEscape(project), user)
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pm := new(ProjectMember)
+	resp, err := s.client.Do(req, pm)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return pm, resp, err
+}
+
 // AddProjectMemberOptions represents the available AddProjectMember() options.
 //
 // GitLab API docs:


### PR DESCRIPTION
Adds the ability to query Merge Requests by Not Labels and adds a function to get inherited members of a project.