### PR TITLE
Add reviewers field to MergeRequest

### DIFF
--- a/merge_requests.go
+++ b/merge_requests.go
@@ -48,6 +48,7 @@ type MergeRequest struct {
 	Author                    *BasicUser   `json:"author"`
 	Assignee                  *BasicUser   `json:"assignee"`
 	Assignees                 []*BasicUser `json:"assignees"`
+	Reviewers                 []*BasicUser `json:"reviewers"`
 	SourceProjectID           int          `json:"source_project_id"`
 	TargetProjectID           int          `json:"target_project_id"`
 	Labels                    Labels       `json:"labels"`

--- a/merge_requests_test.go
+++ b/merge_requests_test.go
@@ -114,6 +114,7 @@ func TestGetMergeRequest(t *testing.T) {
 	require.Equal(t, mergeRequest.Author, &ajk)
 	require.Equal(t, mergeRequest.Assignee, &tk)
 	require.Equal(t, mergeRequest.Assignees, []*BasicUser{&tk})
+	require.Equal(t, mergeRequest.Reviewers, []*BasicUser{&tk})
 	require.Equal(t, mergeRequest.Labels, labels)
 	require.Equal(t, mergeRequest.Squash, true)
 	require.Equal(t, mergeRequest.UserNotesCount, 245)

--- a/testdata/get_merge_request.json
+++ b/testdata/get_merge_request.json
@@ -42,6 +42,16 @@
       "web_url": "https://gitlab.com/tkuah"
     }
   ],
+  "reviewers": [
+    {
+      "id": 2535118,
+      "name": "Thong Kuah",
+      "username": "tkuah",
+      "state": "active",
+      "avatar_url": "https://secure.gravatar.com/avatar/f7b51bdd49a4914d29504d7ff4c3f7b9?s=80&d=identicon",
+      "web_url": "https://gitlab.com/tkuah"
+    }
+  ],
   "source_project_id": 278964,
   "target_project_id": 278964,
   "labels": [

--- a/testdata/get_merge_requests.json
+++ b/testdata/get_merge_requests.json
@@ -1,8 +1,7 @@
 [
   {
     "id": 35385049,
-    "iid": 15442,
-    "project_id": 278964,
+    "iid": 15442, "project_id": 278964,
     "title": "WIP: Use structured logging for DB load balancer",
     "description": "## What does this MR do?\r\n\r\n<!--\r\n\r\nDescribe in detail what your merge request does and why.\r\n\r\nAre there any risks involved with the proposed change? What additional\r\ntest coverage is introduced to offset the risk?\r\n\r\nPlease keep this description up-to-date with any discussion that takes\r\nplace so that reviewers can understand your intent. This is especially\r\nimportant if they didn't participate in the discussion.\r\n\r\n-->\r\n\r\nRelates to https://gitlab.com/gitlab-org/gitlab-ee/issues/13547 and https://gitlab.com/gitlab-org/gitlab-ee/issues/13548\r\n\r\n## Does this MR meet the acceptance criteria?\r\n\r\n### Conformity\r\n\r\n- [ ] [Changelog entry](https://docs.gitlab.com/ee/development/changelog.html) \r\n- [ ] [Documentation created/updated](https://docs.gitlab.com/ee/development/documentation/feature-change-workflow.html) or [follow-up review issue created](https://gitlab.com/gitlab-org/gitlab-ce/issues/new?issuable_template=Doc%20Review)\r\n- [ ] [Code review guidelines](https://docs.gitlab.com/ee/development/code_review.html)\r\n- [ ] [Merge request performance guidelines](https://docs.gitlab.com/ee/development/merge_request_performance_guidelines.html)\r\n- [ ] [Style guides](https://gitlab.com/gitlab-org/gitlab-ee/blob/master/doc/development/contributing/style_guides.md)\r\n- [ ] [Database guides](https://docs.gitlab.com/ee/development/README.html#databases-guides)\r\n- [ ] [Separation of EE specific content](https://docs.gitlab.com/ee/development/ee_features.html#separation-of-ee-code)\r\n\r\n### Performance and Testing\r\n\r\n<!-- What risks does this change pose? How might it affect the quality/performance of the product?\r\nWhat additional test coverage or changes to tests will be needed?\r\nWill it require cross-browser testing?\r\nSee the test engineering process for further guidelines: https://about.gitlab.com/handbook/engineering/quality/test-engineering/ -->\r\n\r\n<!-- If cross-browser testing is not required, please remove the relevant item, or mark it as not needed: [-] -->\r\n\r\n- [ ] [Review and add/update tests for this feature/bug](https://docs.gitlab.com/ee/development/testing_guide/index.html). Consider [all test levels](https://docs.gitlab.com/ee/development/testing_guide/testing_levels.html). See the [Test Planning Process](https://about.gitlab.com/handbook/engineering/quality/guidelines/test-engineering/).\r\n- [ ] [Tested in all supported browsers](https://docs.gitlab.com/ee/install/requirements.html#supported-web-browsers)\r\n\r\n### Security\r\n\r\nIf this MR contains changes to processing or storing of credentials or tokens, authorization and authentication methods and other items described in [the security review guidelines](https://about.gitlab.com/handbook/engineering/security/#when-to-request-a-security-review):\r\n\r\n- [ ] Label as ~security and @ mention `@gitlab-com/gl-security/appsec`\r\n- [ ] The MR includes necessary changes to maintain consistency between UI, API, email, or other methods\r\n- [ ] Security reports checked/validated by a reviewer from the AppSec team",
     "state": "opened",
@@ -42,6 +41,16 @@
         "avatar_url": "https://assets.gitlab-static.net/uploads/-/system/user/avatar/4088036/avatar.png",
         "web_url": "https://gitlab.com/hfyngvason"
       }
+    ],
+    "reviewers": [
+        {
+        "id": 2535118,
+        "name": "Thong Kuah",
+        "username": "tkuah",
+        "state": "active",
+        "avatar_url": "https://secure.gravatar.com/avatar/f7b51bdd49a4914d29504d7ff4c3f7b9?s=80&d=identicon",
+        "web_url": "https://gitlab.com/tkuah"
+        }
     ],
     "source_project_id": 278964,
     "target_project_id": 278964,


### PR DESCRIPTION
Since GitLab 13.7 by default there is a Reviewers available to merge
request.

At this time updating and creating merge request reviewers doesn't seem to possible.

See https://gitlab.com/gitlab-org/gitlab/-/issues/292714