### PR TITLE
#964: Update ObjectAttributes of MergeCommentEvent

### DIFF
--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -329,21 +329,30 @@ type MergeCommentEvent struct {
 		Visibility        VisibilityValue `json:"visibility"`
 	} `json:"project"`
 	ObjectAttributes struct {
-		ID           int    `json:"id"`
-		DiscussionID string `json:"discussion_id"`
-		Note         string `json:"note"`
-		NoteableType string `json:"noteable_type"`
-		AuthorID     int    `json:"author_id"`
-		CreatedAt    string `json:"created_at"`
-		UpdatedAt    string `json:"updated_at"`
-		ProjectID    int    `json:"project_id"`
-		Attachment   string `json:"attachment"`
-		LineCode     string `json:"line_code"`
-		CommitID     string `json:"commit_id"`
-		NoteableID   int    `json:"noteable_id"`
-		System       bool   `json:"system"`
-		StDiff       *Diff  `json:"st_diff"`
-		URL          string `json:"url"`
+		Attachment       string        `json:"attachment"`
+		AuthorID         int           `json:"author_id"`
+		ChangePosition   *NotePosition `json:"change_position"`
+		CommitID         string        `json:"commit_id"`
+		CreatedAt        string        `json:"created_at"`
+		DiscussionID     string        `json:"discussion_id"`
+		ID               int           `json:"id"`
+		LineCode         string        `json:"line_code"`
+		Note             string        `json:"note"`
+		NoteableID       int           `json:"noteable_id"`
+		NoteableType     string        `json:"noteable_type"`
+		OriginalPosition *NotePosition `json:"original_position"`
+		Position         *NotePosition `json:"position"`
+		ProjectID        int           `json:"project_id"`
+		ResolvedAt       string        `json:"resolved_at"`
+		ResolvedByID     string        `json:"resolved_by_id"`
+		ResolvedByPush   string        `json:"resolved_by_push"`
+		StDiff           *Diff         `json:"st_diff"`
+		System           bool          `json:"system"`
+		Type             string        `json:"type"`
+		UpdatedAt        string        `json:"updated_at"`
+		UpdatedByID      string        `json:"updated_by_id"`
+		Description      string        `json:"description"`
+		URL              string        `json:"url"`
 	} `json:"object_attributes"`
 	Repository   *Repository `json:"repository"`
 	MergeRequest struct {

--- a/notes.go
+++ b/notes.go
@@ -70,18 +70,29 @@ type Note struct {
 
 // NotePosition represents the position attributes of a note.
 type NotePosition struct {
-	BaseSHA      string `json:"base_sha"`
-	StartSHA     string `json:"start_sha"`
-	HeadSHA      string `json:"head_sha"`
-	PositionType string `json:"position_type"`
-	NewPath      string `json:"new_path,omitempty"`
-	NewLine      int    `json:"new_line,omitempty"`
-	OldPath      string `json:"old_path,omitempty"`
-	OldLine      int    `json:"old_line,omitempty"`
-	Width        int    `json:"width,omitempty"`
-	Height       int    `json:"height,omitempty"`
-	X            int    `json:"x,omitempty"`
-	Y            int    `json:"y,omitempty"`
+	BaseSHA      string     `json:"base_sha"`
+	StartSHA     string     `json:"start_sha"`
+	HeadSHA      string     `json:"head_sha"`
+	PositionType string     `json:"position_type"`
+	NewPath      string     `json:"new_path,omitempty"`
+	NewLine      int        `json:"new_line,omitempty"`
+	OldPath      string     `json:"old_path,omitempty"`
+	OldLine      int        `json:"old_line,omitempty"`
+	LineRange    *LineRange `json:"line_range"`
+}
+
+// LineRange represents the range of a note.
+type LineRange struct {
+	StartRange *LinePosition `json:"start"`
+	EndRange   *LinePosition `json:"end"`
+}
+
+// LinePosition represents a position in a line range.
+type LinePosition struct {
+	LineCode string `json:"line_code"`
+	Type     string `json:"type"`
+	OldLine  int    `json:"old_line"`
+	NewLine  int    `json:"new_line"`
 }
 
 func (n Note) String() string {


### PR DESCRIPTION
This PR proposes two changes in current structs:
1. Updates the `NotePosition` struct;
2. Updates `ObjectAttributes` of the `MergeCommentEvent` struct.

Since [Gitlab docs](https://docs.gitlab.com/ce/user/project/integrations/webhooks.html#comment-on-merge-request) are currently outdated, I'm pasting here an example of the current payload regarding ObjectAttributes:
```
"object_attributes": {
    "attachment": null,
    "author_id": 4,
    "change_position": {
      "base_sha": null,
      "start_sha": null,
      "head_sha": null,
      "old_path": null,
      "new_path": null,
      "position_type": "text",
      "old_line": null,
      "new_line": null,
      "line_range": null
    },
    "commit_id": null,
    "created_at": "2020-12-17 21:00:48 UTC",
    "discussion_id": "8abd325c824df164f5f900b80b6231c37ac77ac3",
    "id": 26,
    "line_code": "a5cc2925ca8258af241be7e5b0381edf30266302_0_2",
    "note": "We should also change this.",
    "noteable_id": 3,
    "noteable_type": "MergeRequest",
    "original_position": {
      "base_sha": "b96ce44bec480dccb21423028f50cb8accccd0ce",
      "start_sha": "b96ce44bec480dccb21423028f50cb8accccd0ce",
      "head_sha": "a546fe4b1674eaf060915da86995cde3824d4622",
      "old_path": ".gitignore",
      "new_path": ".gitignore",
      "position_type": "text",
      "old_line": null,
      "new_line": 2,
      "line_range": {
        "start": {
          "line_code": "a5cc2925ca8258af241be7e5b0381edf30266302_0_2",
          "type": "new",
          "old_line": null,
          "new_line": 2
        },
        "end": {
          "line_code": "a5cc2925ca8258af241be7e5b0381edf30266302_0_2",
          "type": "new",
          "old_line": null,
          "new_line": 2
        }
      }
    },
    "position": {
      "base_sha": "b96ce44bec480dccb21423028f50cb8accccd0ce",
      "start_sha": "b96ce44bec480dccb21423028f50cb8accccd0ce",
      "head_sha": "a546fe4b1674eaf060915da86995cde3824d4622",
      "old_path": ".gitignore",
      "new_path": ".gitignore",
      "position_type": "text",
      "old_line": null,
      "new_line": 2,
      "line_range": {
        "start": {
          "line_code": "a5cc2925ca8258af241be7e5b0381edf30266302_0_2",
          "type": "new",
          "old_line": null,
          "new_line": 2
        },
        "end": {
          "line_code": "a5cc2925ca8258af241be7e5b0381edf30266302_0_2",
          "type": "new",
          "old_line": null,
          "new_line": 2
        }
      }
    },
    "project_id": 3,
    "resolved_at": null,
    "resolved_by_id": null,
    "resolved_by_push": null,
    "st_diff": null,
    "system": false,
    "type": "DiffNote",
    "updated_at": "2020-12-17 21:00:48 UTC",
    "updated_by_id": null,
    "description": "We should also change this.",
    "url": "https://gitlab.explore.dev/test/simple/-/merge_requests/1#note_26"
  },
```

I've used the order in the payload for the struct definition.

Closes #964.