### PR TITLE
Change milestone type in issue stats options

### DIFF
--- a/issues_statistics.go
+++ b/issues_statistics.go
@@ -52,7 +52,7 @@ func (n IssuesStatistics) String() string {
 // https://docs.gitlab.com/ee/api/issues_statistics.html#get-issues-statistics
 type GetIssuesStatisticsOptions struct {
 	Labels           Labels     `url:"labels,omitempty" json:"labels,omitempty"`
-	Milestone        *Milestone `url:"milestone,omitempty" json:"milestone,omitempty"`
+	Milestone        *string    `url:"milestone,omitempty" json:"milestone,omitempty"`
 	Scope            *string    `url:"scope,omitempty" json:"scope,omitempty"`
 	AuthorID         *int       `url:"author_id,omitempty" json:"author_id,omitempty"`
 	AuthorUsername   *string    `url:"author_username,omitempty" json:"author_username,omitempty"`


### PR DESCRIPTION
milstone represents the title of the milestone and so should be a
string as stated in gitlab api documentation.

Signed-off-by: Stany MARCEL <stanypub@gmail.com>