### PR TITLE
Add exclude_internal option to ListUsersOptions

### DIFF
--- a/users.go
+++ b/users.go
@@ -102,8 +102,9 @@ type UserIdentity struct {
 // GitLab API docs: https://docs.gitlab.com/ce/api/users.html#list-users
 type ListUsersOptions struct {
 	ListOptions
-	Active  *bool `url:"active,omitempty" json:"active,omitempty"`
-	Blocked *bool `url:"blocked,omitempty" json:"blocked,omitempty"`
+	Active          *bool `url:"active,omitempty" json:"active,omitempty"`
+	Blocked         *bool `url:"blocked,omitempty" json:"blocked,omitempty"`
+	ExcludeInternal *bool `url:"exclude_internal,omitempty" json:"exclude_internal,omitempty"`
 
 	// The options below are only available for admins.
 	Search               *string    `url:"search,omitempty" json:"search,omitempty"`


### PR DESCRIPTION
GitLab supports bot users such as the alert bot or the support bot.

To exclude these users from the users’ list, you can use the parameter exclude_internal=true.

Feature is introduced in GitLab 13.4.

Fixes #997

Signed-off-by: Alex Szakaly <alex.szakaly@gmail.com>

Note:

```
As of now, GitLab 13.6.2-ee (98aab73cbd5) Users API does not expose the field exclude_internal
```

