### PR TITLE
Add project compliance_framework field

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -106,11 +106,12 @@ type Project struct {
 		GroupName        string `json:"group_name"`
 		GroupAccessLevel int    `json:"group_access_level"`
 	} `json:"shared_with_groups"`
-	Statistics        *ProjectStatistics `json:"statistics"`
-	Links             *Links             `json:"_links,omitempty"`
-	CIConfigPath      string             `json:"ci_config_path"`
-	CIDefaultGitDepth int                `json:"ci_default_git_depth"`
-	CustomAttributes  []*CustomAttribute `json:"custom_attributes"`
+	Statistics           *ProjectStatistics `json:"statistics"`
+	Links                *Links             `json:"_links,omitempty"`
+	CIConfigPath         string             `json:"ci_config_path"`
+	CIDefaultGitDepth    int                `json:"ci_default_git_depth"`
+	CustomAttributes     []*CustomAttribute `json:"custom_attributes"`
+	ComplianceFrameworks []string           `json:"compliance_frameworks"`
 }
 
 // Repository represents a repository.


### PR DESCRIPTION
Added this field which was not on the current model. 

See the field on the Gitlab project documentation here 
https://docs.gitlab.com/ce/api/projects.html#get-single-project:~:text=compliance_frameworks%22%3A%20%5B%20%22sox%22%20%5D%2C