### PR TITLE
Add in to ListIssuesOptions properties with tests

### DIFF
--- a/issues.go
+++ b/issues.go
@@ -215,6 +215,7 @@ type ListIssuesOptions struct {
 	MyReactionEmoji    *string    `url:"my_reaction_emoji,omitempty" json:"my_reaction_emoji,omitempty"`
 	NotMyReactionEmoji []string   `url:"not[my_reaction_emoji],omitempty" json:"not[my_reaction_emoji],omitempty"`
 	IIDs               []int      `url:"iids[],omitempty" json:"iids,omitempty"`
+	In                 *string    `url:"in,omitempty" json:"in,omitempty"`
 	OrderBy            *string    `url:"order_by,omitempty" json:"order_by,omitempty"`
 	Sort               *string    `url:"sort,omitempty" json:"sort,omitempty"`
 	Search             *string    `url:"search,omitempty" json:"search,omitempty"`

--- a/issues_test.go
+++ b/issues_test.go
@@ -201,6 +201,84 @@ func TestListIssuesWithLabelDetails(t *testing.T) {
 		t.Errorf("Issues.ListIssues returned %+v, want %+v", issues, want)
 	}
 }
+func TestListIssuesSearchInTitle(t *testing.T) {
+	mux, server, client := setup(t)
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v4/issues", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testURL(t, r, "/api/v4/issues?in=title&search=Title")
+		fmt.Fprint(w, `
+			[
+				{
+					"id": 1,
+					"title": "A Test Issue Title",
+					"description": "This is the description for the issue"
+			  }
+			]`,
+		)
+	})
+
+	listProjectIssue := &ListIssuesOptions{
+		Search: String("Title"),
+		In:     String("title"),
+	}
+
+	issues, _, err := client.Issues.ListIssues(listProjectIssue)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	want := []*Issue{{
+		ID:          1,
+		Title:       "A Test Issue Title",
+		Description: "This is the description for the issue",
+	}}
+
+	if !reflect.DeepEqual(want, issues) {
+		t.Errorf("Issues.ListIssues returned %+v, want %+v", issues, want)
+	}
+}
+func TestListIssuesSearchInDescription(t *testing.T) {
+	mux, server, client := setup(t)
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v4/issues", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testURL(t, r, "/api/v4/issues?in=description&search=description")
+		fmt.Fprint(w, `
+			[
+				{
+					"id": 1,
+					"title": "A Test Issue Title",
+					"description": "This is the description for the issue"
+			  }
+			]`,
+		)
+	})
+
+	listProjectIssue := &ListIssuesOptions{
+		Search: String("description"),
+		In:     String("description"),
+	}
+
+	issues, _, err := client.Issues.ListIssues(listProjectIssue)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	want := []*Issue{{
+		ID:          1,
+		Title:       "A Test Issue Title",
+		Description: "This is the description for the issue",
+	}}
+
+	if !reflect.DeepEqual(want, issues) {
+		t.Errorf("Issues.ListIssues returned %+v, want %+v", issues, want)
+	}
+}
 func TestListProjectIssues(t *testing.T) {
 	mux, server, client := setup(t)
 	defer teardown(server)


### PR DESCRIPTION
As discussed in Issue #948, this changeset adds an `In` property to the `ListIssuesOptions` as documented in the GitLab API: https://docs.gitlab.com/ce/api/issues.html#list-issues

I've also added 2 tests to confirm that the parameter is added properly with the expected values. All tests pass. 

I've run `go fmt` as well to ensure that there are no formatting issues.

Resolves #948 