### PR TITLE
Add method to delete artifacts for a job

### DIFF
--- a/jobs.go
+++ b/jobs.go
@@ -406,3 +406,28 @@ func (s *JobsService) PlayJob(pid interface{}, jobID int, options ...RequestOpti
 
 	return job, resp, err
 }
+
+// DeleteArtifacts delete artifacts of a job
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/job_artifacts.html#delete-artifacts
+func (s *JobsService) DeleteArtifacts(pid interface{}, jobID int, options ...RequestOptionFunc) (*Job, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/jobs/%d/artifacts", pathEscape(project), jobID)
+
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	job := new(Job)
+	resp, err := s.client.Do(req, job)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return job, resp, err
+}

--- a/jobs.go
+++ b/jobs.go
@@ -164,7 +164,7 @@ func (s *JobsService) GetJob(pid interface{}, jobID int, options ...RequestOptio
 // GetJobArtifacts get jobs artifacts of a project
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/jobs.html#get-job-artifacts
+// https://docs.gitlab.com/ce/api/job_artifacts.html#get-job-artifacts
 func (s *JobsService) GetJobArtifacts(pid interface{}, jobID int, options ...RequestOptionFunc) (io.Reader, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -190,7 +190,7 @@ func (s *JobsService) GetJobArtifacts(pid interface{}, jobID int, options ...Req
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/jobs.html#download-the-artifacts-file
+// https://docs.gitlab.com/ce/api/job_artifacts.html#download-the-artifacts-archive
 type DownloadArtifactsFileOptions struct {
 	Job *string `url:"job" json:"job"`
 }
@@ -199,7 +199,7 @@ type DownloadArtifactsFileOptions struct {
 // reference name and job provided the job finished successfully.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/jobs.html#download-the-artifacts-file
+// https://docs.gitlab.com/ce/api/job_artifacts.html#download-the-artifacts-archive
 func (s *JobsService) DownloadArtifactsFile(pid interface{}, refName string, opt *DownloadArtifactsFileOptions, options ...RequestOptionFunc) (io.Reader, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -227,7 +227,7 @@ func (s *JobsService) DownloadArtifactsFile(pid interface{}, refName string, opt
 // to a client.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/jobs.html#download-a-single-artifact-file
+// https://docs.gitlab.com/ce/api/job_artifacts.html#download-a-single-artifact-file-by-job-id
 func (s *JobsService) DownloadSingleArtifactsFile(pid interface{}, jobID int, artifactPath string, options ...RequestOptionFunc) (io.Reader, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -360,7 +360,7 @@ func (s *JobsService) EraseJob(pid interface{}, jobID int, options ...RequestOpt
 // expiration is set.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/jobs.html#keep-artifacts
+// https://docs.gitlab.com/ce/api/job_artifacts.html#keep-artifacts
 func (s *JobsService) KeepArtifacts(pid interface{}, jobID int, options ...RequestOptionFunc) (*Job, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {


### PR DESCRIPTION
As described in [GitLab's documentation](https://docs.gitlab.com/ce/api/job_artifacts.html#delete-artifacts) since GitLab 11.9 there is an endpoint available to remove the artifacts for a job, a new method has been introduced in `JobsService` to add support for this missing API call.