### PR TITLE
fix(repository_files): fix filename escape

### DIFF
--- a/repository_files.go
+++ b/repository_files.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
-	"net/url"
 	"strconv"
 	"time"
 )
@@ -74,7 +73,7 @@ func (s *RepositoryFilesService) GetFile(pid interface{}, fileName string, opt *
 	u := fmt.Sprintf(
 		"projects/%s/repository/files/%s",
 		pathEscape(project),
-		url.PathEscape(fileName),
+		pathEscape(fileName),
 	)
 
 	req, err := s.client.NewRequest(http.MethodGet, u, opt, options)
@@ -189,7 +188,7 @@ func (s *RepositoryFilesService) GetFileBlame(pid interface{}, file string, opt 
 	u := fmt.Sprintf(
 		"projects/%s/repository/files/%s/blame",
 		pathEscape(project),
-		url.PathEscape(file),
+		pathEscape(file),
 	)
 
 	req, err := s.client.NewRequest(http.MethodGet, u, opt, options)
@@ -226,7 +225,7 @@ func (s *RepositoryFilesService) GetRawFile(pid interface{}, fileName string, op
 	u := fmt.Sprintf(
 		"projects/%s/repository/files/%s/raw",
 		pathEscape(project),
-		url.PathEscape(fileName),
+		pathEscape(fileName),
 	)
 
 	req, err := s.client.NewRequest(http.MethodGet, u, opt, options)
@@ -281,7 +280,7 @@ func (s *RepositoryFilesService) CreateFile(pid interface{}, fileName string, op
 	u := fmt.Sprintf(
 		"projects/%s/repository/files/%s",
 		pathEscape(project),
-		url.PathEscape(fileName),
+		pathEscape(fileName),
 	)
 
 	req, err := s.client.NewRequest(http.MethodPost, u, opt, options)
@@ -325,7 +324,7 @@ func (s *RepositoryFilesService) UpdateFile(pid interface{}, fileName string, op
 	u := fmt.Sprintf(
 		"projects/%s/repository/files/%s",
 		pathEscape(project),
-		url.PathEscape(fileName),
+		pathEscape(fileName),
 	)
 
 	req, err := s.client.NewRequest(http.MethodPut, u, opt, options)
@@ -367,7 +366,7 @@ func (s *RepositoryFilesService) DeleteFile(pid interface{}, fileName string, op
 	u := fmt.Sprintf(
 		"projects/%s/repository/files/%s",
 		pathEscape(project),
-		url.PathEscape(fileName),
+		pathEscape(fileName),
 	)
 
 	req, err := s.client.NewRequest(http.MethodDelete, u, opt, options)


### PR DESCRIPTION
it seems that all filename param in this api scope have the same issue so they need add the `.` escape