### PR TITLE
AddProjectMemberOptions.UserId shoud be *string

### DIFF
--- a/project_members.go
+++ b/project_members.go
@@ -147,7 +147,7 @@ func (s *ProjectMembersService) GetInheritedProjectMember(pid interface{}, user 
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/members.html#add-a-member-to-a-group-or-project
 type AddProjectMemberOptions struct {
-	UserID      *int              `url:"user_id,omitempty" json:"user_id,omitempty"`
+	UserID      *string           `url:"user_id,omitempty" json:"user_id,omitempty"`
 	AccessLevel *AccessLevelValue `url:"access_level,omitempty" json:"access_level,omitempty"`
 	ExpiresAt   *string           `url:"expires_at,omitempty" json:"expires_at"`
 }

--- a/project_members.go
+++ b/project_members.go
@@ -147,7 +147,7 @@ func (s *ProjectMembersService) GetInheritedProjectMember(pid interface{}, user 
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/members.html#add-a-member-to-a-group-or-project
 type AddProjectMemberOptions struct {
-	UserID      *string           `url:"user_id,omitempty" json:"user_id,omitempty"`
+	UserID      interface{}       `url:"user_id,omitempty" json:"user_id,omitempty"`
 	AccessLevel *AccessLevelValue `url:"access_level,omitempty" json:"access_level,omitempty"`
 	ExpiresAt   *string           `url:"expires_at,omitempty" json:"expires_at"`
 }


### PR DESCRIPTION
https://docs.gitlab.com/ee/api/members.html#add-a-member-to-a-group-or-project

We can pass a comma-separated string to do bulk.