### PR TITLE
Add moved_to_id as an issue attribute

### DIFF
--- a/issues.go
+++ b/issues.go
@@ -98,6 +98,7 @@ type Issue struct {
 	ClosedBy             *IssueCloser     `json:"closed_by"`
 	Title                string           `json:"title"`
 	CreatedAt            *time.Time       `json:"created_at"`
+	MovedToID            int              `json:"moved_to_id"`
 	Labels               Labels           `json:"labels"`
 	LabelDetails         []*LabelDetails  `json:"label_details"`
 	Upvotes              int              `json:"upvotes"`


### PR DESCRIPTION
This field references the global id for an issue that has been moved to another proejct. It is null for issues that have never been moved.