### PR TITLE
fix(users.go): fix json unmarshal error of usermembership accesslevel

### DIFF
--- a/testdata/get_user_memberships.json
+++ b/testdata/get_user_memberships.json
@@ -3,12 +3,12 @@
     "source_id": 1,
     "source_name": "Project one",
     "source_type": "Project",
-    "access_level": "20"
+    "access_level": 20
   },
   {
     "source_id": 3,
     "source_name": "Group three",
     "source_type": "Namespace",
-    "access_level": "20"
+    "access_level": 20
   }
 ]

--- a/users.go
+++ b/users.go
@@ -942,10 +942,10 @@ func (s *UsersService) SetUserStatus(opt *UserStatusOptions, options ...RequestO
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/users.html#user-memberships-admin-only
 type UserMembership struct {
-	SourceID    int    `json:"source_id"`
-	SourceName  string `json:"source_name"`
-	SourceType  string `json:"source_type"`
-	AccessLevel string `json:"access_level"`
+	SourceID    int              `json:"source_id"`
+	SourceName  string           `json:"source_name"`
+	SourceType  string           `json:"source_type"`
+	AccessLevel AccessLevelValue `json:"access_level"`
 }
 
 // GetUserMembershipOptions represents the options available to query user memberships.

--- a/users_test.go
+++ b/users_test.go
@@ -253,6 +253,6 @@ func TestGetMemberships(t *testing.T) {
 	memberships, _, err := client.Users.GetUserMemberships(1, opt)
 	require.NoError(t, err)
 
-	want := []*UserMembership{{SourceID: 1, SourceName: "Project one", SourceType: "Project", AccessLevel: "20"}, {SourceID: 3, SourceName: "Group three", SourceType: "Namespace", AccessLevel: "20"}}
+	want := []*UserMembership{{SourceID: 1, SourceName: "Project one", SourceType: "Project", AccessLevel: 20}, {SourceID: 3, SourceName: "Group three", SourceType: "Namespace", AccessLevel: 20}}
 	assert.Equal(t, want, memberships)
 }


### PR DESCRIPTION
Fix json unmarshal error of usermembership accesslevel，the gitlab api response accesslevel int type, when unmarshal response will return 400