### PR TITLE
fix(merge_requests/issues): fix Issue.ID type to handle Jira issues

### DIFF
--- a/merge_requests_test.go
+++ b/merge_requests_test.go
@@ -224,6 +224,6 @@ func TestGetIssuesClosedOnMerge_Jira(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Len(t, issues, 1)
-	assert.Equal(t, "PROJECT-123", issues[0].ID)
+	assert.Equal(t, "PROJECT-123", issues[0].ExternalID)
 	assert.Equal(t, "Title of this issue", issues[0].Title)
 }

--- a/merge_requests_test.go
+++ b/merge_requests_test.go
@@ -211,3 +211,19 @@ func TestGetMergeRequestParticipants(t *testing.T) {
 		t.Errorf("Issues.GetMergeRequestParticipants returned %+v, want %+v", mergeRequestParticipants, want)
 	}
 }
+
+func TestGetIssuesClosedOnMerge_Jira(t *testing.T) {
+	mux, server, client := setup(t)
+	defer teardown(server)
+	mux.HandleFunc("/api/v4/projects/1/merge_requests/1/closes_issues", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `[{"id":"PROJECT-123","title":"Title of this issue"}]`)
+	})
+
+	issues, _, err := client.MergeRequests.GetIssuesClosedOnMerge(1, 1, nil)
+
+	assert.NoError(t, err)
+	assert.Len(t, issues, 1)
+	assert.Equal(t, "PROJECT-123", issues[0].ID)
+	assert.Equal(t, "Title of this issue", issues[0].Title)
+}


### PR DESCRIPTION
This MR fixes the `Issue.ID` type field that can be an integer or a string to support third parties issue systems (like Jira).

The Gitlab documentation page is available [here](https://docs.gitlab.com/ee/api/merge_requests.html#list-issues-that-will-close-on-merge).
