### PR TITLE
Use context while configuring limiter in requests

### DIFF
--- a/gitlab.go
+++ b/gitlab.go
@@ -408,7 +408,7 @@ func rateLimitBackoff(min, max time.Duration, attemptNum int, resp *http.Respons
 }
 
 // configureLimiter configures the rate limiter.
-func (c *Client) configureLimiter() error {
+func (c *Client) configureLimiter(ctx context.Context) error {
 	// Set default values for when rate limiting is disabled.
 	limit := rate.Inf
 	burst := 0
@@ -419,7 +419,7 @@ func (c *Client) configureLimiter() error {
 	}()
 
 	// Create a new request.
-	req, err := http.NewRequest(http.MethodGet, c.baseURL.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL.String(), nil)
 	if err != nil {
 		return err
 	}
@@ -607,7 +607,7 @@ func (r *Response) populatePageValues() {
 func (c *Client) Do(req *retryablehttp.Request, v interface{}) (*Response, error) {
 	// If not yet configured, try to configure the rate limiter. Fail
 	// silently as the limiter will be disabled in case of an error.
-	c.configureLimiterOnce.Do(func() { c.configureLimiter() })
+	c.configureLimiterOnce.Do(func() { c.configureLimiter(req.Context()) })
 
 	// Wait will block until the limiter can obtain a new token.
 	err := c.limiter.Wait(req.Context())


### PR DESCRIPTION
This merge request fixes the problem of ignoring context while do requests.

Consider the following program:
```go
git, err := gitlab.NewClient("yourtokengoeshere", gitlab.WithBaseURL("https://gitlab.unreachable.com"))
if err != nil {
	log.Fatal(err)
}

ctx, cancel := context.WithTimeout(context.Background(), 2 * time.Second)
defer cancel()

_, _, err = git.Users.CurrentUser(gitlab.WithContext(ctx))
if err != nil {
	log.Fatal(err)
}
```

It is expected that the program exits after 2 seconds and prints `context deadline exceeded` because GitLab server is unreachable. But it won't. Without my fix, the program exits only after 30 seconds.