### PR TITLE
Add with merge request status recheck

### DIFF
--- a/gitlab_test.go
+++ b/gitlab_test.go
@@ -66,6 +66,12 @@ func testBody(t *testing.T, r *http.Request, want string) {
 	}
 }
 
+func testParams(t *testing.T, r *http.Request, want string) {
+	if got := r.URL.RawQuery; got != want {
+		t.Errorf("Request query: %s, want %s", got, want)
+	}
+}
+
 func mustWriteHTTPResponse(t *testing.T, w io.Writer, fixturePath string) {
 	f, err := os.Open(fixturePath)
 	if err != nil {

--- a/merge_requests.go
+++ b/merge_requests.go
@@ -133,26 +133,29 @@ func (m MergeRequestDiffVersion) String() string {
 // https://docs.gitlab.com/ce/api/merge_requests.html#list-merge-requests
 type ListMergeRequestsOptions struct {
 	ListOptions
-	State           *string    `url:"state,omitempty" json:"state,omitempty"`
-	OrderBy         *string    `url:"order_by,omitempty" json:"order_by,omitempty"`
-	Sort            *string    `url:"sort,omitempty" json:"sort,omitempty"`
-	Milestone       *string    `url:"milestone,omitempty" json:"milestone,omitempty"`
-	View            *string    `url:"view,omitempty" json:"view,omitempty"`
-	Labels          Labels     `url:"labels,comma,omitempty" json:"labels,omitempty"`
-	NotLabels       Labels     `url:"not[labels],comma,omitempty" json:"not[labels],omitempty"`
-	CreatedAfter    *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
-	CreatedBefore   *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
-	UpdatedAfter    *time.Time `url:"updated_after,omitempty" json:"updated_after,omitempty"`
-	UpdatedBefore   *time.Time `url:"updated_before,omitempty" json:"updated_before,omitempty"`
-	Scope           *string    `url:"scope,omitempty" json:"scope,omitempty"`
-	AuthorID        *int       `url:"author_id,omitempty" json:"author_id,omitempty"`
-	AssigneeID      *int       `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
-	MyReactionEmoji *string    `url:"my_reaction_emoji,omitempty" json:"my_reaction_emoji,omitempty"`
-	SourceBranch    *string    `url:"source_branch,omitempty" json:"source_branch,omitempty"`
-	TargetBranch    *string    `url:"target_branch,omitempty" json:"target_branch,omitempty"`
-	Search          *string    `url:"search,omitempty" json:"search,omitempty"`
-	In              *string    `url:"in,omitempty" json:"in,omitempty"`
-	WIP             *string    `url:"wip,omitempty" json:"wip,omitempty"`
+	State                  *string    `url:"state,omitempty" json:"state,omitempty"`
+	OrderBy                *string    `url:"order_by,omitempty" json:"order_by,omitempty"`
+	Sort                   *string    `url:"sort,omitempty" json:"sort,omitempty"`
+	Milestone              *string    `url:"milestone,omitempty" json:"milestone,omitempty"`
+	View                   *string    `url:"view,omitempty" json:"view,omitempty"`
+	Labels                 Labels     `url:"labels,comma,omitempty" json:"labels,omitempty"`
+	NotLabels              Labels     `url:"not[labels],comma,omitempty" json:"not[labels],omitempty"`
+	WithLabelsDetails      *bool      `url:"with_labels_details,omitempty" json:"with_labels_details,omitempty"`
+	WithMergeStatusRecheck *bool      `url:"with_merge_status_recheck,omitempty" json:"with_merge_status_recheck,omitempty"`
+	CreatedAfter           *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
+	CreatedBefore          *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
+	UpdatedAfter           *time.Time `url:"updated_after,omitempty" json:"updated_after,omitempty"`
+	UpdatedBefore          *time.Time `url:"updated_before,omitempty" json:"updated_before,omitempty"`
+	Scope                  *string    `url:"scope,omitempty" json:"scope,omitempty"`
+	AuthorID               *int       `url:"author_id,omitempty" json:"author_id,omitempty"`
+	AuthorUsername         *string    `url:"author_username,omitempty" json:"author_username,omitempty"`
+	AssigneeID             *int       `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
+	MyReactionEmoji        *string    `url:"my_reaction_emoji,omitempty" json:"my_reaction_emoji,omitempty"`
+	SourceBranch           *string    `url:"source_branch,omitempty" json:"source_branch,omitempty"`
+	TargetBranch           *string    `url:"target_branch,omitempty" json:"target_branch,omitempty"`
+	Search                 *string    `url:"search,omitempty" json:"search,omitempty"`
+	In                     *string    `url:"in,omitempty" json:"in,omitempty"`
+	WIP                    *string    `url:"wip,omitempty" json:"wip,omitempty"`
 }
 
 // ListMergeRequests gets all merge requests. The state parameter can be used
@@ -168,8 +171,11 @@ func (s *MergeRequestsService) ListMergeRequests(opt *ListMergeRequestsOptions, 
 		return nil, nil, err
 	}
 
+	fmt.Println(req.URL)
+
 	var m []*MergeRequest
 	resp, err := s.client.Do(req, &m)
+
 	if err != nil {
 		return nil, resp, err
 	}
@@ -184,24 +190,26 @@ func (s *MergeRequestsService) ListMergeRequests(opt *ListMergeRequestsOptions, 
 // https://docs.gitlab.com/ce/api/merge_requests.html#list-group-merge-requests
 type ListGroupMergeRequestsOptions struct {
 	ListOptions
-	State           *string    `url:"state,omitempty" json:"state,omitempty"`
-	OrderBy         *string    `url:"order_by,omitempty" json:"order_by,omitempty"`
-	Sort            *string    `url:"sort,omitempty" json:"sort,omitempty"`
-	Milestone       *string    `url:"milestone,omitempty" json:"milestone,omitempty"`
-	View            *string    `url:"view,omitempty" json:"view,omitempty"`
-	Labels          Labels     `url:"labels,omitempty" json:"labels,omitempty"`
-	NotLabels       Labels     `url:"not[labels],comma,omitempty" json:"not[labels],omitempty"`
-	CreatedAfter    *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
-	CreatedBefore   *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
-	UpdatedAfter    *time.Time `url:"updated_after,omitempty" json:"updated_after,omitempty"`
-	UpdatedBefore   *time.Time `url:"updated_before,omitempty" json:"updated_before,omitempty"`
-	Scope           *string    `url:"scope,omitempty" json:"scope,omitempty"`
-	AuthorID        *int       `url:"author_id,omitempty" json:"author_id,omitempty"`
-	AssigneeID      *int       `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
-	MyReactionEmoji *string    `url:"my_reaction_emoji,omitempty" json:"my_reaction_emoji,omitempty"`
-	SourceBranch    *string    `url:"source_branch,omitempty" json:"source_branch,omitempty"`
-	TargetBranch    *string    `url:"target_branch,omitempty" json:"target_branch,omitempty"`
-	Search          *string    `url:"search,omitempty" json:"search,omitempty"`
+	State                  *string    `url:"state,omitempty" json:"state,omitempty"`
+	OrderBy                *string    `url:"order_by,omitempty" json:"order_by,omitempty"`
+	Sort                   *string    `url:"sort,omitempty" json:"sort,omitempty"`
+	Milestone              *string    `url:"milestone,omitempty" json:"milestone,omitempty"`
+	View                   *string    `url:"view,omitempty" json:"view,omitempty"`
+	Labels                 Labels     `url:"labels,omitempty" json:"labels,omitempty"`
+	NotLabels              Labels     `url:"not[labels],comma,omitempty" json:"not[labels],omitempty"`
+	WithLabelsDetails      *bool      `url:"with_labels_details,omitempty" json:"with_labels_details,omitempty"`
+	WithMergeStatusRecheck *bool      `url:"with_merge_status_recheck,omitempty" json:"with_merge_status_recheck,omitempty"`
+	CreatedAfter           *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
+	CreatedBefore          *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
+	UpdatedAfter           *time.Time `url:"updated_after,omitempty" json:"updated_after,omitempty"`
+	UpdatedBefore          *time.Time `url:"updated_before,omitempty" json:"updated_before,omitempty"`
+	Scope                  *string    `url:"scope,omitempty" json:"scope,omitempty"`
+	AuthorID               *int       `url:"author_id,omitempty" json:"author_id,omitempty"`
+	AssigneeID             *int       `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
+	MyReactionEmoji        *string    `url:"my_reaction_emoji,omitempty" json:"my_reaction_emoji,omitempty"`
+	SourceBranch           *string    `url:"source_branch,omitempty" json:"source_branch,omitempty"`
+	TargetBranch           *string    `url:"target_branch,omitempty" json:"target_branch,omitempty"`
+	Search                 *string    `url:"search,omitempty" json:"search,omitempty"`
 }
 
 // ListGroupMergeRequests gets all merge requests for this group.
@@ -236,26 +244,28 @@ func (s *MergeRequestsService) ListGroupMergeRequests(gid interface{}, opt *List
 // https://docs.gitlab.com/ce/api/merge_requests.html#list-project-merge-requests
 type ListProjectMergeRequestsOptions struct {
 	ListOptions
-	IIDs            []int      `url:"iids[],omitempty" json:"iids,omitempty"`
-	State           *string    `url:"state,omitempty" json:"state,omitempty"`
-	OrderBy         *string    `url:"order_by,omitempty" json:"order_by,omitempty"`
-	Sort            *string    `url:"sort,omitempty" json:"sort,omitempty"`
-	Milestone       *string    `url:"milestone,omitempty" json:"milestone,omitempty"`
-	View            *string    `url:"view,omitempty" json:"view,omitempty"`
-	Labels          Labels     `url:"labels,comma,omitempty" json:"labels,omitempty"`
-	NotLabels       Labels     `url:"not[labels],comma,omitempty" json:"not[labels],omitempty"`
-	CreatedAfter    *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
-	CreatedBefore   *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
-	UpdatedAfter    *time.Time `url:"updated_after,omitempty" json:"updated_after,omitempty"`
-	UpdatedBefore   *time.Time `url:"updated_before,omitempty" json:"updated_before,omitempty"`
-	Scope           *string    `url:"scope,omitempty" json:"scope,omitempty"`
-	AuthorID        *int       `url:"author_id,omitempty" json:"author_id,omitempty"`
-	AssigneeID      *int       `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
-	MyReactionEmoji *string    `url:"my_reaction_emoji,omitempty" json:"my_reaction_emoji,omitempty"`
-	SourceBranch    *string    `url:"source_branch,omitempty" json:"source_branch,omitempty"`
-	TargetBranch    *string    `url:"target_branch,omitempty" json:"target_branch,omitempty"`
-	Search          *string    `url:"search,omitempty" json:"search,omitempty"`
-	WIP             *string    `url:"wip,omitempty" json:"wip,omitempty"`
+	IIDs                   []int      `url:"iids[],omitempty" json:"iids,omitempty"`
+	State                  *string    `url:"state,omitempty" json:"state,omitempty"`
+	OrderBy                *string    `url:"order_by,omitempty" json:"order_by,omitempty"`
+	Sort                   *string    `url:"sort,omitempty" json:"sort,omitempty"`
+	Milestone              *string    `url:"milestone,omitempty" json:"milestone,omitempty"`
+	View                   *string    `url:"view,omitempty" json:"view,omitempty"`
+	Labels                 Labels     `url:"labels,comma,omitempty" json:"labels,omitempty"`
+	NotLabels              Labels     `url:"not[labels],comma,omitempty" json:"not[labels],omitempty"`
+	WithLabelsDetails      *bool      `url:"with_labels_details,omitempty" json:"with_labels_details,omitempty"`
+	WithMergeStatusRecheck *bool      `url:"with_merge_status_recheck,omitempty" json:"with_merge_status_recheck,omitempty"`
+	CreatedAfter           *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
+	CreatedBefore          *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
+	UpdatedAfter           *time.Time `url:"updated_after,omitempty" json:"updated_after,omitempty"`
+	UpdatedBefore          *time.Time `url:"updated_before,omitempty" json:"updated_before,omitempty"`
+	Scope                  *string    `url:"scope,omitempty" json:"scope,omitempty"`
+	AuthorID               *int       `url:"author_id,omitempty" json:"author_id,omitempty"`
+	AssigneeID             *int       `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
+	MyReactionEmoji        *string    `url:"my_reaction_emoji,omitempty" json:"my_reaction_emoji,omitempty"`
+	SourceBranch           *string    `url:"source_branch,omitempty" json:"source_branch,omitempty"`
+	TargetBranch           *string    `url:"target_branch,omitempty" json:"target_branch,omitempty"`
+	Search                 *string    `url:"search,omitempty" json:"search,omitempty"`
+	WIP                    *string    `url:"wip,omitempty" json:"wip,omitempty"`
 }
 
 // ListProjectMergeRequests gets all merge requests for this project.

--- a/merge_requests.go
+++ b/merge_requests.go
@@ -140,6 +140,7 @@ type ListMergeRequestsOptions struct {
 	View                   *string    `url:"view,omitempty" json:"view,omitempty"`
 	Labels                 Labels     `url:"labels,comma,omitempty" json:"labels,omitempty"`
 	NotLabels              Labels     `url:"not[labels],comma,omitempty" json:"not[labels],omitempty"`
+	WithLabelsDetails      *bool      `url:"with_labels_details,omitempty" json:"with_labels_details,omitempty"`
 	WithMergeStatusRecheck *bool      `url:"with_merge_status_recheck,omitempty" json:"with_merge_status_recheck,omitempty"`
 	CreatedAfter           *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
 	CreatedBefore          *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
@@ -192,6 +193,7 @@ type ListGroupMergeRequestsOptions struct {
 	View                   *string    `url:"view,omitempty" json:"view,omitempty"`
 	Labels                 Labels     `url:"labels,omitempty" json:"labels,omitempty"`
 	NotLabels              Labels     `url:"not[labels],comma,omitempty" json:"not[labels],omitempty"`
+	WithLabelsDetails      *bool      `url:"with_labels_details,omitempty" json:"with_labels_details,omitempty"`
 	WithMergeStatusRecheck *bool      `url:"with_merge_status_recheck,omitempty" json:"with_merge_status_recheck,omitempty"`
 	CreatedAfter           *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
 	CreatedBefore          *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
@@ -246,6 +248,7 @@ type ListProjectMergeRequestsOptions struct {
 	View                   *string    `url:"view,omitempty" json:"view,omitempty"`
 	Labels                 Labels     `url:"labels,comma,omitempty" json:"labels,omitempty"`
 	NotLabels              Labels     `url:"not[labels],comma,omitempty" json:"not[labels],omitempty"`
+	WithLabelsDetails      *bool      `url:"with_labels_details,omitempty" json:"with_labels_details,omitempty"`
 	WithMergeStatusRecheck *bool      `url:"with_merge_status_recheck,omitempty" json:"with_merge_status_recheck,omitempty"`
 	CreatedAfter           *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
 	CreatedBefore          *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`

--- a/merge_requests.go
+++ b/merge_requests.go
@@ -140,7 +140,6 @@ type ListMergeRequestsOptions struct {
 	View                   *string    `url:"view,omitempty" json:"view,omitempty"`
 	Labels                 Labels     `url:"labels,comma,omitempty" json:"labels,omitempty"`
 	NotLabels              Labels     `url:"not[labels],comma,omitempty" json:"not[labels],omitempty"`
-	WithLabelsDetails      *bool      `url:"with_labels_details,omitempty" json:"with_labels_details,omitempty"`
 	WithMergeStatusRecheck *bool      `url:"with_merge_status_recheck,omitempty" json:"with_merge_status_recheck,omitempty"`
 	CreatedAfter           *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
 	CreatedBefore          *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
@@ -148,7 +147,6 @@ type ListMergeRequestsOptions struct {
 	UpdatedBefore          *time.Time `url:"updated_before,omitempty" json:"updated_before,omitempty"`
 	Scope                  *string    `url:"scope,omitempty" json:"scope,omitempty"`
 	AuthorID               *int       `url:"author_id,omitempty" json:"author_id,omitempty"`
-	AuthorUsername         *string    `url:"author_username,omitempty" json:"author_username,omitempty"`
 	AssigneeID             *int       `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
 	MyReactionEmoji        *string    `url:"my_reaction_emoji,omitempty" json:"my_reaction_emoji,omitempty"`
 	SourceBranch           *string    `url:"source_branch,omitempty" json:"source_branch,omitempty"`
@@ -170,8 +168,6 @@ func (s *MergeRequestsService) ListMergeRequests(opt *ListMergeRequestsOptions, 
 	if err != nil {
 		return nil, nil, err
 	}
-
-	fmt.Println(req.URL)
 
 	var m []*MergeRequest
 	resp, err := s.client.Do(req, &m)
@@ -197,7 +193,6 @@ type ListGroupMergeRequestsOptions struct {
 	View                   *string    `url:"view,omitempty" json:"view,omitempty"`
 	Labels                 Labels     `url:"labels,omitempty" json:"labels,omitempty"`
 	NotLabels              Labels     `url:"not[labels],comma,omitempty" json:"not[labels],omitempty"`
-	WithLabelsDetails      *bool      `url:"with_labels_details,omitempty" json:"with_labels_details,omitempty"`
 	WithMergeStatusRecheck *bool      `url:"with_merge_status_recheck,omitempty" json:"with_merge_status_recheck,omitempty"`
 	CreatedAfter           *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
 	CreatedBefore          *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
@@ -252,7 +247,6 @@ type ListProjectMergeRequestsOptions struct {
 	View                   *string    `url:"view,omitempty" json:"view,omitempty"`
 	Labels                 Labels     `url:"labels,comma,omitempty" json:"labels,omitempty"`
 	NotLabels              Labels     `url:"not[labels],comma,omitempty" json:"not[labels],omitempty"`
-	WithLabelsDetails      *bool      `url:"with_labels_details,omitempty" json:"with_labels_details,omitempty"`
 	WithMergeStatusRecheck *bool      `url:"with_merge_status_recheck,omitempty" json:"with_merge_status_recheck,omitempty"`
 	CreatedAfter           *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
 	CreatedBefore          *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`

--- a/merge_requests.go
+++ b/merge_requests.go
@@ -171,7 +171,6 @@ func (s *MergeRequestsService) ListMergeRequests(opt *ListMergeRequestsOptions, 
 
 	var m []*MergeRequest
 	resp, err := s.client.Do(req, &m)
-
 	if err != nil {
 		return nil, resp, err
 	}


### PR DESCRIPTION
Add With Merge Status Recheck for support Github 13.0 

> Note: Starting in GitLab 13.0, listing merge requests may not proactively update the merge_status field (which also affects the has_conflicts field), as this can be an expensive operation. If you are interested in the value of these fields from this endpoint, set the with_merge_status_recheck parameter to true in the query.

Ref:
https://docs.gitlab.com/ce/api/merge_requests.html#list-merge-requests