### PR TITLE
Use *bool for Silver/Premium push rules

### DIFF
--- a/groups.go
+++ b/groups.go
@@ -521,8 +521,10 @@ type GroupPushRules struct {
 	AuthorEmailRegex           string     `json:"author_email_regex"`
 	FileNameRegex              string     `json:"file_name_regex"`
 	MaxFileSize                int        `json:"max_file_size"`
-	CommitCommitterCheck       bool       `json:"commit_committer_check"`
-	RejectUnsignedCommits      bool       `json:"reject_unsigned_commits"`
+
+	// Only available in GitLab Silver/Premium and above.
+	CommitCommitterCheck  *bool `json:"commit_committer_check,omitempty"`
+	RejectUnsignedCommits *bool `json:"reject_unsigned_commits,omitempty"`
 }
 
 // GetGroupPushRules gets the push rules of a group.

--- a/projects.go
+++ b/projects.go
@@ -1212,8 +1212,10 @@ type ProjectPushRules struct {
 	AuthorEmailRegex           string     `json:"author_email_regex"`
 	FileNameRegex              string     `json:"file_name_regex"`
 	MaxFileSize                int        `json:"max_file_size"`
-	CommitCommitterCheck       bool       `json:"commit_committer_check"`
-	RejectUnsignedCommits      bool       `json:"reject_unsigned_commits"`
+
+	// Only available in GitLab Silver/Premium and above.
+	CommitCommitterCheck  *bool `json:"commit_committer_check,omitempty"`
+	RejectUnsignedCommits *bool `json:"reject_unsigned_commits,omitempty"`
 }
 
 // GetProjectPushRules gets the push rules of a project.


### PR DESCRIPTION
The `commit_committer_check` and `reject_unsigned_commits` project and group push rules are only available in GitLab Silver/Premium and above.

See: https://docs.gitlab.com/ee/api/projects.html#get-project-push-rules

This commit changes the push rules response struct to use type `*bool` instead of `bool` for those rules, since they aren't returned by the API if you don't have the right plan. Leaving the type as `bool` makes it hard to tell if trying to set those rules will succeed or return a `403 Forbidden` error.