### PR TITLE
feat(commit status): add AllowFailure in CommitStatus struct.

### DIFF
--- a/commits.go
+++ b/commits.go
@@ -389,17 +389,18 @@ type GetCommitStatusesOptions struct {
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/commits.html#get-the-status-of-a-commit
 type CommitStatus struct {
-	ID          int        `json:"id"`
-	SHA         string     `json:"sha"`
-	Ref         string     `json:"ref"`
-	Status      string     `json:"status"`
-	Name        string     `json:"name"`
-	TargetURL   string     `json:"target_url"`
-	Description string     `json:"description"`
-	CreatedAt   *time.Time `json:"created_at"`
-	StartedAt   *time.Time `json:"started_at"`
-	FinishedAt  *time.Time `json:"finished_at"`
-	Author      Author     `json:"author"`
+	ID           int        `json:"id"`
+	SHA          string     `json:"sha"`
+	Ref          string     `json:"ref"`
+	Status       string     `json:"status"`
+	Name         string     `json:"name"`
+	TargetURL    string     `json:"target_url"`
+	Description  string     `json:"description"`
+	CreatedAt    *time.Time `json:"created_at"`
+	StartedAt    *time.Time `json:"started_at"`
+	FinishedAt   *time.Time `json:"finished_at"`
+	Author       Author     `json:"author"`
+	AllowFailure bool       `json:"allow_failure"`
 }
 
 // GetCommitStatuses gets the statuses of a commit in a project.


### PR DESCRIPTION
#972 

When checking the status of a commit, the allow_failure option should be checked. This key is added in the commit status API in GitLab 12, so the user can combine that with the status to get the final decision.