### PR TITLE
Added ExpiresAt field to AddSSHKeyOptions according to Gitlab API spec

### DIFF
--- a/users.go
+++ b/users.go
@@ -364,6 +364,7 @@ func (s *UsersService) GetSSHKey(key int, options ...RequestOptionFunc) (*SSHKey
 type AddSSHKeyOptions struct {
 	Title *string `url:"title,omitempty" json:"title,omitempty"`
 	Key   *string `url:"key,omitempty" json:"key,omitempty"`
+	ExpiresAt *ISOTime `url:"expires_at,omitempty" json:"expires_at,omitempty"`
 }
 
 // AddSSHKey creates a new key owned by the currently authenticated user.

--- a/users.go
+++ b/users.go
@@ -362,8 +362,8 @@ func (s *UsersService) GetSSHKey(key int, options ...RequestOptionFunc) (*SSHKey
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#add-ssh-key
 type AddSSHKeyOptions struct {
-	Title *string `url:"title,omitempty" json:"title,omitempty"`
-	Key   *string `url:"key,omitempty" json:"key,omitempty"`
+	Title     *string  `url:"title,omitempty" json:"title,omitempty"`
+	Key       *string  `url:"key,omitempty" json:"key,omitempty"`
 	ExpiresAt *ISOTime `url:"expires_at,omitempty" json:"expires_at,omitempty"`
 }
 


### PR DESCRIPTION
The Gitlab API now supports the optional field expires_at when adding a new SSH key to the user account. This has been previously only possible via UI. This PR adds the struct field ExpiresAt in the same way as already present in ImpersonationToken.