### PR TITLE
Update Pipeline test report

### DIFF
--- a/examples/pipelinestestreport.go
+++ b/examples/pipelinestestreport.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"log"
+
+	"github.com/xanzy/go-gitlab"
+)
+
+func pipelineTestReportExample() {
+	git, err := gitlab.NewClient("yourtokengoeshere")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	opt := &gitlab.ListProjectPipelinesOptions{Ref: gitlab.String("master")}
+	projectID := 1234
+
+	pipelines, _, err := git.Pipelines.ListProjectPipelines(projectID, opt)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, pipeline := range pipelines {
+		log.Printf("Found pipeline: %v", pipeline)
+
+		report, _, err := git.Pipelines.GetPipelineTestReport(projectID, pipeline.ID)
+		if err != nil {
+			log.Fatal(err)
+		}
+		log.Printf("Found test report: %v", report)
+
+	}
+}

--- a/pipelines.go
+++ b/pipelines.go
@@ -82,7 +82,7 @@ func (p Pipeline) String() string {
 
 // PipelineTestReport contains a detailed report of a test run.
 type PipelineTestReport struct {
-	TotalTime    int                  `json:"total_time"`
+	TotalTime    float64              `json:"total_time"`
 	TotalCount   int                  `json:"total_count"`
 	SuccessCount int                  `json:"success_count"`
 	FailedCount  int                  `json:"failed_count"`
@@ -94,7 +94,7 @@ type PipelineTestReport struct {
 // PipelineTestSuites contains test suites results.
 type PipelineTestSuites struct {
 	Name         string              `json:"name"`
-	TotalTime    int                 `json:"total_time"`
+	TotalTime    float64             `json:"total_time"`
 	TotalCount   int                 `json:"total_count"`
 	SuccessCount int                 `json:"success_count"`
 	FailedCount  int                 `json:"failed_count"`
@@ -105,12 +105,10 @@ type PipelineTestSuites struct {
 
 // PipelineTestCases contains test cases details.
 type PipelineTestCases struct {
-	Status        string `json:"status"`
-	Name          string `json:"name"`
-	Classname     string `json:"classname"`
-	ExecutionTime int    `json:"execution_time"`
-	SystemOutput  string `json:"system_output"`
-	StackTrace    string `json:"stack_trace"`
+	Status        string  `json:"status"`
+	Name          string  `json:"name"`
+	Classname     string  `json:"classname"`
+	ExecutionTime float64 `json:"execution_time"`
 }
 
 func (p PipelineTestReport) String() string {

--- a/pipelines_test.go
+++ b/pipelines_test.go
@@ -83,29 +83,64 @@ func TestGetPipelineTestReport(t *testing.T) {
 	}
 
 	want := &PipelineTestReport{
-		TotalTime:    1,
-		TotalCount:   2,
-		SuccessCount: 3,
-		FailedCount:  4,
-		SkippedCount: 5,
-		ErrorCount:   6,
-		TestSuites: []PipelineTestSuites{{
-			Name:         "foo",
-			TotalTime:    1,
-			TotalCount:   2,
-			SuccessCount: 3,
-			FailedCount:  4,
-			SkippedCount: 5,
-			ErrorCount:   6,
-			TestCases: []PipelineTestCases{{
-				Status:        "success",
-				Name:          "bar",
-				Classname:     "class_foo",
-				ExecutionTime: 1,
-				SystemOutput:  "",
-				StackTrace:    "",
-			}},
-		}}}
+		TotalTime:    61.502,
+		TotalCount:   9,
+		SuccessCount: 5,
+		FailedCount:  0,
+		SkippedCount: 0,
+		ErrorCount:   4,
+		TestSuites: []PipelineTestSuites{
+			{
+				Name:         "Failing",
+				TotalTime:    60.494,
+				TotalCount:   8,
+				SuccessCount: 4,
+				FailedCount:  0,
+				SkippedCount: 0,
+				ErrorCount:   4,
+				TestCases: []PipelineTestCases{
+					{
+						Status:        "error",
+						Name:          "Error testcase 1",
+						Classname:     "",
+						ExecutionTime: 19.987,
+					},
+
+					{
+						Status:        "error",
+						Name:          "Error testcase 2",
+						Classname:     "",
+						ExecutionTime: 19.984,
+					},
+					{
+						Status:        "error",
+						Name:          "Error testcase 3",
+						Classname:     "",
+						ExecutionTime: 0.0,
+					},
+					{
+						Status:        "success",
+						Name:          "Succes full testcase",
+						Classname:     "",
+						ExecutionTime: 19.7799999999999985,
+					}},
+			},
+			{
+				Name:         "Succes suite",
+				TotalTime:    1.008,
+				TotalCount:   1,
+				SuccessCount: 1,
+				FailedCount:  0,
+				SkippedCount: 0,
+				ErrorCount:   0,
+				TestCases: []PipelineTestCases{{
+					Status:        "success",
+					Name:          "Succesfull testcase",
+					Classname:     "",
+					ExecutionTime: 1.008,
+				}},
+			},
+		}}
 	if !reflect.DeepEqual(want, testreport) {
 		t.Errorf("Pipelines.GetPipelineTestReport returned %+v, want %+v", testreport, want)
 	}

--- a/testdata/get_pipeline_testreport.json
+++ b/testdata/get_pipeline_testreport.json
@@ -1,25 +1,84 @@
 {
-    "total_time": 1,
-    "total_count": 2,
-    "success_count": 3,
-    "failed_count": 4,
-    "skipped_count": 5,
-    "error_count": 6,
+    "total_time": 61.502,
+    "total_count": 9,
+    "success_count": 5,
+    "failed_count": 0,
+    "skipped_count": 0,
+    "error_count": 4,
     "test_suites": [
         {
-            "name": "foo",
-            "total_time": 1,
-            "total_count": 2,
-            "success_count": 3,
-            "failed_count": 4,
-            "skipped_count": 5,
-            "error_count": 6,
+            "name": "Failing",
+            "total_time": 60.494,
+            "total_count": 8,
+            "success_count": 4,
+            "failed_count": 0,
+            "skipped_count": 0,
+            "error_count": 4,
+            "suite_error": null,
+            "test_cases": [
+                {
+                    "status": "error",
+                    "name": "Error testcase 1",
+                    "classname": null,
+                    "execution_time": 19.987,
+                    "system_output": [
+                        {
+                            "message": "output message",
+                            "type": "pending"
+                        },
+                        {
+                            "message": "output message 2",
+                            "type": "skipped"
+                        }
+                    ],
+                    "stack_trace": null
+                },
+                {
+                    "status": "error",
+                    "name": "Error testcase 2",
+                    "classname": null,
+                    "execution_time": 19.984,
+                    "system_output": null,
+                    "stack_trace": null
+                },
+                {
+                    "status": "error",
+                    "name": "Error testcase 3",
+                    "classname": null,
+                    "execution_time": 0.0,
+                    "system_output":
+                        {
+                            "message": "Undefined message",
+                            "type": "undefined"
+                        }
+                    ,
+                    "stack_trace": null
+                },
+                {
+                    "status": "success",
+                    "name": "Succes full testcase",
+                    "classname": null,
+                    "execution_time": 19.7799999999999985,
+                    "system_output": null,
+                    "stack_trace": null
+                }
+            ]
+        },
+        {
+            "name": "Succes suite",
+            "total_time": 1.008,
+            "total_count": 1,
+            "success_count": 1,
+            "failed_count": 0,
+            "skipped_count": 0,
+            "error_count": 0,
+            "suite_error": null,
             "test_cases": [
                 {
                     "status": "success",
-                    "name": "bar",
-                    "classname": "class_foo",
-                    "execution_time": 1,
+                    "name": "Succesfull testcase",
+                    "classname": null,
+                    "execution_time": 1.008,
                     "system_output": null,
                     "stack_trace": null
                 }


### PR DESCRIPTION
Gitlab documentation wasn't entirly as expected:

- Remove system_output and strack_trace field aren't consitant (see test data)
- Updated type of time fields to float
- Added example how to retrive testreport