### PR TITLE
Return a *bytes.Reader instead of an io.Reader

### DIFF
--- a/jobs.go
+++ b/jobs.go
@@ -19,7 +19,6 @@ package gitlab
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"time"
 )
 
@@ -214,7 +213,7 @@ func (s *JobsService) GetJob(pid interface{}, jobID int, options ...RequestOptio
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/job_artifacts.html#get-job-artifacts
-func (s *JobsService) GetJobArtifacts(pid interface{}, jobID int, options ...RequestOptionFunc) (io.Reader, *Response, error) {
+func (s *JobsService) GetJobArtifacts(pid interface{}, jobID int, options ...RequestOptionFunc) (*bytes.Reader, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
@@ -232,7 +231,8 @@ func (s *JobsService) GetJobArtifacts(pid interface{}, jobID int, options ...Req
 		return nil, resp, err
 	}
 
-	return artifactsBuf, resp, err
+	artifactsReader := bytes.NewReader(artifactsBuf.Bytes())
+	return artifactsReader, resp, err
 }
 
 // DownloadArtifactsFileOptions represents the available DownloadArtifactsFile()
@@ -249,7 +249,7 @@ type DownloadArtifactsFileOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/job_artifacts.html#download-the-artifacts-archive
-func (s *JobsService) DownloadArtifactsFile(pid interface{}, refName string, opt *DownloadArtifactsFileOptions, options ...RequestOptionFunc) (io.Reader, *Response, error) {
+func (s *JobsService) DownloadArtifactsFile(pid interface{}, refName string, opt *DownloadArtifactsFileOptions, options ...RequestOptionFunc) (*bytes.Reader, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
@@ -267,7 +267,8 @@ func (s *JobsService) DownloadArtifactsFile(pid interface{}, refName string, opt
 		return nil, resp, err
 	}
 
-	return artifactsBuf, resp, err
+	artifactsReader := bytes.NewReader(artifactsBuf.Bytes())
+	return artifactsReader, resp, err
 }
 
 // DownloadSingleArtifactsFile download a file from the artifacts from the
@@ -277,7 +278,7 @@ func (s *JobsService) DownloadArtifactsFile(pid interface{}, refName string, opt
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/job_artifacts.html#download-a-single-artifact-file-by-job-id
-func (s *JobsService) DownloadSingleArtifactsFile(pid interface{}, jobID int, artifactPath string, options ...RequestOptionFunc) (io.Reader, *Response, error) {
+func (s *JobsService) DownloadSingleArtifactsFile(pid interface{}, jobID int, artifactPath string, options ...RequestOptionFunc) (*bytes.Reader, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
@@ -301,14 +302,15 @@ func (s *JobsService) DownloadSingleArtifactsFile(pid interface{}, jobID int, ar
 		return nil, resp, err
 	}
 
-	return artifactBuf, resp, err
+	artifactReader := bytes.NewReader(artifactBuf.Bytes())
+	return artifactReader, resp, err
 }
 
 // GetTraceFile gets a trace of a specific job of a project
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/jobs.html#get-a-trace-file
-func (s *JobsService) GetTraceFile(pid interface{}, jobID int, options ...RequestOptionFunc) (io.Reader, *Response, error) {
+func (s *JobsService) GetTraceFile(pid interface{}, jobID int, options ...RequestOptionFunc) (*bytes.Reader, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
@@ -326,7 +328,8 @@ func (s *JobsService) GetTraceFile(pid interface{}, jobID int, options ...Reques
 		return nil, resp, err
 	}
 
-	return traceBuf, resp, err
+	traceReader := bytes.NewReader(traceBuf.Bytes())
+	return traceReader, resp, err
 }
 
 // CancelJob cancels a single job of a project.

--- a/jobs.go
+++ b/jobs.go
@@ -231,8 +231,7 @@ func (s *JobsService) GetJobArtifacts(pid interface{}, jobID int, options ...Req
 		return nil, resp, err
 	}
 
-	artifactsReader := bytes.NewReader(artifactsBuf.Bytes())
-	return artifactsReader, resp, err
+	return bytes.NewReader(artifactsBuf.Bytes()), resp, err
 }
 
 // DownloadArtifactsFileOptions represents the available DownloadArtifactsFile()
@@ -267,8 +266,7 @@ func (s *JobsService) DownloadArtifactsFile(pid interface{}, refName string, opt
 		return nil, resp, err
 	}
 
-	artifactsReader := bytes.NewReader(artifactsBuf.Bytes())
-	return artifactsReader, resp, err
+	return bytes.NewReader(artifactsBuf.Bytes()), resp, err
 }
 
 // DownloadSingleArtifactsFile download a file from the artifacts from the
@@ -302,8 +300,7 @@ func (s *JobsService) DownloadSingleArtifactsFile(pid interface{}, jobID int, ar
 		return nil, resp, err
 	}
 
-	artifactReader := bytes.NewReader(artifactBuf.Bytes())
-	return artifactReader, resp, err
+	return bytes.NewReader(artifactBuf.Bytes()), resp, err
 }
 
 // GetTraceFile gets a trace of a specific job of a project
@@ -328,8 +325,7 @@ func (s *JobsService) GetTraceFile(pid interface{}, jobID int, options ...Reques
 		return nil, resp, err
 	}
 
-	traceReader := bytes.NewReader(traceBuf.Bytes())
-	return traceReader, resp, err
+	return bytes.NewReader(traceBuf.Bytes()), resp, err
 }
 
 // CancelJob cancels a single job of a project.


### PR DESCRIPTION
Change GetJobArtifacts, DownloadArtifactsFile, DownloadSingleArtifactsFile, and GetTraceFile to return a *bytes.Reader instead of an io.Reader.

This change makes it simple to e.g. unzip archive files without needing to first write the data to a file.

I don't see any applicable tests to touch up, I've tested it in a personal application that uses GetJobArtifacts to download and unpack artifact archive files and it works as expected.

Closes: #1023