### PR TITLE
Add allow_collaboration to MergeRequest struct

### DIFF
--- a/merge_requests.go
+++ b/merge_requests.go
@@ -105,6 +105,7 @@ type MergeRequest struct {
 	HasConflicts                bool `json:"has_conflicts"`
 	BlockingDiscussionsResolved bool `json:"blocking_discussions_resolved"`
 	Overflow                    bool `json:"overflow"`
+	AllowCollaboration          bool `json:"allow_collaboration"`
 }
 
 func (m MergeRequest) String() string {

--- a/merge_requests.go
+++ b/merge_requests.go
@@ -70,6 +70,7 @@ type MergeRequest struct {
 	ChangesCount              string       `json:"changes_count"`
 	ShouldRemoveSourceBranch  bool         `json:"should_remove_source_branch"`
 	ForceRemoveSourceBranch   bool         `json:"force_remove_source_branch"`
+	AllowCollaboration        bool         `json:"allow_collaboration"`
 	WebURL                    string       `json:"web_url"`
 	DiscussionLocked          bool         `json:"discussion_locked"`
 	Changes                   []struct {
@@ -105,7 +106,6 @@ type MergeRequest struct {
 	HasConflicts                bool `json:"has_conflicts"`
 	BlockingDiscussionsResolved bool `json:"blocking_discussions_resolved"`
 	Overflow                    bool `json:"overflow"`
-	AllowCollaboration          bool `json:"allow_collaboration"`
 }
 
 func (m MergeRequest) String() string {


### PR DESCRIPTION
The MergeRequest struct was missing the allow_collaboration parameter which is part of the "GET Single Merge Request" response payload

https://docs.gitlab.com/ce/api/merge_requests.html#get-single-mr