### PR TITLE
Add support for packages APIs.

### DIFF
--- a/gitlab.go
+++ b/gitlab.go
@@ -144,6 +144,7 @@ type Client struct {
 	Namespaces            *NamespacesService
 	Notes                 *NotesService
 	NotificationSettings  *NotificationSettingsService
+	Packages              *PackagesService
 	PagesDomains          *PagesDomainsService
 	PipelineSchedules     *PipelineSchedulesService
 	PipelineTriggers      *PipelineTriggersService
@@ -309,6 +310,7 @@ func newClient(options ...ClientOptionFunc) (*Client, error) {
 	c.Namespaces = &NamespacesService{client: c}
 	c.Notes = &NotesService{client: c}
 	c.NotificationSettings = &NotificationSettingsService{client: c}
+	c.Packages = &PackagesService{client: c}
 	c.PagesDomains = &PagesDomainsService{client: c}
 	c.PipelineSchedules = &PipelineSchedulesService{client: c}
 	c.PipelineTriggers = &PipelineTriggersService{client: c}

--- a/packages.go
+++ b/packages.go
@@ -134,7 +134,8 @@ func (s *PackagesService) ListPackageFiles(pid interface{}, packageID int, opt *
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/packages/%d/package_files",
+	u := fmt.Sprintf(
+		"projects/%s/packages/%d/package_files",
 		pathEscape(project),
 		packageID,
 	)

--- a/packages.go
+++ b/packages.go
@@ -36,7 +36,7 @@ type Package struct {
 	ID        int        `json:"id"`
 	Name      string     `json:"name"`
 	Version   string     `json:"version"`
-	Type      string     `json:"package_type"`
+	PackageType      string     `json:"package_type"`
 	CreatedAt *time.Time `json:"created_at"`
 }
 

--- a/packages.go
+++ b/packages.go
@@ -79,11 +79,11 @@ func (s PackageFile) String() string {
 // https://docs.gitlab.com/ee/api/packages.html#within-a-project
 type ListProjectPackagesOptions struct {
 	ListOptions
-	OrderBy            string `url:"order_by,omitempty" json:"order_by,omitempty"`
-	Sort               string `url:"sort,omitempty" json:"sort,omitempty"`
-	PackageType        string `url:"package_type,omitempty" json:"package_type,omitempty"`
-	PackageName        string `url:"package_name,omitempty" json:"package_name,omitempty"`
-	IncludeVersionless bool   `url:"include_versionless,omitempty" json:"include_versionless,omitempty"`
+	OrderBy            *string `url:"order_by,omitempty" json:"order_by,omitempty"`
+	Sort               *string `url:"sort,omitempty" json:"sort,omitempty"`
+	PackageType        *string `url:"package_type,omitempty" json:"package_type,omitempty"`
+	PackageName        *string `url:"package_name,omitempty" json:"package_name,omitempty"`
+	IncludeVersionless *bool   `url:"include_versionless,omitempty" json:"include_versionless,omitempty"`
 }
 
 // ListProjectPackages gets a list of packages in a project.

--- a/packages.go
+++ b/packages.go
@@ -48,7 +48,7 @@ func (s Package) String() string {
 // PackageLinks holds links for itself and deleting.
 type PackageLinks struct {
 	WebPath       string `json:"web_path"`
-	DeleteApiPath string `json:"delete_api_path"`
+	DeleteAPIPath string `json:"delete_api_path"`
 }
 
 func (s PackageLinks) String() string {

--- a/packages.go
+++ b/packages.go
@@ -103,12 +103,12 @@ func (s *PackagesService) ListProjectPackages(pid interface{}, opt *ListProjectP
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/packages.html#delete-a-project-package
-func (s *PackagesService) DeleteProjectPackage(pid interface{}, packageId int, options ...RequestOptionFunc) (*Response, error) {
+func (s *PackagesService) DeleteProjectPackage(pid interface{}, packageID int, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/packages/%d", pathEscape(project), packageId)
+	u := fmt.Sprintf("projects/%s/packages/%d", pathEscape(project), packageID)
 
 	req, err := s.client.NewRequest("DELETE", u, nil, options)
 	if err != nil {
@@ -129,14 +129,14 @@ type ListPackageFilesOptions ListOptions
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/packages.html#list-package-files
-func (s *PackagesService) ListPackageFiles(pid interface{}, packageId int, opt *ListPackageFilesOptions, options ...RequestOptionFunc) ([]*PackageFile, *Response, error) {
+func (s *PackagesService) ListPackageFiles(pid interface{}, packageID int, opt *ListPackageFilesOptions, options ...RequestOptionFunc) ([]*PackageFile, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/packages/%d/package_files",
 		pathEscape(project),
-		packageId,
+		packageID,
 	)
 
 	req, err := s.client.NewRequest("GET", u, opt, options)

--- a/packages.go
+++ b/packages.go
@@ -49,7 +49,7 @@ func (s Package) String() string {
 // GitLab API docs: https://docs.gitlab.com/ee/api/packages.html
 type PackageFile struct {
 	ID        int        `json:"id"`
-	PackageId int        `json:"package_id"`
+	PackageID int        `json:"package_id"`
 	CreatedAt *time.Time `json:"created_at"`
 	FileName  string     `json:"file_name"`
 	Size      int        `json:"size"`

--- a/packages.go
+++ b/packages.go
@@ -1,0 +1,154 @@
+//
+// Copyright 2021, Kordian Bruck
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package gitlab
+
+import (
+	"fmt"
+	"time"
+)
+
+// PackagesService handles communication with the packages related methods
+// of the GitLab API.
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/packages.html
+type PackagesService struct {
+	client *Client
+}
+
+// Package represents a GitLab single package
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/packages.html
+type Package struct {
+	ID        int        `json:"id"`
+	Name      string     `json:"name"`
+	Version   string     `json:"version"`
+	Type      string     `json:"package_type"`
+	CreatedAt *time.Time `json:"created_at"`
+}
+
+func (s Package) String() string {
+	return Stringify(s)
+}
+
+// PackageFile represents one file contained within a package
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/packages.html
+type PackageFile struct {
+	ID        int        `json:"id"`
+	PackageId int        `json:"package_id"`
+	CreatedAt *time.Time `json:"created_at"`
+	FileName  string     `json:"file_name"`
+	Size      int        `json:"size"`
+	MD5       string     `json:"file_md5"`
+	SHA1      string     `json:"file_sha1"`
+}
+
+func (s PackageFile) String() string {
+	return Stringify(s)
+}
+
+// ListProjectPackagesOptions are the parameters available in a ListProjectPackages() Operation
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/packages.html#within-a-project
+type ListProjectPackagesOptions struct {
+	ListOptions
+	OrderBy            string `json:"order_by,omitempty"`
+	Sort               string `json:"sort,omitempty"`
+	Type               string `json:"package_type,omitempty"`
+	Name               string `json:"package_name,omitempty"`
+	IncludeVersionless bool   `json:"include_versionless,omitempty"`
+}
+
+// ListProjectPackages gets a list of packages in a project.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/packages.html#within-a-project
+func (s *PackagesService) ListProjectPackages(pid interface{}, opt *ListProjectPackagesOptions, options ...RequestOptionFunc) ([]*Package, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/packages", pathEscape(project))
+
+	req, err := s.client.NewRequest("GET", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var packages []*Package
+	resp, err := s.client.Do(req, &packages)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return packages, resp, err
+}
+
+// DeleteRegistryRepository deletes a repository in a registry.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/packages.html#delete-a-project-package
+func (s *PackagesService) DeleteProjectPackage(pid interface{}, packageId int, options ...RequestOptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/packages/%d", pathEscape(project), packageId)
+
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// ListPackageFilesOptions represents the available
+// ListPackageFiles() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/packages.html#list-package-files
+type ListPackageFilesOptions ListOptions
+
+// ListPackageFiles gets a list of files that are within a package
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/packages.html#list-package-files
+func (s *PackagesService) ListPackageFiles(pid interface{}, packageId int, opt *ListPackageFilesOptions, options ...RequestOptionFunc) ([]*PackageFile, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/packages/%d/package_files",
+		pathEscape(project),
+		packageId,
+	)
+
+	req, err := s.client.NewRequest("GET", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var tags []*PackageFile
+	resp, err := s.client.Do(req, &tags)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return tags, resp, err
+}

--- a/packages.go
+++ b/packages.go
@@ -69,7 +69,7 @@ type ListProjectPackagesOptions struct {
 	ListOptions
 	OrderBy            string `url:"order_by,omitempty" json:"order_by,omitempty"`
 	Sort               string `url:"sort,omitempty" json:"sort,omitempty"`
-	Type               string `url:"package_type,omitempty" json:"package_type,omitempty"`
+	PackageType               string `url:"package_type,omitempty" json:"package_type,omitempty"`
 	Name               string `url:"package_name,omitempty" json:"package_name,omitempty"`
 	IncludeVersionless bool   `url:"include_versionless,omitempty" json:"include_versionless,omitempty"`
 }

--- a/packages.go
+++ b/packages.go
@@ -67,11 +67,11 @@ func (s PackageFile) String() string {
 // https://docs.gitlab.com/ee/api/packages.html#within-a-project
 type ListProjectPackagesOptions struct {
 	ListOptions
-	OrderBy            string `json:"order_by,omitempty"`
-	Sort               string `json:"sort,omitempty"`
-	Type               string `json:"package_type,omitempty"`
-	Name               string `json:"package_name,omitempty"`
-	IncludeVersionless bool   `json:"include_versionless,omitempty"`
+	OrderBy            string `url:"order_by,omitempty" json:"order_by,omitempty"`
+	Sort               string `url:"sort,omitempty" json:"sort,omitempty"`
+	Type               string `url:"package_type,omitempty" json:"package_type,omitempty"`
+	Name               string `url:"package_name,omitempty" json:"package_name,omitempty"`
+	IncludeVersionless bool   `url:"include_versionless,omitempty" json:"include_versionless,omitempty"`
 }
 
 // ListProjectPackages gets a list of packages in a project.

--- a/packages.go
+++ b/packages.go
@@ -29,39 +29,51 @@ type PackagesService struct {
 	client *Client
 }
 
-// Package represents a GitLab single package
+// Package represents a GitLab single package.
 //
 // GitLab API docs: https://docs.gitlab.com/ee/api/packages.html
 type Package struct {
-	ID        int        `json:"id"`
-	Name      string     `json:"name"`
-	Version   string     `json:"version"`
-	PackageType      string     `json:"package_type"`
-	CreatedAt *time.Time `json:"created_at"`
+	ID          int           `json:"id"`
+	Name        string        `json:"name"`
+	Version     string        `json:"version"`
+	PackageType string        `json:"package_type"`
+	Links       *PackageLinks `json:"_links"`
+	CreatedAt   *time.Time    `json:"created_at"`
 }
 
 func (s Package) String() string {
 	return Stringify(s)
 }
 
-// PackageFile represents one file contained within a package
+// PackageLinks holds links for itself and deleting.
+type PackageLinks struct {
+	WebPath       string `json:"web_path"`
+	DeleteApiPath string `json:"delete_api_path"`
+}
+
+func (s PackageLinks) String() string {
+	return Stringify(s)
+}
+
+// PackageFile represents one file contained within a package.
 //
 // GitLab API docs: https://docs.gitlab.com/ee/api/packages.html
 type PackageFile struct {
-	ID        int        `json:"id"`
-	PackageID int        `json:"package_id"`
-	CreatedAt *time.Time `json:"created_at"`
-	FileName  string     `json:"file_name"`
-	Size      int        `json:"size"`
-	MD5       string     `json:"file_md5"`
-	SHA1      string     `json:"file_sha1"`
+	ID        int         `json:"id"`
+	PackageID int         `json:"package_id"`
+	CreatedAt *time.Time  `json:"created_at"`
+	FileName  string      `json:"file_name"`
+	Size      int         `json:"size"`
+	FileMD5   string      `json:"file_md5"`
+	FileSHA1  string      `json:"file_sha1"`
+	Pipeline  *[]Pipeline `json:"pipelines"`
 }
 
 func (s PackageFile) String() string {
 	return Stringify(s)
 }
 
-// ListProjectPackagesOptions are the parameters available in a ListProjectPackages() Operation
+// ListProjectPackagesOptions are the parameters available in a ListProjectPackages() Operation.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/packages.html#within-a-project
@@ -69,8 +81,8 @@ type ListProjectPackagesOptions struct {
 	ListOptions
 	OrderBy            string `url:"order_by,omitempty" json:"order_by,omitempty"`
 	Sort               string `url:"sort,omitempty" json:"sort,omitempty"`
-	PackageType               string `url:"package_type,omitempty" json:"package_type,omitempty"`
-	Name               string `url:"package_name,omitempty" json:"package_name,omitempty"`
+	PackageType        string `url:"package_type,omitempty" json:"package_type,omitempty"`
+	PackageName        string `url:"package_name,omitempty" json:"package_name,omitempty"`
 	IncludeVersionless bool   `url:"include_versionless,omitempty" json:"include_versionless,omitempty"`
 }
 
@@ -90,32 +102,13 @@ func (s *PackagesService) ListProjectPackages(pid interface{}, opt *ListProjectP
 		return nil, nil, err
 	}
 
-	var packages []*Package
-	resp, err := s.client.Do(req, &packages)
+	var ps []*Package
+	resp, err := s.client.Do(req, &ps)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return packages, resp, err
-}
-
-// DeleteRegistryRepository deletes a repository in a registry.
-//
-// GitLab API docs:
-// https://docs.gitlab.com/ee/api/packages.html#delete-a-project-package
-func (s *PackagesService) DeleteProjectPackage(pid interface{}, packageID int, options ...RequestOptionFunc) (*Response, error) {
-	project, err := parseID(pid)
-	if err != nil {
-		return nil, err
-	}
-	u := fmt.Sprintf("projects/%s/packages/%d", pathEscape(project), packageID)
-
-	req, err := s.client.NewRequest("DELETE", u, nil, options)
-	if err != nil {
-		return nil, err
-	}
-
-	return s.client.Do(req, nil)
+	return ps, resp, err
 }
 
 // ListPackageFilesOptions represents the available
@@ -129,7 +122,7 @@ type ListPackageFilesOptions ListOptions
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/packages.html#list-package-files
-func (s *PackagesService) ListPackageFiles(pid interface{}, packageID int, opt *ListPackageFilesOptions, options ...RequestOptionFunc) ([]*PackageFile, *Response, error) {
+func (s *PackagesService) ListPackageFiles(pid interface{}, pkg int, opt *ListPackageFilesOptions, options ...RequestOptionFunc) ([]*PackageFile, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
@@ -137,7 +130,7 @@ func (s *PackagesService) ListPackageFiles(pid interface{}, packageID int, opt *
 	u := fmt.Sprintf(
 		"projects/%s/packages/%d/package_files",
 		pathEscape(project),
-		packageID,
+		pkg,
 	)
 
 	req, err := s.client.NewRequest("GET", u, opt, options)
@@ -145,11 +138,30 @@ func (s *PackagesService) ListPackageFiles(pid interface{}, packageID int, opt *
 		return nil, nil, err
 	}
 
-	var tags []*PackageFile
-	resp, err := s.client.Do(req, &tags)
+	var pfs []*PackageFile
+	resp, err := s.client.Do(req, &pfs)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return tags, resp, err
+	return pfs, resp, err
+}
+
+// DeleteProjectPackage deletes a package in a project.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/packages.html#delete-a-project-package
+func (s *PackagesService) DeleteProjectPackage(pid interface{}, pkg int, options ...RequestOptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/packages/%d", pathEscape(project), pkg)
+
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
 }


### PR DESCRIPTION
This should be the basic supported for package apis requested in #1043 

* Listing packages in a project
* Listing package files 
* Deleting packages

Missing, but probably will do a separate PR for the following:

* Listing packages in a group
* Get a single project package (by ID only) - not sure this is that useful