### PR TITLE
Add User to MergeRequest struct

### DIFF
--- a/merge_requests.go
+++ b/merge_requests.go
@@ -81,7 +81,7 @@ type MergeRequest struct {
 		RenamedFile bool   `json:"renamed_file"`
 		DeletedFile bool   `json:"deleted_file"`
 	} `json:"changes"`
-	User                      []struct {
+	User                      struct {
 		CanMerge bool `json:"can_merge"`
 	} `json:"user"`
 	TimeStats    *TimeStats    `json:"time_stats"`

--- a/merge_requests.go
+++ b/merge_requests.go
@@ -81,6 +81,9 @@ type MergeRequest struct {
 		RenamedFile bool   `json:"renamed_file"`
 		DeletedFile bool   `json:"deleted_file"`
 	} `json:"changes"`
+	User                      []struct {
+		CanMerge bool `json:"can_merge"`
+	} `json:"user"`
 	TimeStats    *TimeStats    `json:"time_stats"`
 	Squash       bool          `json:"squash"`
 	Pipeline     *PipelineInfo `json:"pipeline"`


### PR DESCRIPTION
The GitLab merge request endpoint has `"user" : {"can_merge" : false},` as part of the payload which indicates whether the current authenticated user has permission to merge a particular merge request. 
This PR adds it to the MergeRequest struct so it can be accessed with `User.CanMerge`

Reference: https://docs.gitlab.com/ee/api/merge_requests.html#get-single-mr