### PR TITLE
renamed FileAction to FileActionValue + added helper function

### DIFF
--- a/commits.go
+++ b/commits.go
@@ -197,13 +197,13 @@ type CreateCommitOptions struct {
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/commits.html#create-a-commit-with-multiple-files-and-actions
 type CommitActionOptions struct {
-	Action          *FileAction `url:"action,omitempty" json:"action,omitempty"`
-	FilePath        *string     `url:"file_path,omitempty" json:"file_path,omitempty"`
-	PreviousPath    *string     `url:"previous_path,omitempty" json:"previous_path,omitempty"`
-	Content         *string     `url:"content,omitempty" json:"content,omitempty"`
-	Encoding        *string     `url:"encoding,omitempty" json:"encoding,omitempty"`
-	LastCommitID    *string     `url:"last_commit_id,omitempty" json:"last_commit_id,omitempty"`
-	ExecuteFilemode *bool       `url:"execute_filemode,omitempty" json:"execute_filemode,omitempty"`
+	Action          *FileActionValue `url:"action,omitempty" json:"action,omitempty"`
+	FilePath        *string          `url:"file_path,omitempty" json:"file_path,omitempty"`
+	PreviousPath    *string          `url:"previous_path,omitempty" json:"previous_path,omitempty"`
+	Content         *string          `url:"content,omitempty" json:"content,omitempty"`
+	Encoding        *string          `url:"encoding,omitempty" json:"encoding,omitempty"`
+	LastCommitID    *string          `url:"last_commit_id,omitempty" json:"last_commit_id,omitempty"`
+	ExecuteFilemode *bool            `url:"execute_filemode,omitempty" json:"execute_filemode,omitempty"`
 }
 
 // CreateCommit creates a commit with multiple files and actions.

--- a/types.go
+++ b/types.go
@@ -121,18 +121,26 @@ func DeploymentStatus(v DeploymentStatusValue) *DeploymentStatusValue {
 	return p
 }
 
-// FileAction represents the available actions that can be performed on a file.
+// FileActionValue represents the available actions that can be performed on a file.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/commits.html#create-a-commit-with-multiple-files-and-actions
-type FileAction string
+type FileActionValue string
 
 // The available file actions.
 const (
-	FileCreate FileAction = "create"
-	FileDelete FileAction = "delete"
-	FileMove   FileAction = "move"
-	FileUpdate FileAction = "update"
+	FileCreate FileActionValue = "create"
+	FileDelete FileActionValue = "delete"
+	FileMove   FileActionValue = "move"
+	FileUpdate FileActionValue = "update"
 )
+
+// FileAction is a helper routine that allocates a new FileActionValue value
+// to store v and returns a pointer to it.
+func FileAction(v FileActionValue) *FileActionValue {
+	p := new(FileActionValue)
+	*p = v
+	return p
+}
 
 // ISOTime represents an ISO 8601 formatted date
 type ISOTime time.Time


### PR DESCRIPTION
renamed `FileAction` to `FileActionValue` + added helper function
```go
func FileAction(v FileActionValue) *FileActionValue
```
that helps instantiate `*FileActionValue` type required in Commits API (commits.go).
breaks BC
close #1063