### PR TITLE
Add StartBranch field into CreateFileOptions and UpdateFileOptions

### DIFF
--- a/repository_files.go
+++ b/repository_files.go
@@ -260,6 +260,7 @@ func (r FileInfo) String() string {
 // https://docs.gitlab.com/ce/api/repository_files.html#create-new-file-in-repository
 type CreateFileOptions struct {
 	Branch        *string `url:"branch,omitempty" json:"branch,omitempty"`
+	StartBranch   *string `url:"start_branch,omitempty" json:"start_branch,omitempty"`
 	Encoding      *string `url:"encoding,omitempty" json:"encoding,omitempty"`
 	AuthorEmail   *string `url:"author_email,omitempty" json:"author_email,omitempty"`
 	AuthorName    *string `url:"author_name,omitempty" json:"author_name,omitempty"`
@@ -302,6 +303,7 @@ func (s *RepositoryFilesService) CreateFile(pid interface{}, fileName string, op
 // https://docs.gitlab.com/ce/api/repository_files.html#update-existing-file-in-repository
 type UpdateFileOptions struct {
 	Branch        *string `url:"branch,omitempty" json:"branch,omitempty"`
+	StartBranch   *string `url:"start_branch,omitempty" json:"start_branch,omitempty"`
 	Encoding      *string `url:"encoding,omitempty" json:"encoding,omitempty"`
 	AuthorEmail   *string `url:"author_email,omitempty" json:"author_email,omitempty"`
 	AuthorName    *string `url:"author_name,omitempty" json:"author_name,omitempty"`


### PR DESCRIPTION
This field is mandatory if you want to create or
update file onto a new (non-existing) branch.

If the option is missing, then the GitLab API will
return HTTP 400: You can only create or edit files
when you are on a branch.

Note for CreateFile: the GitLab API will not send
proper error message, just silently fail.

Signed-off-by: Alex Szakaly <alex.szakaly@gmail.com>

## Reproducer
```go
package main

import (
	"fmt"

	"github.com/xanzy/go-gitlab"
)

func main() {
	client, err := gitlab.NewClient("mytoken",
		gitlab.WithBaseURL("https://my.gitlab.foo.bar.acme/api/v4"))
	if err != nil {
		panic(err)
	}

	updateFileInfo, _, errUpdateFile := client.RepositoryFiles.UpdateFile(8, "Makefile", &gitlab.UpdateFileOptions{
		Branch: gitlab.String("update-branch"),
		// Without StartBranch option we assume that the branch update-branch exists, otherwise we will get: 400 {message: You can only create or edit files when you are on a branch}
		Encoding:      gitlab.String("base64"),
		Content:       gitlab.String("dXBkYXRlIGZpbGUgY29udGVudCAy"),
		CommitMessage: gitlab.String("Test UpdateFile"),
	})

	if errUpdateFile != nil {
		panic(err)
	}

	fmt.Printf("updateFileInfo info %v", updateFileInfo)

	createFileInfo, _, errCreateFile := client.RepositoryFiles.CreateFile(8, "newfile", &gitlab.CreateFileOptions{
		Branch: gitlab.String("create-branch"),
		// Without StartBranch option we assume that the branch create-branch exists, otherwise we will get error without proper message.
		Encoding:      gitlab.String("base64"),
		Content:       gitlab.String("Y3JlYXRlIGZpbGUgY29udGVudA===="),
		CommitMessage: gitlab.String("Test CreateFile"),
	})

	fmt.Printf("errCreateFile: %v", err)

	if errCreateFile != nil {
		panic(err)
	}

	fmt.Printf("createFileInfo info %v", createFileInfo)

}

```