### PR TITLE
Support ID field in contribution events

### DIFF
--- a/events.go
+++ b/events.go
@@ -34,6 +34,7 @@ type EventsService struct {
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/events.html#get-user-contribution-events
 type ContributionEvent struct {
+	ID          int        `json:"id"`
 	Title       string     `json:"title"`
 	ProjectID   int        `json:"project_id"`
 	ActionName  string     `json:"action_name"`


### PR DESCRIPTION
GitLab events also have a unique ID.

https://gitlab.com/gitlab-org/gitlab/-/blob/a523866d205c89f8a7fe94ca45be407f224c56e7/lib/api/entities/event.rb#L6