### PR TITLE
Extend ProjectsNamespace with avatar_url and web_url

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -134,11 +134,13 @@ type Repository struct {
 
 // ProjectNamespace represents a project namespace.
 type ProjectNamespace struct {
-	ID       int    `json:"id"`
-	Name     string `json:"name"`
-	Path     string `json:"path"`
-	Kind     string `json:"kind"`
-	FullPath string `json:"full_path"`
+	ID        int    `json:"id"`
+	Name      string `json:"name"`
+	Path      string `json:"path"`
+	Kind      string `json:"kind"`
+	FullPath  string `json:"full_path"`
+	AvatarURL string `json:"avatar_url"`
+	WebURL    string `json:"web_url"`
 }
 
 // StorageStatistics represents a statistics record for a group or project.


### PR DESCRIPTION
These fields were present in the Gitlab v4 api since 11.0, but without proper documentation. The only place where we can find some information about these fields is in the *Note* under https://docs.gitlab.com/13.3/ee/api/projects.html#get-single-project API description.

I tested the code on /projects/{:id} and /projects. 