### PR TITLE
Add total_time_spent to IssueEvent

### DIFF
--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -191,6 +191,10 @@ type IssueEvent struct {
 			Previous int `json:"previous"`
 			Current  int `json:"current"`
 		} `json:"updated_by_id"`
+		TotalTimeSpent struct {
+			Previous int `json:"previous"`
+			Current  int `json:"current"`
+		} `json:"total_time_spent"`
 	} `json:"changes"`
 }
 

--- a/event_webhook_types_test.go
+++ b/event_webhook_types_test.go
@@ -232,3 +232,23 @@ func TestDeploymentEventUnmarshal(t *testing.T) {
 		t.Errorf("CommitTitle is %s, want %s", event.CommitTitle, "Add new file")
 	}
 }
+
+func TestIssueEventUnmarshal(t *testing.T) {
+	jsonObject := loadFixture("testdata/webhooks/issue.json")
+
+	var event *IssueEvent
+	err := json.Unmarshal(jsonObject, &event)
+
+	if err != nil {
+		t.Errorf("Deployment Event can not unmarshaled: %v\n ", err.Error())
+	}
+	if event.Project.ID != 1 {
+		t.Errorf("Project.ID is %v, want %v", event.Project.ID, 1)
+	}
+	if event.Changes.TotalTimeSpent.Previous != 8100 {
+		t.Errorf("Changes.TotalTimeSpent.Previous is %v , want %v", event.Changes.TotalTimeSpent.Previous, 8100)
+	}
+	if event.Changes.TotalTimeSpent.Current != 9900 {
+		t.Errorf("Changes.TotalTimeSpent.Current is %v , want %v", event.Changes.TotalTimeSpent.Current, 8100)
+	}
+}

--- a/testdata/webhooks/issue.json
+++ b/testdata/webhooks/issue.json
@@ -110,6 +110,10 @@
     "title": {
       "previous": null,
       "current": "New title"
+    },
+    "total_time_spent": {
+      "previous": 8100,
+      "current": 9900
     }
   }
 }


### PR DESCRIPTION
This PR add total_time_spent to IssueEvent , this field is present in payloads when a quick action "/spend " is called in a gitlab issue 

Example from  [Example Issue](https://gitlab.com/janmgr/my-awesome-project/-/issues/1l)
```json
{
  "object_kind": "issue",
  "event_type": "issue",
  "user": {
    "id": 4403527,
    "name": "Jan Gallardo",
    "username": "janmgr",
    "avatar_url": "https://assets.gitlab-static.net/uploads/-/system/user/avatar/4403527/avatar.png",
    "email": "jmgr@outlook.cl"
  },
  "project": {
    "id": 15923137,
    "name": "My Awesome Project",
    "description": "",
    "web_url": "https://gitlab.com/janmgr/my-awesome-project",
    "avatar_url": null,
    "git_ssh_url": "git@gitlab.com:janmgr/my-awesome-project.git",
    "git_http_url": "https://gitlab.com/janmgr/my-awesome-project.git",
    "namespace": "Jan Gallardo",
    "visibility_level": 0,
    "path_with_namespace": "janmgr/my-awesome-project",
    "default_branch": null,
    "ci_config_path": null,
    "homepage": "https://gitlab.com/janmgr/my-awesome-project",
    "url": "git@gitlab.com:janmgr/my-awesome-project.git",
    "ssh_url": "git@gitlab.com:janmgr/my-awesome-project.git",
    "http_url": "https://gitlab.com/janmgr/my-awesome-project.git"
  },
  "object_attributes": {
    "author_id": 4403527,
    "closed_at": null,
    "confidential": false,
    "created_at": "2021-02-12 20:26:19 UTC",
    "description": "",
    "discussion_locked": null,
    "due_date": null,
    "id": 78998387,
    "iid": 1,
    "last_edited_at": null,
    "last_edited_by_id": null,
    "milestone_id": null,
    "moved_to_id": null,
    "duplicated_to_id": null,
    "project_id": 15923137,
    "relative_position": 513,
    "state_id": 1,
    "time_estimate": 0,
    "title": "test issue",
    "updated_at": "2021-02-12 20:26:46 UTC",
    "updated_by_id": 4403527,
    "weight": null,
    "url": "https://gitlab.com/janmgr/my-awesome-project/-/issues/1",
    "total_time_spent": 3600,
    "human_total_time_spent": "1h",
    "human_time_estimate": null,
    "assignee_ids": [

    ],
    "assignee_id": null,
    "labels": [

    ],
    "state": "opened",
    "action": "update"
  },
  "labels": [

  ],
  "changes": {
    "updated_at": {
      "previous": "2021-02-12 20:26:19 UTC",
      "current": "2021-02-12 20:26:46 UTC"
    },
    "updated_by_id": {
      "previous": null,
      "current": 4403527
    },
    "total_time_spent": {
      "previous": 0,
      "current": 3600
    }
  },
  "repository": {
    "name": "My Awesome Project",
    "url": "git@gitlab.com:janmgr/my-awesome-project.git",
    "description": "",
    "homepage": "https://gitlab.com/janmgr/my-awesome-project"
  }
}
```