### PR TITLE
Add missing attributes to SetCommitStatus API

### DIFF
--- a/commits.go
+++ b/commits.go
@@ -447,7 +447,7 @@ type SetCommitStatusOptions struct {
 	TargetURL   *string         `url:"target_url,omitempty" json:"target_url,omitempty"`
 	Description *string         `url:"description,omitempty" json:"description,omitempty"`
 	Coverage    *float64        `url:"coverage,omitempty" json:"coverage,omitempty"`
-	PipelineID  *int64          `url:"pipeline_id,omitempty" json:"pipeline_id,omitempty"`
+	PipelineID  *int            `url:"pipeline_id,omitempty" json:"pipeline_id,omitempty"`
 }
 
 // SetCommitStatus sets the status of a commit in a project.

--- a/commits.go
+++ b/commits.go
@@ -446,6 +446,8 @@ type SetCommitStatusOptions struct {
 	Context     *string         `url:"context,omitempty" json:"context,omitempty"`
 	TargetURL   *string         `url:"target_url,omitempty" json:"target_url,omitempty"`
 	Description *string         `url:"description,omitempty" json:"description,omitempty"`
+	Coverage    *float64        `url:"coverage,omitempty" json:"coverage,omitempty"`
+	PipelineID  *int64          `url:"pipeline_id,omitempty" json:"pipeline_id,omitempty"`
 }
 
 // SetCommitStatus sets the status of a commit in a project.

--- a/commits_test.go
+++ b/commits_test.go
@@ -88,16 +88,19 @@ func TestSetCommitStatus(t *testing.T) {
 		testMethod(t, r, "POST")
 		body, err := ioutil.ReadAll(r.Body)
 		require.NoError(t, err)
+
 		var content SetCommitStatusOptions
 		err = json.Unmarshal(body, &content)
 		require.NoError(t, err)
+
 		assert.Equal(t, "ci/jenkins", *content.Name)
 		assert.Equal(t, 99.9, *content.Coverage)
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
 	cov := 99.9
-	opt := &SetCommitStatusOptions{State: Running, Ref: String("master"), Name: String("ci/jenkins"), Context: String(""), TargetURL: String("http://abc"), Description: String("build"), Coverage: &cov}
+	opt := &SetCommitStatusOptions{State: Running, Ref: String("master"), Name: String("ci/jenkins"),
+		Context: String(""), TargetURL: String("http://abc"), Description: String("build"), Coverage: &cov}
 	status, _, err := client.Commits.SetCommitStatus("1", "b0b3a907f41409829b307a28b82fdbd552ee5a27", opt)
 
 	if err != nil {


### PR DESCRIPTION
Add a the ability to set a couple of missing attributes in the SetCommitStatus API call