### PR TITLE
Bridge: Make Downstream Pipeline optional

### DIFF
--- a/jobs.go
+++ b/jobs.go
@@ -98,21 +98,13 @@ type Bridge struct {
 		UpdateAt  *time.Time `json:"updated_at"`
 		WebURL    string     `json:"web_url"`
 	} `json:"pipeline"`
-	Ref                string `json:"ref"`
-	Stage              string `json:"stage"`
-	Status             string `json:"status"`
-	Tag                bool   `json:"tag"`
-	WebURL             string `json:"web_url"`
-	User               *User  `json:"user"`
-	DownstreamPipeline *struct {
-		ID        int        `json:"id"`
-		Sha       string     `json:"sha"`
-		Ref       string     `json:"ref"`
-		Status    string     `json:"status"`
-		CreatedAt *time.Time `json:"created_at"`
-		UpdateAt  *time.Time `json:"updated_at"`
-		WebURL    string     `json:"web_url"`
-	} `json:"downstream_pipeline"`
+	Ref                string        `json:"ref"`
+	Stage              string        `json:"stage"`
+	Status             string        `json:"status"`
+	Tag                bool          `json:"tag"`
+	WebURL             string        `json:"web_url"`
+	User               *User         `json:"user"`
+	DownstreamPipeline *PipelineInfo `json:"downstream_pipeline"`
 }
 
 // ListJobsOptions are options for two list apis

--- a/jobs.go
+++ b/jobs.go
@@ -80,24 +80,16 @@ type Job struct {
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/jobs.html#list-pipeline-bridges
 type Bridge struct {
-	Commit       *Commit    `json:"commit"`
-	Coverage     float64    `json:"coverage"`
-	AllowFailure bool       `json:"allow_failure"`
-	CreatedAt    *time.Time `json:"created_at"`
-	StartedAt    *time.Time `json:"started_at"`
-	FinishedAt   *time.Time `json:"finished_at"`
-	Duration     float64    `json:"duration"`
-	ID           int        `json:"id"`
-	Name         string     `json:"name"`
-	Pipeline     struct {
-		ID        int        `json:"id"`
-		Ref       string     `json:"ref"`
-		Sha       string     `json:"sha"`
-		Status    string     `json:"status"`
-		CreatedAt *time.Time `json:"created_at"`
-		UpdateAt  *time.Time `json:"updated_at"`
-		WebURL    string     `json:"web_url"`
-	} `json:"pipeline"`
+	Commit             *Commit       `json:"commit"`
+	Coverage           float64       `json:"coverage"`
+	AllowFailure       bool          `json:"allow_failure"`
+	CreatedAt          *time.Time    `json:"created_at"`
+	StartedAt          *time.Time    `json:"started_at"`
+	FinishedAt         *time.Time    `json:"finished_at"`
+	Duration           float64       `json:"duration"`
+	ID                 int           `json:"id"`
+	Name               string        `json:"name"`
+	Pipeline           PipelineInfo  `json:"pipeline"`
 	Ref                string        `json:"ref"`
 	Stage              string        `json:"stage"`
 	Status             string        `json:"status"`

--- a/jobs.go
+++ b/jobs.go
@@ -104,7 +104,7 @@ type Bridge struct {
 	Tag                bool   `json:"tag"`
 	WebURL             string `json:"web_url"`
 	User               *User  `json:"user"`
-	DownstreamPipeline struct {
+	DownstreamPipeline *struct {
 		ID        int        `json:"id"`
 		Sha       string     `json:"sha"`
 		Ref       string     `json:"ref"`


### PR DESCRIPTION
In case pipelines with a bridge(trigger) job but the downstream pipeline
has yet been scheduled, the downstream object will be 'null'.

Make DownstreamPipeline in Bridge struct a pointer instead of value to
allow null to be detected.