### PR TITLE
Adds group level push rules API

### DIFF
--- a/groups.go
+++ b/groups.go
@@ -605,9 +605,7 @@ func (s *GroupsService) EditGroupPushRule(gid interface{}, opt *EditGroupPushRul
 	return gpr, resp, err
 }
 
-// DeleteGroupPushRule removes a push rule from a group. This is an
-// idempotent method and can be called multiple times. Either the push rule is
-// available or not.
+// DeleteGroupPushRule deletes the push rules of a group.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/groups.html#delete-group-push-rule-starter

--- a/groups.go
+++ b/groups.go
@@ -475,7 +475,7 @@ func (s *GroupsService) DeleteGroupLDAPLinkForProvider(gid interface{}, provider
 // GroupPushRules represents a group push rule.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/groups.html#get-group-push-rules-starter
+// https://docs.gitlab.com/ee/api/groups.html#get-group-push-rules
 type GroupPushRules struct {
 	ID                         int        `json:"id"`
 	CreatedAt                  *time.Time `json:"created_at"`

--- a/groups.go
+++ b/groups.go
@@ -495,7 +495,7 @@ type GroupPushRules struct {
 // GetGroupPushRules gets the push rules of a group.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/groups.html#get-group-push-rules-starter
+// https://docs.gitlab.com/ee/api/groups.html#get-group-push-rules
 func (s *GroupsService) GetGroupPushRules(gid interface{}, options ...RequestOptionFunc) (*GroupPushRules, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -521,7 +521,7 @@ func (s *GroupsService) GetGroupPushRules(gid interface{}, options ...RequestOpt
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/groups.html#add-group-push-rule-starter
+// https://docs.gitlab.com/ee/api/groups.html#add-group-push-rule
 type AddGroupPushRuleOptions struct {
 	DenyDeleteTag              *bool   `url:"deny_delete_tag,omitempty" json:"deny_delete_tag,omitempty"`
 	MemberCheck                *bool   `url:"member_check,omitempty" json:"member_check,omitempty"`
@@ -539,7 +539,7 @@ type AddGroupPushRuleOptions struct {
 // AddGroupPushRule adds push rules to the specified group.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/groups.html#add-group-push-rule-starter
+// https://docs.gitlab.com/ee/api/groups.html#add-group-push-rule
 func (s *GroupsService) AddGroupPushRule(gid interface{}, opt *AddGroupPushRuleOptions, options ...RequestOptionFunc) (*GroupPushRules, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -565,7 +565,7 @@ func (s *GroupsService) AddGroupPushRule(gid interface{}, opt *AddGroupPushRuleO
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/groups.html#edit-group-push-rule-starter
+// https://docs.gitlab.com/ee/api/groups.html#edit-group-push-rule
 type EditGroupPushRuleOptions struct {
 	DenyDeleteTag              *bool   `url:"deny_delete_tag,omitempty" json:"deny_delete_tag,omitempty"`
 	MemberCheck                *bool   `url:"member_check,omitempty" json:"member_check,omitempty"`
@@ -583,7 +583,7 @@ type EditGroupPushRuleOptions struct {
 // EditGroupPushRule edits a push rule for a specified group.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/groups.html#edit-group-push-rule-starter
+// https://docs.gitlab.com/ee/api/groups.html#edit-group-push-rule
 func (s *GroupsService) EditGroupPushRule(gid interface{}, opt *EditGroupPushRuleOptions, options ...RequestOptionFunc) (*GroupPushRules, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -608,7 +608,7 @@ func (s *GroupsService) EditGroupPushRule(gid interface{}, opt *EditGroupPushRul
 // DeleteGroupPushRule deletes the push rules of a group.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/groups.html#delete-group-push-rule-starter
+// https://docs.gitlab.com/ee/api/groups.html#delete-group-push-rule
 func (s *GroupsService) DeleteGroupPushRule(gid interface{}, options ...RequestOptionFunc) (*Response, error) {
 	group, err := parseID(gid)
 	if err != nil {

--- a/groups.go
+++ b/groups.go
@@ -471,3 +471,157 @@ func (s *GroupsService) DeleteGroupLDAPLinkForProvider(gid interface{}, provider
 
 	return s.client.Do(req, nil)
 }
+
+// GroupPushRules represents a group push rule.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/groups.html#get-group-push-rules-starter
+type GroupPushRules struct {
+	ID                         int        `json:"id"`
+	CreatedAt                  *time.Time `json:"created_at"`
+	CommitMessageRegex         string     `json:"commit_message_regex"`
+	CommitMessageNegativeRegex string     `json:"commit_message_negative_regex"`
+	BranchNameRegex            string     `json:"branch_name_regex"`
+	DenyDeleteTag              bool       `json:"deny_delete_tag"`
+	MemberCheck                bool       `json:"member_check"`
+	PreventSecrets             bool       `json:"prevent_secrets"`
+	AuthorEmailRegex           string     `json:"author_email_regex"`
+	FileNameRegex              string     `json:"file_name_regex"`
+	MaxFileSize                int        `json:"max_file_size"`
+	CommitCommitterCheck       bool       `json:"commit_committer_check"`
+	RejectUnsignedCommits      bool       `json:"reject_unsigned_commits"`
+}
+
+// GetGroupPushRules gets the push rules of a group.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/groups.html#get-group-push-rules-starter
+func (s *GroupsService) GetGroupPushRules(gid interface{}, options ...RequestOptionFunc) (*GroupPushRules, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/push_rule", pathEscape(group))
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	gpr := new(GroupPushRules)
+	resp, err := s.client.Do(req, gpr)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return gpr, resp, err
+}
+
+// AddGroupPushRuleOptions represents the available AddGroupPushRule()
+// options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/groups.html#add-group-push-rule-starter
+type AddGroupPushRuleOptions struct {
+	DenyDeleteTag              *bool   `url:"deny_delete_tag,omitempty" json:"deny_delete_tag,omitempty"`
+	MemberCheck                *bool   `url:"member_check,omitempty" json:"member_check,omitempty"`
+	PreventSecrets             *bool   `url:"prevent_secrets,omitempty" json:"prevent_secrets,omitempty"`
+	CommitMessageRegex         *string `url:"commit_message_regex,omitempty" json:"commit_message_regex,omitempty"`
+	CommitMessageNegativeRegex *string `url:"commit_message_negative_regex,omitempty" json:"commit_message_negative_regex,omitempty"`
+	BranchNameRegex            *string `url:"branch_name_regex,omitempty" json:"branch_name_regex,omitempty"`
+	AuthorEmailRegex           *string `url:"author_email_regex,omitempty" json:"author_email_regex,omitempty"`
+	FileNameRegex              *string `url:"file_name_regex,omitempty" json:"file_name_regex,omitempty"`
+	MaxFileSize                *int    `url:"max_file_size,omitempty" json:"max_file_size,omitempty"`
+	CommitCommitterCheck       *bool   `url:"commit_committer_check,omitempty" json:"commit_committer_check,omitempty"`
+	RejectUnsignedCommits      *bool   `url:"reject_unsigned_commits,omitempty" json:"reject_unsigned_commits,omitempty"`
+}
+
+// AddGroupPushRule adds push rules to the specified group.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/groups.html#add-group-push-rule-starter
+func (s *GroupsService) AddGroupPushRule(gid interface{}, opt *AddGroupPushRuleOptions, options ...RequestOptionFunc) (*GroupPushRules, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/push_rule", pathEscape(group))
+
+	req, err := s.client.NewRequest("POST", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	gpr := new(GroupPushRules)
+	resp, err := s.client.Do(req, gpr)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return gpr, resp, err
+}
+
+// EditGroupPushRuleOptions represents the available EditGroupPushRule()
+// options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/groups.html#edit-group-push-rule-starter
+type EditGroupPushRuleOptions struct {
+	DenyDeleteTag              *bool   `url:"deny_delete_tag,omitempty" json:"deny_delete_tag,omitempty"`
+	MemberCheck                *bool   `url:"member_check,omitempty" json:"member_check,omitempty"`
+	PreventSecrets             *bool   `url:"prevent_secrets,omitempty" json:"prevent_secrets,omitempty"`
+	CommitMessageRegex         *string `url:"commit_message_regex,omitempty" json:"commit_message_regex,omitempty"`
+	CommitMessageNegativeRegex *string `url:"commit_message_negative_regex,omitempty" json:"commit_message_negative_regex,omitempty"`
+	BranchNameRegex            *string `url:"branch_name_regex,omitempty" json:"branch_name_regex,omitempty"`
+	AuthorEmailRegex           *string `url:"author_email_regex,omitempty" json:"author_email_regex,omitempty"`
+	FileNameRegex              *string `url:"file_name_regex,omitempty" json:"file_name_regex,omitempty"`
+	MaxFileSize                *int    `url:"max_file_size,omitempty" json:"max_file_size,omitempty"`
+	CommitCommitterCheck       *bool   `url:"commit_committer_check,omitempty" json:"commit_committer_check,omitempty"`
+	RejectUnsignedCommits      *bool   `url:"reject_unsigned_commits,omitempty" json:"reject_unsigned_commits,omitempty"`
+}
+
+// EditGroupPushRule edits a push rule for a specified group.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/groups.html#edit-group-push-rule-starter
+func (s *GroupsService) EditGroupPushRule(gid interface{}, opt *EditGroupPushRuleOptions, options ...RequestOptionFunc) (*GroupPushRules, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/push_rule", pathEscape(group))
+
+	req, err := s.client.NewRequest("PUT", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	gpr := new(GroupPushRules)
+	resp, err := s.client.Do(req, gpr)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return gpr, resp, err
+}
+
+// DeleteGroupPushRule removes a push rule from a group. This is an
+// idempotent method and can be called multiple times. Either the push rule is
+// available or not.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/groups.html#delete-group-push-rule-starter
+func (s *GroupsService) DeleteGroupPushRule(gid interface{}, options ...RequestOptionFunc) (*Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("groups/%s/push_rule", pathEscape(group))
+
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}

--- a/projects.go
+++ b/projects.go
@@ -1190,19 +1190,20 @@ func (s *ProjectsService) ListProjectForks(pid interface{}, opt *ListProjectsOpt
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/projects.html#push-rules
 type ProjectPushRules struct {
-	ID                    int        `json:"id"`
-	ProjectID             int        `json:"project_id"`
-	CommitMessageRegex    string     `json:"commit_message_regex"`
-	BranchNameRegex       string     `json:"branch_name_regex"`
-	DenyDeleteTag         bool       `json:"deny_delete_tag"`
-	CreatedAt             *time.Time `json:"created_at"`
-	MemberCheck           bool       `json:"member_check"`
-	PreventSecrets        bool       `json:"prevent_secrets"`
-	AuthorEmailRegex      string     `json:"author_email_regex"`
-	FileNameRegex         string     `json:"file_name_regex"`
-	MaxFileSize           int        `json:"max_file_size"`
-	CommitCommitterCheck  bool       `json:"commit_committer_check"`
-	RejectUnsignedCommits bool       `json:"reject_unsigned_commits"`
+	ID                         int        `json:"id"`
+	ProjectID                  int        `json:"project_id"`
+	CommitMessageRegex         string     `json:"commit_message_regex"`
+	CommitMessageNegativeRegex string     `json:"commit_message_negative_regex"`
+	BranchNameRegex            string     `json:"branch_name_regex"`
+	DenyDeleteTag              bool       `json:"deny_delete_tag"`
+	CreatedAt                  *time.Time `json:"created_at"`
+	MemberCheck                bool       `json:"member_check"`
+	PreventSecrets             bool       `json:"prevent_secrets"`
+	AuthorEmailRegex           string     `json:"author_email_regex"`
+	FileNameRegex              string     `json:"file_name_regex"`
+	MaxFileSize                int        `json:"max_file_size"`
+	CommitCommitterCheck       bool       `json:"commit_committer_check"`
+	RejectUnsignedCommits      bool       `json:"reject_unsigned_commits"`
 }
 
 // GetProjectPushRules gets the push rules of a project.
@@ -1236,14 +1237,17 @@ func (s *ProjectsService) GetProjectPushRules(pid interface{}, options ...Reques
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/projects.html#add-project-push-rule
 type AddProjectPushRuleOptions struct {
-	DenyDeleteTag      *bool   `url:"deny_delete_tag,omitempty" json:"deny_delete_tag,omitempty"`
-	MemberCheck        *bool   `url:"member_check,omitempty" json:"member_check,omitempty"`
-	PreventSecrets     *bool   `url:"prevent_secrets,omitempty" json:"prevent_secrets,omitempty"`
-	CommitMessageRegex *string `url:"commit_message_regex,omitempty" json:"commit_message_regex,omitempty"`
-	BranchNameRegex    *string `url:"branch_name_regex,omitempty" json:"branch_name_regex,omitempty"`
-	AuthorEmailRegex   *string `url:"author_email_regex,omitempty" json:"author_email_regex,omitempty"`
-	FileNameRegex      *string `url:"file_name_regex,omitempty" json:"file_name_regex,omitempty"`
-	MaxFileSize        *int    `url:"max_file_size,omitempty" json:"max_file_size,omitempty"`
+	DenyDeleteTag              *bool   `url:"deny_delete_tag,omitempty" json:"deny_delete_tag,omitempty"`
+	MemberCheck                *bool   `url:"member_check,omitempty" json:"member_check,omitempty"`
+	PreventSecrets             *bool   `url:"prevent_secrets,omitempty" json:"prevent_secrets,omitempty"`
+	CommitMessageRegex         *string `url:"commit_message_regex,omitempty" json:"commit_message_regex,omitempty"`
+	CommitMessageNegativeRegex *string `url:"commit_message_negative_regex,omitempty" json:"commit_message_negative_regex,omitempty"`
+	BranchNameRegex            *string `url:"branch_name_regex,omitempty" json:"branch_name_regex,omitempty"`
+	AuthorEmailRegex           *string `url:"author_email_regex,omitempty" json:"author_email_regex,omitempty"`
+	FileNameRegex              *string `url:"file_name_regex,omitempty" json:"file_name_regex,omitempty"`
+	MaxFileSize                *int    `url:"max_file_size,omitempty" json:"max_file_size,omitempty"`
+	CommitCommitterCheck       *bool   `url:"commit_committer_check,omitempty" json:"commit_committer_check,omitempty"`
+	RejectUnsignedCommits      *bool   `url:"reject_unsigned_commits,omitempty" json:"reject_unsigned_commits,omitempty"`
 }
 
 // AddProjectPushRule adds a push rule to a specified project.
@@ -1277,16 +1281,17 @@ func (s *ProjectsService) AddProjectPushRule(pid interface{}, opt *AddProjectPus
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/projects.html#edit-project-push-rule
 type EditProjectPushRuleOptions struct {
-	AuthorEmailRegex      *string `url:"author_email_regex,omitempty" json:"author_email_regex,omitempty"`
-	BranchNameRegex       *string `url:"branch_name_regex,omitempty" json:"branch_name_regex,omitempty"`
-	CommitMessageRegex    *string `url:"commit_message_regex,omitempty" json:"commit_message_regex,omitempty"`
-	FileNameRegex         *string `url:"file_name_regex,omitempty" json:"file_name_regex,omitempty"`
-	DenyDeleteTag         *bool   `url:"deny_delete_tag,omitempty" json:"deny_delete_tag,omitempty"`
-	MemberCheck           *bool   `url:"member_check,omitempty" json:"member_check,omitempty"`
-	PreventSecrets        *bool   `url:"prevent_secrets,omitempty" json:"prevent_secrets,omitempty"`
-	MaxFileSize           *int    `url:"max_file_size,omitempty" json:"max_file_size,omitempty"`
-	CommitCommitterCheck  *bool   `url:"commit_committer_check,omitempty" json:"commit_committer_check,omitempty"`
-	RejectUnsignedCommits *bool   `url:"reject_unsigned_commits,omitempty" json:"reject_unsigned_commits,omitempty"`
+	AuthorEmailRegex           *string `url:"author_email_regex,omitempty" json:"author_email_regex,omitempty"`
+	BranchNameRegex            *string `url:"branch_name_regex,omitempty" json:"branch_name_regex,omitempty"`
+	CommitMessageRegex         *string `url:"commit_message_regex,omitempty" json:"commit_message_regex,omitempty"`
+	CommitMessageNegativeRegex *string `url:"commit_message_negative_regex,omitempty" json:"commit_message_negative_regex,omitempty"`
+	FileNameRegex              *string `url:"file_name_regex,omitempty" json:"file_name_regex,omitempty"`
+	DenyDeleteTag              *bool   `url:"deny_delete_tag,omitempty" json:"deny_delete_tag,omitempty"`
+	MemberCheck                *bool   `url:"member_check,omitempty" json:"member_check,omitempty"`
+	PreventSecrets             *bool   `url:"prevent_secrets,omitempty" json:"prevent_secrets,omitempty"`
+	MaxFileSize                *int    `url:"max_file_size,omitempty" json:"max_file_size,omitempty"`
+	CommitCommitterCheck       *bool   `url:"commit_committer_check,omitempty" json:"commit_committer_check,omitempty"`
+	RejectUnsignedCommits      *bool   `url:"reject_unsigned_commits,omitempty" json:"reject_unsigned_commits,omitempty"`
 }
 
 // EditProjectPushRule edits a push rule for a specified project.


### PR DESCRIPTION
This merge adds the push rules API added for groups in GitLab 13.4. Currently available for gitlab.com and soon to be available to self-hosted gitlab instances.

https://docs.gitlab.com/ee/api/groups.html#push-rules-starter

Also took a look at the project level push rules and added newly available push rules.