### PR TITLE
Fix struct field types for MergeCommentEvent.ObjectAttributes.ResolvedByID and ResolvedByPush

### DIFF
--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -348,8 +348,8 @@ type MergeCommentEvent struct {
 		Position         *NotePosition `json:"position"`
 		ProjectID        int           `json:"project_id"`
 		ResolvedAt       string        `json:"resolved_at"`
-		ResolvedByID     string        `json:"resolved_by_id"`
-		ResolvedByPush   string        `json:"resolved_by_push"`
+		ResolvedByID     int           `json:"resolved_by_id"`
+		ResolvedByPush   bool          `json:"resolved_by_push"`
 		StDiff           *Diff         `json:"st_diff"`
 		System           bool          `json:"system"`
 		Type             string        `json:"type"`


### PR DESCRIPTION
Taken from a GitLab.com instance webhook some hours ago:

```
"object_attributes": {
  ...
  "resolved_by_id": 4872349,
  "resolved_by_push": false,
  ...
}
```

The GitLab docs don't mention the fields unfortunately in their example.

I can add a test but I wasn't sure if I should just duplicate `note_merge_request` - let me know how to handle the different variations here if needed :)