### PR TITLE
FIX(repository_files): Fix Filename Escape

### DIFF
--- a/repository_files.go
+++ b/repository_files.go
@@ -112,7 +112,7 @@ func (s *RepositoryFilesService) GetFileMetaData(pid interface{}, fileName strin
 	u := fmt.Sprintf(
 		"projects/%s/repository/files/%s",
 		pathEscape(project),
-		pathEscape(url.PathEscape(fileName)),
+		pathEscape(fileName),
 	)
 
 	req, err := s.client.NewRequest(http.MethodHead, u, opt, options)

--- a/repository_files.go
+++ b/repository_files.go
@@ -112,7 +112,7 @@ func (s *RepositoryFilesService) GetFileMetaData(pid interface{}, fileName strin
 	u := fmt.Sprintf(
 		"projects/%s/repository/files/%s",
 		pathEscape(project),
-		url.PathEscape(fileName),
+		pathEscape(url.PathEscape(fileName)),
 	)
 
 	req, err := s.client.NewRequest(http.MethodHead, u, opt, options)


### PR DESCRIPTION
here should use  `pathEscape` to parse `.` to `%2E`

not so some filename(most of normally) with `.` will return file not found 

[gitlab doc](https://docs.gitlab.com/ce/api/repository_files.html#get-raw-file-from-repository)