### PR TITLE
Add job token support

### DIFF
--- a/gitlab.go
+++ b/gitlab.go
@@ -60,6 +60,7 @@ const (
 	basicAuth authType = iota
 	oAuthToken
 	privateToken
+	jobToken
 )
 
 // A Client manages communication with the GitLab API.
@@ -199,6 +200,18 @@ func NewClient(token string, options ...ClientOptionFunc) (*Client, error) {
 		return nil, err
 	}
 	client.authType = privateToken
+	client.token = token
+	return client, nil
+}
+
+// NewJobTokenClient returns a new GitLab API client. To use API methods which require
+// authentication, provide a valid job token(usually from CI_JOB_TOKEN environment variable).
+func NewJobTokenClient(token string, options ...ClientOptionFunc) (*Client, error) {
+	client, err := newClient(options...)
+	if err != nil {
+		return nil, err
+	}
+	client.authType = jobToken
 	client.token = token
 	return client, nil
 }
@@ -627,6 +640,8 @@ func (c *Client) Do(req *retryablehttp.Request, v interface{}) (*Response, error
 		req.Header.Set("Authorization", "Bearer "+c.token)
 	case privateToken:
 		req.Header.Set("PRIVATE-TOKEN", c.token)
+	case jobToken:
+		req.Header.Set("JOB-TOKEN", c.token)
 	}
 
 	resp, err := c.client.Do(req)


### PR DESCRIPTION
This pull request adds job token as an authentication method.

Some of the Gitlab APIs can be accessed with a job token, such as [create releases](https://gitlab.com/gitlab-org/gitlab-foss/-/blob/master/lib/api/releases.rb#L68):
```ruby
route_setting :authentication, job_token_allowed: true
post ':id/releases' do
```
And here is the corresponding function in go-gitlab:
https://github.com/xanzy/go-gitlab/blob/ea8a48513e1b409b760ebf3cfcbffb765ae2d40b/releases.go#L132-L143
I think it would be very nice to call allowed functions like this one with a job token provided by Gitlab CI, so that we don't need to pass an additional private token into a CI job.