### PR TITLE
Added support for group share with group api

### DIFF
--- a/groups.go
+++ b/groups.go
@@ -541,7 +541,7 @@ type ShareGroupWithGroupOptions struct {
 	ExpiresAt   *ISOTime          `url:"expires_at,omitempty" json:"expires_at,omitempty"`
 }
 
-// ShareGroupWithGroup allows to share a group with a group.
+// ShareGroupWithGroup shares a group with another group.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/groups.html#create-a-link-to-share-a-group-with-another-group

--- a/groups.go
+++ b/groups.go
@@ -531,19 +531,21 @@ func (s *GroupsService) DeleteGroupLDAPLinkForProvider(gid interface{}, provider
 	return s.client.Do(req, nil)
 }
 
-// GroupShareWithGroupOptions represents options to share group with groups
+// ShareGroupWithGroupOptions represents the available ShareGroupWithGroup() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/groups.html#share-groups-with-groups
-type GroupShareWithGroupOptions struct {
-	GroupID     *int              `url:"group_id" json:"group_id"`
-	GroupAccess *AccessLevelValue `url:"group_access" json:"group_access"`
-	ExpiresAt   *string           `url:"expires_at" json:"expires_at"`
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/groups.html#share-groups-with-groups
+type ShareGroupWithGroupOptions struct {
+	GroupID     *int              `url:"group_id,omitempty" json:"group_id,omitempty"`
+	GroupAccess *AccessLevelValue `url:"group_access,omitempty" json:"group_access,omitempty"`
+	ExpiresAt   *ISOTime          `url:"expires_at,omitempty" json:"expires_at,omitempty"`
 }
 
 // ShareGroupWithGroup allows to share a group with a group.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/groups.html#create-a-link-to-share-a-group-with-another-group
-func (s *GroupsService) ShareGroupWithGroup(gid interface{}, opt *GroupShareWithGroupOptions, options ...RequestOptionFunc) (*Group, *Response, error) {
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/groups.html#create-a-link-to-share-a-group-with-another-group
+func (s *GroupsService) ShareGroupWithGroup(gid interface{}, opt *ShareGroupWithGroupOptions, options ...RequestOptionFunc) (*Group, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
 		return nil, nil, err
@@ -564,10 +566,11 @@ func (s *GroupsService) ShareGroupWithGroup(gid interface{}, opt *GroupShareWith
 	return g, resp, err
 }
 
-// DeleteSharedGroupFromGroup allows to unshare a group from a group.
+// UnshareGroupFromGroup unshares a group from another group.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/groups.html#delete-link-sharing-group-with-another-group
-func (s *GroupsService) DeleteSharedGroupFromGroup(gid interface{}, groupID int, options ...RequestOptionFunc) (*Response, error) {
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/groups.html#delete-link-sharing-group-with-another-group
+func (s *GroupsService) UnshareGroupFromGroup(gid interface{}, groupID int, options ...RequestOptionFunc) (*Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
 		return nil, err

--- a/groups.go
+++ b/groups.go
@@ -531,6 +531,57 @@ func (s *GroupsService) DeleteGroupLDAPLinkForProvider(gid interface{}, provider
 	return s.client.Do(req, nil)
 }
 
+// GroupShareWithGroupOptions represents options to share group with groups
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/groups.html#share-groups-with-groups
+type GroupShareWithGroupOptions struct {
+	GroupID     *int              `url:"group_id" json:"group_id"`
+	GroupAccess *AccessLevelValue `url:"group_access" json:"group_access"`
+	ExpiresAt   *string           `url:"expires_at" json:"expires_at"`
+}
+
+// ShareGroupWithGroup allows to share a group with a group.
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/groups.html#create-a-link-to-share-a-group-with-another-group
+func (s *GroupsService) ShareGroupWithGroup(gid interface{}, opt *GroupShareWithGroupOptions, options ...RequestOptionFunc) (*Group, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/share", pathEscape(group))
+
+	req, err := s.client.NewRequest(http.MethodPost, u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	g := new(Group)
+	resp, err := s.client.Do(req, g)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return g, resp, err
+}
+
+// DeleteSharedGroupFromGroup allows to unshare a group from a group.
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/groups.html#delete-link-sharing-group-with-another-group
+func (s *GroupsService) DeleteSharedGroupFromGroup(gid interface{}, groupID int, options ...RequestOptionFunc) (*Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("groups/%s/share/%d", pathEscape(group), groupID)
+
+	req, err := s.client.NewRequest(http.MethodDelete, u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
 // GroupPushRules represents a group push rule.
 //
 // GitLab API docs:

--- a/groups_test.go
+++ b/groups_test.go
@@ -310,7 +310,7 @@ func TestShareGroupWithGroup(t *testing.T) {
 			fmt.Fprint(w, `{"id": 1, "name": "g"}`)
 		})
 
-	group, _, err := client.Groups.ShareGroupWithGroup(1, &GroupShareWithGroupOptions{
+	group, _, err := client.Groups.ShareGroupWithGroup(1, &ShareGroupWithGroupOptions{
 		GroupID:     Int(1),
 		GroupAccess: AccessLevel(DeveloperPermissions),
 	})
@@ -323,7 +323,7 @@ func TestShareGroupWithGroup(t *testing.T) {
 	}
 }
 
-func TestDeleteSharedGroupFromGroup(t *testing.T) {
+func TestUnshareGroupFromGroup(t *testing.T) {
 	mux, server, client := setup(t)
 	defer teardown(server)
 	mux.HandleFunc("/api/v4/groups/1/share/2",
@@ -332,11 +332,11 @@ func TestDeleteSharedGroupFromGroup(t *testing.T) {
 			w.WriteHeader(204)
 		})
 
-	r, err := client.Groups.DeleteSharedGroupFromGroup(1, 2)
+	r, err := client.Groups.UnshareGroupFromGroup(1, 2)
 	if err != nil {
-		t.Errorf("Groups.DeleteSharedGroupFromGroup returned error: %v", err)
+		t.Errorf("Groups.UnshareGroupFromGroup returned error: %v", err)
 	}
 	if r.StatusCode != 204 {
-		t.Errorf("Groups.DeleteSharedGroupFromGroup returned status code %d", r.StatusCode)
+		t.Errorf("Groups.UnshareGroupFromGroup returned status code %d", r.StatusCode)
 	}
 }

--- a/groups_test.go
+++ b/groups_test.go
@@ -300,3 +300,43 @@ func TestRestoreGroup(t *testing.T) {
 		t.Errorf("Groups.RestoreGroup returned %+v, want %+v", group, want)
 	}
 }
+
+func TestShareGroupWithGroup(t *testing.T) {
+	mux, server, client := setup(t)
+	defer teardown(server)
+	mux.HandleFunc("/api/v4/groups/1/share",
+		func(w http.ResponseWriter, r *http.Request) {
+			testMethod(t, r, http.MethodPost)
+			fmt.Fprint(w, `{"id": 1, "name": "g"}`)
+		})
+
+	group, _, err := client.Groups.ShareGroupWithGroup(1, &GroupShareWithGroupOptions{
+		GroupID:     Int(1),
+		GroupAccess: AccessLevel(DeveloperPermissions),
+	})
+	if err != nil {
+		t.Errorf("Groups.ShareGroupWithGroup returned error: %v", err)
+	}
+	want := &Group{ID: 1, Name: "g"}
+	if !reflect.DeepEqual(want, group) {
+		t.Errorf("Groups.ShareGroupWithGroup returned %+v, want %+v", group, want)
+	}
+}
+
+func TestDeleteSharedGroupFromGroup(t *testing.T) {
+	mux, server, client := setup(t)
+	defer teardown(server)
+	mux.HandleFunc("/api/v4/groups/1/share/2",
+		func(w http.ResponseWriter, r *http.Request) {
+			testMethod(t, r, http.MethodDelete)
+			w.WriteHeader(204)
+		})
+
+	r, err := client.Groups.DeleteSharedGroupFromGroup(1, 2)
+	if err != nil {
+		t.Errorf("Groups.DeleteSharedGroupFromGroup returned error: %v", err)
+	}
+	if r.StatusCode != 204 {
+		t.Errorf("Groups.DeleteSharedGroupFromGroup returned status code %d", r.StatusCode)
+	}
+}


### PR DESCRIPTION
This PR adds support to share a group with another group.  Its the equivalent of `Projects.ShareProjectWithGroup` and `Projects.DeleteSharedProjectFromGroup` for groups.

API: https://docs.gitlab.com/ee/api/groups.html#create-a-link-to-share-a-group-with-another-group