### PR TITLE
Add support for the Release webhook

### DIFF
--- a/event_parsing.go
+++ b/event_parsing.go
@@ -37,10 +37,10 @@ const (
 	EventConfidentialNote  EventType = "Confidential Note Hook"
 	EventTypePipeline      EventType = "Pipeline Hook"
 	EventTypePush          EventType = "Push Hook"
+	EventTypeRelease       EventType = "Release Hook"
 	EventTypeSystemHook    EventType = "System Hook"
 	EventTypeTagPush       EventType = "Tag Push Hook"
 	EventTypeWikiPage      EventType = "Wiki Page Hook"
-	EventTypeRelease       EventType = "Release Hook"
 )
 
 const (
@@ -203,8 +203,6 @@ func ParseWebhook(eventType EventType, payload []byte) (event interface{}, err e
 		event = &BuildEvent{}
 	case EventTypeDeployment:
 		event = &DeploymentEvent{}
-	case EventTypeRelease:
-		event = &ReleaseEvent{}
 	case EventTypeIssue, EventConfidentialIssue:
 		event = &IssueEvent{}
 	case EventTypeJob:
@@ -215,6 +213,8 @@ func ParseWebhook(eventType EventType, payload []byte) (event interface{}, err e
 		event = &PipelineEvent{}
 	case EventTypePush:
 		event = &PushEvent{}
+	case EventTypeRelease:
+		event = &ReleaseEvent{}
 	case EventTypeTagPush:
 		event = &TagEvent{}
 	case EventTypeWikiPage:

--- a/event_parsing.go
+++ b/event_parsing.go
@@ -40,6 +40,7 @@ const (
 	EventTypeSystemHook    EventType = "System Hook"
 	EventTypeTagPush       EventType = "Tag Push Hook"
 	EventTypeWikiPage      EventType = "Wiki Page Hook"
+	EventTypeRelease       EventType = "Release Hook"
 )
 
 const (
@@ -202,6 +203,8 @@ func ParseWebhook(eventType EventType, payload []byte) (event interface{}, err e
 		event = &BuildEvent{}
 	case EventTypeDeployment:
 		event = &DeploymentEvent{}
+	case EventTypeRelease:
+		event = &ReleaseEvent{}
 	case EventTypeIssue, EventConfidentialIssue:
 		event = &IssueEvent{}
 	case EventTypeJob:

--- a/event_parsing_webhook_test.go
+++ b/event_parsing_webhook_test.go
@@ -324,6 +324,28 @@ func TestParseWikiPageHook(t *testing.T) {
 	}
 }
 
+func TestParseReleaseHook(t *testing.T) {
+	raw := loadFixture("testdata/webhooks/release.json")
+
+	parsedEvent, err := ParseWebhook("Release Hook", raw)
+	if err != nil {
+		t.Errorf("Error parsing release hook: %s", err)
+	}
+
+	event, ok := parsedEvent.(*ReleaseEvent)
+	if !ok {
+		t.Errorf("Expected ReleaseEvent, but parsing produced %T", parsedEvent)
+	}
+
+	if event.ObjectKind != "release" {
+		t.Errorf("ObjectKind is %v, want %v", event.ObjectKind, "release")
+	}
+
+	if event.Project.Name != "Project Name" {
+		t.Errorf("Project name is %v, want %v", event.Project.Name, "Project Name")
+	}
+}
+
 func TestParsePipelineHook(t *testing.T) {
 	raw := loadFixture("testdata/webhooks/pipeline.json")
 

--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -940,6 +940,13 @@ type ReleaseEvent struct {
 	Action string `json:"action"`
 	Assets struct {
 		Count int `json:"count"`
+		Links []struct {
+			ID       int    `json:"id"`
+			External bool   `json:"external"`
+			LinkType string `json:"link_type"`
+			Name     string `json:"name"`
+			URL      string `json:"url"`
+		} `json:"links"`
 		Sources []struct {
 			Format string `json:"format"`
 			URL    string `json:"url"`

--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -905,3 +905,55 @@ type DeploymentEvent struct {
 	CommitURL   string `json:"commit_url"`
 	CommitTitle string `json:"commit_title"`
 }
+
+// ReleaseEvent represents a release event
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/user/project/integrations/webhooks.html#release-events
+type ReleaseEvent struct {
+	ID          int    `json:"id"`
+	CreatedAt   string `json:"created_at"` // Should be *time.Time (see Gitlab issue #21468)
+	Description string `json:"description"`
+	Name        string `json:"name"`
+	Tag         string `json:"tag"`
+	ReleasedAt  string `json:"released_at"` // Should be *time.Time (see Gitlab issue #21468)
+	ObjectKind  string `json:"object_kind"`
+	Project     struct {
+		ID                int     `json:"id"`
+		Name              string  `json:"name"`
+		Description       string  `json:"description"`
+		WebURL            string  `json:"web_url"`
+		AvatarURL         *string `json:"avatar_url"`
+		GitSSHURL         string  `json:"git_ssh_url"`
+		GitHTTPURL        string  `json:"git_http_url"`
+		Namespace         string  `json:"namespace"`
+		VisibilityLevel   int     `json:"visibility_level"`
+		PathWithNamespace string  `json:"path_with_namespace"`
+		DefaultBranch     string  `json:"default_branch"`
+		CIConfigPath      string  `json:"ci_config_path"`
+		Homepage          string  `json:"homepage"`
+		URL               string  `json:"url"`
+		SSHURL            string  `json:"ssh_url"`
+		HTTPURL           string  `json:"http_url"`
+	} `json:"project"`
+	URL    string `json:"url"`
+	Action string `json:"action"`
+	Assets struct {
+		Count int `json:"count"`
+		Sources []struct {
+			Format string `json:"format"`
+			URL    string `json:"url"`
+		} `json:"sources"`
+	} `json:"assets"`
+	Commit struct {
+		ID        string `json:"id"`
+		Message   string `json:"message"`
+		Title     string `json:"title"`
+		Timestamp string `json:"timestamp"` // Should be *time.Time (see Gitlab issue #21468)
+		URL       string `json:"url"`
+		Author    struct {
+			Name  string `json:"name"`
+			Email string `json:"email"`
+		} `json:"author"`
+	} `json:"commit"`
+}

--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -23,72 +23,54 @@ import (
 	"time"
 )
 
-// PushEvent represents a push event.
+//BuildEvent represents a build event
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/user/project/integrations/webhooks.html#push-events
-type PushEvent struct {
-	ObjectKind   string `json:"object_kind"`
-	Before       string `json:"before"`
-	After        string `json:"after"`
-	Ref          string `json:"ref"`
-	CheckoutSHA  string `json:"checkout_sha"`
-	UserID       int    `json:"user_id"`
-	UserName     string `json:"user_name"`
-	UserUsername string `json:"user_username"`
-	UserEmail    string `json:"user_email"`
-	UserAvatar   string `json:"user_avatar"`
-	ProjectID    int    `json:"project_id"`
-	Project      struct {
-		Name              string          `json:"name"`
-		Description       string          `json:"description"`
-		AvatarURL         string          `json:"avatar_url"`
-		GitSSHURL         string          `json:"git_ssh_url"`
-		GitHTTPURL        string          `json:"git_http_url"`
-		Namespace         string          `json:"namespace"`
-		PathWithNamespace string          `json:"path_with_namespace"`
-		DefaultBranch     string          `json:"default_branch"`
-		Homepage          string          `json:"homepage"`
-		URL               string          `json:"url"`
-		SSHURL            string          `json:"ssh_url"`
-		HTTPURL           string          `json:"http_url"`
-		WebURL            string          `json:"web_url"`
-		Visibility        VisibilityValue `json:"visibility"`
-	} `json:"project"`
+// https://docs.gitlab.com/ce/user/project/integrations/webhooks.html#build-events
+type BuildEvent struct {
+	ObjectKind        string  `json:"object_kind"`
+	Ref               string  `json:"ref"`
+	Tag               bool    `json:"tag"`
+	BeforeSHA         string  `json:"before_sha"`
+	SHA               string  `json:"sha"`
+	BuildID           int     `json:"build_id"`
+	BuildName         string  `json:"build_name"`
+	BuildStage        string  `json:"build_stage"`
+	BuildStatus       string  `json:"build_status"`
+	BuildStartedAt    string  `json:"build_started_at"`
+	BuildFinishedAt   string  `json:"build_finished_at"`
+	BuildDuration     float64 `json:"build_duration"`
+	BuildAllowFailure bool    `json:"build_allow_failure"`
+	ProjectID         int     `json:"project_id"`
+	ProjectName       string  `json:"project_name"`
+	User              struct {
+		ID    int    `json:"id"`
+		Name  string `json:"name"`
+		Email string `json:"email"`
+	} `json:"user"`
+	Commit struct {
+		ID          int    `json:"id"`
+		SHA         string `json:"sha"`
+		Message     string `json:"message"`
+		AuthorName  string `json:"author_name"`
+		AuthorEmail string `json:"author_email"`
+		Status      string `json:"status"`
+		Duration    int    `json:"duration"`
+		StartedAt   string `json:"started_at"`
+		FinishedAt  string `json:"finished_at"`
+	} `json:"commit"`
 	Repository *Repository `json:"repository"`
-	Commits    []*struct {
-		ID        string     `json:"id"`
-		Message   string     `json:"message"`
-		Timestamp *time.Time `json:"timestamp"`
-		URL       string     `json:"url"`
-		Author    struct {
-			Name  string `json:"name"`
-			Email string `json:"email"`
-		} `json:"author"`
-		Added    []string `json:"added"`
-		Modified []string `json:"modified"`
-		Removed  []string `json:"removed"`
-	} `json:"commits"`
-	TotalCommitsCount int `json:"total_commits_count"`
 }
 
-// TagEvent represents a tag event.
+// CommitCommentEvent represents a comment on a commit event.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/user/project/integrations/webhooks.html#tag-events
-type TagEvent struct {
-	ObjectKind  string `json:"object_kind"`
-	Before      string `json:"before"`
-	After       string `json:"after"`
-	Ref         string `json:"ref"`
-	CheckoutSHA string `json:"checkout_sha"`
-	UserID      int    `json:"user_id"`
-	UserName    string `json:"user_name"`
-	UserAvatar  string `json:"user_avatar"`
-	UserEmail   string `json:"user_email"`
-	ProjectID   int    `json:"project_id"`
-	Message     string `json:"message"`
-	Project     struct {
+// https://docs.gitlab.com/ce/user/project/integrations/webhooks.html#comment-on-commit
+type CommitCommentEvent struct {
+	ObjectKind string `json:"object_kind"`
+	User       *User  `json:"user"`
+	ProjectID  int    `json:"project_id"`
+	Project    struct {
 		Name              string          `json:"name"`
 		Description       string          `json:"description"`
 		AvatarURL         string          `json:"avatar_url"`
@@ -104,8 +86,32 @@ type TagEvent struct {
 		WebURL            string          `json:"web_url"`
 		Visibility        VisibilityValue `json:"visibility"`
 	} `json:"project"`
-	Repository *Repository `json:"repository"`
-	Commits    []*struct {
+	Repository       *Repository `json:"repository"`
+	ObjectAttributes struct {
+		ID           int    `json:"id"`
+		Note         string `json:"note"`
+		NoteableType string `json:"noteable_type"`
+		AuthorID     int    `json:"author_id"`
+		CreatedAt    string `json:"created_at"`
+		UpdatedAt    string `json:"updated_at"`
+		ProjectID    int    `json:"project_id"`
+		Attachment   string `json:"attachment"`
+		LineCode     string `json:"line_code"`
+		CommitID     string `json:"commit_id"`
+		NoteableID   int    `json:"noteable_id"`
+		System       bool   `json:"system"`
+		StDiff       struct {
+			Diff        string `json:"diff"`
+			NewPath     string `json:"new_path"`
+			OldPath     string `json:"old_path"`
+			AMode       string `json:"a_mode"`
+			BMode       string `json:"b_mode"`
+			NewFile     bool   `json:"new_file"`
+			RenamedFile bool   `json:"renamed_file"`
+			DeletedFile bool   `json:"deleted_file"`
+		} `json:"st_diff"`
+	} `json:"object_attributes"`
+	Commit *struct {
 		ID        string     `json:"id"`
 		Message   string     `json:"message"`
 		Timestamp *time.Time `json:"timestamp"`
@@ -114,11 +120,115 @@ type TagEvent struct {
 			Name  string `json:"name"`
 			Email string `json:"email"`
 		} `json:"author"`
-		Added    []string `json:"added"`
-		Modified []string `json:"modified"`
-		Removed  []string `json:"removed"`
-	} `json:"commits"`
-	TotalCommitsCount int `json:"total_commits_count"`
+	} `json:"commit"`
+}
+
+// DeploymentEvent represents a deployment event
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/user/project/integrations/webhooks.html#deployment-events
+type DeploymentEvent struct {
+	ObjectKind    string `json:"object_kind"`
+	Status        string `json:"status"`
+	DeployableID  int    `json:"deployable_id"`
+	DeployableURL string `json:"deployable_url"`
+	Environment   string `json:"environment"`
+	Project       struct {
+		ID                int     `json:"id"`
+		Name              string  `json:"name"`
+		Description       string  `json:"description"`
+		WebURL            string  `json:"web_url"`
+		AvatarURL         *string `json:"avatar_url"`
+		GitSSHURL         string  `json:"git_ssh_url"`
+		GitHTTPURL        string  `json:"git_http_url"`
+		Namespace         string  `json:"namespace"`
+		VisibilityLevel   int     `json:"visibility_level"`
+		PathWithNamespace string  `json:"path_with_namespace"`
+		DefaultBranch     string  `json:"default_branch"`
+		CIConfigPath      string  `json:"ci_config_path"`
+		Homepage          string  `json:"homepage"`
+		URL               string  `json:"url"`
+		SSHURL            string  `json:"ssh_url"`
+		HTTPURL           string  `json:"http_url"`
+	} `json:"project"`
+	ShortSHA string `json:"short_sha"`
+	User     struct {
+		Name      string `json:"name"`
+		Username  string `json:"username"`
+		AvatarURL string `json:"avatar_url"`
+		Email     string `json:"email"`
+	} `json:"user"`
+	UserURL     string `json:"user_url"`
+	CommitURL   string `json:"commit_url"`
+	CommitTitle string `json:"commit_title"`
+}
+
+// IssueCommentEvent represents a comment on an issue event.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/user/project/integrations/webhooks.html#comment-on-issue
+type IssueCommentEvent struct {
+	ObjectKind string `json:"object_kind"`
+	User       *User  `json:"user"`
+	ProjectID  int    `json:"project_id"`
+	Project    struct {
+		Name              string          `json:"name"`
+		Description       string          `json:"description"`
+		AvatarURL         string          `json:"avatar_url"`
+		GitSSHURL         string          `json:"git_ssh_url"`
+		GitHTTPURL        string          `json:"git_http_url"`
+		Namespace         string          `json:"namespace"`
+		PathWithNamespace string          `json:"path_with_namespace"`
+		DefaultBranch     string          `json:"default_branch"`
+		Homepage          string          `json:"homepage"`
+		URL               string          `json:"url"`
+		SSHURL            string          `json:"ssh_url"`
+		HTTPURL           string          `json:"http_url"`
+		WebURL            string          `json:"web_url"`
+		Visibility        VisibilityValue `json:"visibility"`
+	} `json:"project"`
+	Repository       *Repository `json:"repository"`
+	ObjectAttributes struct {
+		ID           int     `json:"id"`
+		Note         string  `json:"note"`
+		NoteableType string  `json:"noteable_type"`
+		AuthorID     int     `json:"author_id"`
+		CreatedAt    string  `json:"created_at"`
+		UpdatedAt    string  `json:"updated_at"`
+		ProjectID    int     `json:"project_id"`
+		Attachment   string  `json:"attachment"`
+		LineCode     string  `json:"line_code"`
+		CommitID     string  `json:"commit_id"`
+		NoteableID   int     `json:"noteable_id"`
+		System       bool    `json:"system"`
+		StDiff       []*Diff `json:"st_diff"`
+		URL          string  `json:"url"`
+	} `json:"object_attributes"`
+	Issue struct {
+		ID                  int      `json:"id"`
+		IID                 int      `json:"iid"`
+		ProjectID           int      `json:"project_id"`
+		MilestoneID         int      `json:"milestone_id"`
+		AuthorID            int      `json:"author_id"`
+		Description         string   `json:"description"`
+		State               string   `json:"state"`
+		Title               string   `json:"title"`
+		LastEditedAt        string   `json:"last_edit_at"`
+		LastEditedByID      int      `json:"last_edited_by_id"`
+		UpdatedAt           string   `json:"updated_at"`
+		UpdatedByID         int      `json:"updated_by_id"`
+		CreatedAt           string   `json:"created_at"`
+		ClosedAt            string   `json:"closed_at"`
+		DueDate             *ISOTime `json:"due_date"`
+		URL                 string   `json:"url"`
+		TimeEstimate        int      `json:"time_estimate"`
+		Confidential        bool     `json:"confidential"`
+		TotalTimeSpent      int      `json:"total_time_spent"`
+		HumanTotalTimeSpent string   `json:"human_total_time_spent"`
+		HumanTimeEstimate   string   `json:"human_time_estimate"`
+		AssigneeIDs         []int    `json:"assignee_ids"`
+		AssigneeID          int      `json:"assignee_id"`
+	} `json:"issue"`
 }
 
 // IssueEvent represents a issue event.
@@ -247,67 +357,6 @@ type JobEvent struct {
 	} `json:"runner"`
 }
 
-// CommitCommentEvent represents a comment on a commit event.
-//
-// GitLab API docs:
-// https://docs.gitlab.com/ce/user/project/integrations/webhooks.html#comment-on-commit
-type CommitCommentEvent struct {
-	ObjectKind string `json:"object_kind"`
-	User       *User  `json:"user"`
-	ProjectID  int    `json:"project_id"`
-	Project    struct {
-		Name              string          `json:"name"`
-		Description       string          `json:"description"`
-		AvatarURL         string          `json:"avatar_url"`
-		GitSSHURL         string          `json:"git_ssh_url"`
-		GitHTTPURL        string          `json:"git_http_url"`
-		Namespace         string          `json:"namespace"`
-		PathWithNamespace string          `json:"path_with_namespace"`
-		DefaultBranch     string          `json:"default_branch"`
-		Homepage          string          `json:"homepage"`
-		URL               string          `json:"url"`
-		SSHURL            string          `json:"ssh_url"`
-		HTTPURL           string          `json:"http_url"`
-		WebURL            string          `json:"web_url"`
-		Visibility        VisibilityValue `json:"visibility"`
-	} `json:"project"`
-	Repository       *Repository `json:"repository"`
-	ObjectAttributes struct {
-		ID           int    `json:"id"`
-		Note         string `json:"note"`
-		NoteableType string `json:"noteable_type"`
-		AuthorID     int    `json:"author_id"`
-		CreatedAt    string `json:"created_at"`
-		UpdatedAt    string `json:"updated_at"`
-		ProjectID    int    `json:"project_id"`
-		Attachment   string `json:"attachment"`
-		LineCode     string `json:"line_code"`
-		CommitID     string `json:"commit_id"`
-		NoteableID   int    `json:"noteable_id"`
-		System       bool   `json:"system"`
-		StDiff       struct {
-			Diff        string `json:"diff"`
-			NewPath     string `json:"new_path"`
-			OldPath     string `json:"old_path"`
-			AMode       string `json:"a_mode"`
-			BMode       string `json:"b_mode"`
-			NewFile     bool   `json:"new_file"`
-			RenamedFile bool   `json:"renamed_file"`
-			DeletedFile bool   `json:"deleted_file"`
-		} `json:"st_diff"`
-	} `json:"object_attributes"`
-	Commit *struct {
-		ID        string     `json:"id"`
-		Message   string     `json:"message"`
-		Timestamp *time.Time `json:"timestamp"`
-		URL       string     `json:"url"`
-		Author    struct {
-			Name  string `json:"name"`
-			Email string `json:"email"`
-		} `json:"author"`
-	} `json:"commit"`
-}
-
 // MergeCommentEvent represents a comment on a merge event.
 //
 // GitLab API docs:
@@ -409,118 +458,6 @@ type MergeCommentEvent struct {
 		TotalTimeSpent int  `json:"total_time_spent"`
 		HeadPipelineID int  `json:"head_pipeline_id"`
 	} `json:"merge_request"`
-}
-
-// IssueCommentEvent represents a comment on an issue event.
-//
-// GitLab API docs:
-// https://docs.gitlab.com/ce/user/project/integrations/webhooks.html#comment-on-issue
-type IssueCommentEvent struct {
-	ObjectKind string `json:"object_kind"`
-	User       *User  `json:"user"`
-	ProjectID  int    `json:"project_id"`
-	Project    struct {
-		Name              string          `json:"name"`
-		Description       string          `json:"description"`
-		AvatarURL         string          `json:"avatar_url"`
-		GitSSHURL         string          `json:"git_ssh_url"`
-		GitHTTPURL        string          `json:"git_http_url"`
-		Namespace         string          `json:"namespace"`
-		PathWithNamespace string          `json:"path_with_namespace"`
-		DefaultBranch     string          `json:"default_branch"`
-		Homepage          string          `json:"homepage"`
-		URL               string          `json:"url"`
-		SSHURL            string          `json:"ssh_url"`
-		HTTPURL           string          `json:"http_url"`
-		WebURL            string          `json:"web_url"`
-		Visibility        VisibilityValue `json:"visibility"`
-	} `json:"project"`
-	Repository       *Repository `json:"repository"`
-	ObjectAttributes struct {
-		ID           int     `json:"id"`
-		Note         string  `json:"note"`
-		NoteableType string  `json:"noteable_type"`
-		AuthorID     int     `json:"author_id"`
-		CreatedAt    string  `json:"created_at"`
-		UpdatedAt    string  `json:"updated_at"`
-		ProjectID    int     `json:"project_id"`
-		Attachment   string  `json:"attachment"`
-		LineCode     string  `json:"line_code"`
-		CommitID     string  `json:"commit_id"`
-		NoteableID   int     `json:"noteable_id"`
-		System       bool    `json:"system"`
-		StDiff       []*Diff `json:"st_diff"`
-		URL          string  `json:"url"`
-	} `json:"object_attributes"`
-	Issue struct {
-		ID                  int      `json:"id"`
-		IID                 int      `json:"iid"`
-		ProjectID           int      `json:"project_id"`
-		MilestoneID         int      `json:"milestone_id"`
-		AuthorID            int      `json:"author_id"`
-		Description         string   `json:"description"`
-		State               string   `json:"state"`
-		Title               string   `json:"title"`
-		LastEditedAt        string   `json:"last_edit_at"`
-		LastEditedByID      int      `json:"last_edited_by_id"`
-		UpdatedAt           string   `json:"updated_at"`
-		UpdatedByID         int      `json:"updated_by_id"`
-		CreatedAt           string   `json:"created_at"`
-		ClosedAt            string   `json:"closed_at"`
-		DueDate             *ISOTime `json:"due_date"`
-		URL                 string   `json:"url"`
-		TimeEstimate        int      `json:"time_estimate"`
-		Confidential        bool     `json:"confidential"`
-		TotalTimeSpent      int      `json:"total_time_spent"`
-		HumanTotalTimeSpent string   `json:"human_total_time_spent"`
-		HumanTimeEstimate   string   `json:"human_time_estimate"`
-		AssigneeIDs         []int    `json:"assignee_ids"`
-		AssigneeID          int      `json:"assignee_id"`
-	} `json:"issue"`
-}
-
-// SnippetCommentEvent represents a comment on a snippet event.
-//
-// GitLab API docs:
-// https://docs.gitlab.com/ce/user/project/integrations/webhooks.html#comment-on-code-snippet
-type SnippetCommentEvent struct {
-	ObjectKind string `json:"object_kind"`
-	User       *User  `json:"user"`
-	ProjectID  int    `json:"project_id"`
-	Project    struct {
-		Name              string          `json:"name"`
-		Description       string          `json:"description"`
-		AvatarURL         string          `json:"avatar_url"`
-		GitSSHURL         string          `json:"git_ssh_url"`
-		GitHTTPURL        string          `json:"git_http_url"`
-		Namespace         string          `json:"namespace"`
-		PathWithNamespace string          `json:"path_with_namespace"`
-		DefaultBranch     string          `json:"default_branch"`
-		Homepage          string          `json:"homepage"`
-		URL               string          `json:"url"`
-		SSHURL            string          `json:"ssh_url"`
-		HTTPURL           string          `json:"http_url"`
-		WebURL            string          `json:"web_url"`
-		Visibility        VisibilityValue `json:"visibility"`
-	} `json:"project"`
-	Repository       *Repository `json:"repository"`
-	ObjectAttributes struct {
-		ID           int    `json:"id"`
-		Note         string `json:"note"`
-		NoteableType string `json:"noteable_type"`
-		AuthorID     int    `json:"author_id"`
-		CreatedAt    string `json:"created_at"`
-		UpdatedAt    string `json:"updated_at"`
-		ProjectID    int    `json:"project_id"`
-		Attachment   string `json:"attachment"`
-		LineCode     string `json:"line_code"`
-		CommitID     string `json:"commit_id"`
-		NoteableID   int    `json:"noteable_id"`
-		System       bool   `json:"system"`
-		StDiff       *Diff  `json:"st_diff"`
-		URL          string `json:"url"`
-	} `json:"object_attributes"`
-	Snippet *Snippet `json:"snippet"`
 }
 
 // MergeEvent represents a merge event.
@@ -695,47 +632,6 @@ func (p *MergeParams) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// WikiPageEvent represents a wiki page event.
-//
-// GitLab API docs:
-// https://docs.gitlab.com/ce/user/project/integrations/webhooks.html#wiki-page-events
-type WikiPageEvent struct {
-	ObjectKind string `json:"object_kind"`
-	User       *User  `json:"user"`
-	Project    struct {
-		Name              string          `json:"name"`
-		Description       string          `json:"description"`
-		AvatarURL         string          `json:"avatar_url"`
-		GitSSHURL         string          `json:"git_ssh_url"`
-		GitHTTPURL        string          `json:"git_http_url"`
-		Namespace         string          `json:"namespace"`
-		PathWithNamespace string          `json:"path_with_namespace"`
-		DefaultBranch     string          `json:"default_branch"`
-		Homepage          string          `json:"homepage"`
-		URL               string          `json:"url"`
-		SSHURL            string          `json:"ssh_url"`
-		HTTPURL           string          `json:"http_url"`
-		WebURL            string          `json:"web_url"`
-		Visibility        VisibilityValue `json:"visibility"`
-	} `json:"project"`
-	Wiki struct {
-		WebURL            string `json:"web_url"`
-		GitSSHURL         string `json:"git_ssh_url"`
-		GitHTTPURL        string `json:"git_http_url"`
-		PathWithNamespace string `json:"path_with_namespace"`
-		DefaultBranch     string `json:"default_branch"`
-	} `json:"wiki"`
-	ObjectAttributes struct {
-		Title   string `json:"title"`
-		Content string `json:"content"`
-		Format  string `json:"format"`
-		Message string `json:"message"`
-		Slug    string `json:"slug"`
-		URL     string `json:"url"`
-		Action  string `json:"action"`
-	} `json:"object_attributes"`
-}
-
 // PipelineEvent represents a pipeline event.
 //
 // GitLab API docs:
@@ -827,83 +723,53 @@ type PipelineEvent struct {
 	} `json:"builds"`
 }
 
-//BuildEvent represents a build event
+// PushEvent represents a push event.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/user/project/integrations/webhooks.html#build-events
-type BuildEvent struct {
-	ObjectKind        string  `json:"object_kind"`
-	Ref               string  `json:"ref"`
-	Tag               bool    `json:"tag"`
-	BeforeSHA         string  `json:"before_sha"`
-	SHA               string  `json:"sha"`
-	BuildID           int     `json:"build_id"`
-	BuildName         string  `json:"build_name"`
-	BuildStage        string  `json:"build_stage"`
-	BuildStatus       string  `json:"build_status"`
-	BuildStartedAt    string  `json:"build_started_at"`
-	BuildFinishedAt   string  `json:"build_finished_at"`
-	BuildDuration     float64 `json:"build_duration"`
-	BuildAllowFailure bool    `json:"build_allow_failure"`
-	ProjectID         int     `json:"project_id"`
-	ProjectName       string  `json:"project_name"`
-	User              struct {
-		ID    int    `json:"id"`
-		Name  string `json:"name"`
-		Email string `json:"email"`
-	} `json:"user"`
-	Commit struct {
-		ID          int    `json:"id"`
-		SHA         string `json:"sha"`
-		Message     string `json:"message"`
-		AuthorName  string `json:"author_name"`
-		AuthorEmail string `json:"author_email"`
-		Status      string `json:"status"`
-		Duration    int    `json:"duration"`
-		StartedAt   string `json:"started_at"`
-		FinishedAt  string `json:"finished_at"`
-	} `json:"commit"`
-	Repository *Repository `json:"repository"`
-}
-
-// DeploymentEvent represents a deployment event
-//
-// GitLab API docs:
-// https://docs.gitlab.com/ce/user/project/integrations/webhooks.html#deployment-events
-type DeploymentEvent struct {
-	ObjectKind    string `json:"object_kind"`
-	Status        string `json:"status"`
-	DeployableID  int    `json:"deployable_id"`
-	DeployableURL string `json:"deployable_url"`
-	Environment   string `json:"environment"`
-	Project       struct {
-		ID                int     `json:"id"`
-		Name              string  `json:"name"`
-		Description       string  `json:"description"`
-		WebURL            string  `json:"web_url"`
-		AvatarURL         *string `json:"avatar_url"`
-		GitSSHURL         string  `json:"git_ssh_url"`
-		GitHTTPURL        string  `json:"git_http_url"`
-		Namespace         string  `json:"namespace"`
-		VisibilityLevel   int     `json:"visibility_level"`
-		PathWithNamespace string  `json:"path_with_namespace"`
-		DefaultBranch     string  `json:"default_branch"`
-		CIConfigPath      string  `json:"ci_config_path"`
-		Homepage          string  `json:"homepage"`
-		URL               string  `json:"url"`
-		SSHURL            string  `json:"ssh_url"`
-		HTTPURL           string  `json:"http_url"`
+// https://docs.gitlab.com/ce/user/project/integrations/webhooks.html#push-events
+type PushEvent struct {
+	ObjectKind   string `json:"object_kind"`
+	Before       string `json:"before"`
+	After        string `json:"after"`
+	Ref          string `json:"ref"`
+	CheckoutSHA  string `json:"checkout_sha"`
+	UserID       int    `json:"user_id"`
+	UserName     string `json:"user_name"`
+	UserUsername string `json:"user_username"`
+	UserEmail    string `json:"user_email"`
+	UserAvatar   string `json:"user_avatar"`
+	ProjectID    int    `json:"project_id"`
+	Project      struct {
+		Name              string          `json:"name"`
+		Description       string          `json:"description"`
+		AvatarURL         string          `json:"avatar_url"`
+		GitSSHURL         string          `json:"git_ssh_url"`
+		GitHTTPURL        string          `json:"git_http_url"`
+		Namespace         string          `json:"namespace"`
+		PathWithNamespace string          `json:"path_with_namespace"`
+		DefaultBranch     string          `json:"default_branch"`
+		Homepage          string          `json:"homepage"`
+		URL               string          `json:"url"`
+		SSHURL            string          `json:"ssh_url"`
+		HTTPURL           string          `json:"http_url"`
+		WebURL            string          `json:"web_url"`
+		Visibility        VisibilityValue `json:"visibility"`
 	} `json:"project"`
-	ShortSHA string `json:"short_sha"`
-	User     struct {
-		Name      string `json:"name"`
-		Username  string `json:"username"`
-		AvatarURL string `json:"avatar_url"`
-		Email     string `json:"email"`
-	} `json:"user"`
-	UserURL     string `json:"user_url"`
-	CommitURL   string `json:"commit_url"`
-	CommitTitle string `json:"commit_title"`
+	Repository *Repository `json:"repository"`
+	Commits    []*struct {
+		ID        string     `json:"id"`
+		Message   string     `json:"message"`
+		Timestamp *time.Time `json:"timestamp"`
+		URL       string     `json:"url"`
+		Author    struct {
+			Name  string `json:"name"`
+			Email string `json:"email"`
+		} `json:"author"`
+		Added    []string `json:"added"`
+		Modified []string `json:"modified"`
+		Removed  []string `json:"removed"`
+	} `json:"commits"`
+	TotalCommitsCount int `json:"total_commits_count"`
 }
 
 // ReleaseEvent represents a release event
@@ -963,4 +829,138 @@ type ReleaseEvent struct {
 			Email string `json:"email"`
 		} `json:"author"`
 	} `json:"commit"`
+}
+
+// SnippetCommentEvent represents a comment on a snippet event.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/user/project/integrations/webhooks.html#comment-on-code-snippet
+type SnippetCommentEvent struct {
+	ObjectKind string `json:"object_kind"`
+	User       *User  `json:"user"`
+	ProjectID  int    `json:"project_id"`
+	Project    struct {
+		Name              string          `json:"name"`
+		Description       string          `json:"description"`
+		AvatarURL         string          `json:"avatar_url"`
+		GitSSHURL         string          `json:"git_ssh_url"`
+		GitHTTPURL        string          `json:"git_http_url"`
+		Namespace         string          `json:"namespace"`
+		PathWithNamespace string          `json:"path_with_namespace"`
+		DefaultBranch     string          `json:"default_branch"`
+		Homepage          string          `json:"homepage"`
+		URL               string          `json:"url"`
+		SSHURL            string          `json:"ssh_url"`
+		HTTPURL           string          `json:"http_url"`
+		WebURL            string          `json:"web_url"`
+		Visibility        VisibilityValue `json:"visibility"`
+	} `json:"project"`
+	Repository       *Repository `json:"repository"`
+	ObjectAttributes struct {
+		ID           int    `json:"id"`
+		Note         string `json:"note"`
+		NoteableType string `json:"noteable_type"`
+		AuthorID     int    `json:"author_id"`
+		CreatedAt    string `json:"created_at"`
+		UpdatedAt    string `json:"updated_at"`
+		ProjectID    int    `json:"project_id"`
+		Attachment   string `json:"attachment"`
+		LineCode     string `json:"line_code"`
+		CommitID     string `json:"commit_id"`
+		NoteableID   int    `json:"noteable_id"`
+		System       bool   `json:"system"`
+		StDiff       *Diff  `json:"st_diff"`
+		URL          string `json:"url"`
+	} `json:"object_attributes"`
+	Snippet *Snippet `json:"snippet"`
+}
+
+// TagEvent represents a tag event.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/user/project/integrations/webhooks.html#tag-events
+type TagEvent struct {
+	ObjectKind  string `json:"object_kind"`
+	Before      string `json:"before"`
+	After       string `json:"after"`
+	Ref         string `json:"ref"`
+	CheckoutSHA string `json:"checkout_sha"`
+	UserID      int    `json:"user_id"`
+	UserName    string `json:"user_name"`
+	UserAvatar  string `json:"user_avatar"`
+	UserEmail   string `json:"user_email"`
+	ProjectID   int    `json:"project_id"`
+	Message     string `json:"message"`
+	Project     struct {
+		Name              string          `json:"name"`
+		Description       string          `json:"description"`
+		AvatarURL         string          `json:"avatar_url"`
+		GitSSHURL         string          `json:"git_ssh_url"`
+		GitHTTPURL        string          `json:"git_http_url"`
+		Namespace         string          `json:"namespace"`
+		PathWithNamespace string          `json:"path_with_namespace"`
+		DefaultBranch     string          `json:"default_branch"`
+		Homepage          string          `json:"homepage"`
+		URL               string          `json:"url"`
+		SSHURL            string          `json:"ssh_url"`
+		HTTPURL           string          `json:"http_url"`
+		WebURL            string          `json:"web_url"`
+		Visibility        VisibilityValue `json:"visibility"`
+	} `json:"project"`
+	Repository *Repository `json:"repository"`
+	Commits    []*struct {
+		ID        string     `json:"id"`
+		Message   string     `json:"message"`
+		Timestamp *time.Time `json:"timestamp"`
+		URL       string     `json:"url"`
+		Author    struct {
+			Name  string `json:"name"`
+			Email string `json:"email"`
+		} `json:"author"`
+		Added    []string `json:"added"`
+		Modified []string `json:"modified"`
+		Removed  []string `json:"removed"`
+	} `json:"commits"`
+	TotalCommitsCount int `json:"total_commits_count"`
+}
+
+// WikiPageEvent represents a wiki page event.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/user/project/integrations/webhooks.html#wiki-page-events
+type WikiPageEvent struct {
+	ObjectKind string `json:"object_kind"`
+	User       *User  `json:"user"`
+	Project    struct {
+		Name              string          `json:"name"`
+		Description       string          `json:"description"`
+		AvatarURL         string          `json:"avatar_url"`
+		GitSSHURL         string          `json:"git_ssh_url"`
+		GitHTTPURL        string          `json:"git_http_url"`
+		Namespace         string          `json:"namespace"`
+		PathWithNamespace string          `json:"path_with_namespace"`
+		DefaultBranch     string          `json:"default_branch"`
+		Homepage          string          `json:"homepage"`
+		URL               string          `json:"url"`
+		SSHURL            string          `json:"ssh_url"`
+		HTTPURL           string          `json:"http_url"`
+		WebURL            string          `json:"web_url"`
+		Visibility        VisibilityValue `json:"visibility"`
+	} `json:"project"`
+	Wiki struct {
+		WebURL            string `json:"web_url"`
+		GitSSHURL         string `json:"git_ssh_url"`
+		GitHTTPURL        string `json:"git_http_url"`
+		PathWithNamespace string `json:"path_with_namespace"`
+		DefaultBranch     string `json:"default_branch"`
+	} `json:"wiki"`
+	ObjectAttributes struct {
+		Title   string `json:"title"`
+		Content string `json:"content"`
+		Format  string `json:"format"`
+		Message string `json:"message"`
+		Slug    string `json:"slug"`
+		URL     string `json:"url"`
+		Action  string `json:"action"`
+	} `json:"object_attributes"`
 }

--- a/event_webhook_types_test.go
+++ b/event_webhook_types_test.go
@@ -233,6 +233,37 @@ func TestDeploymentEventUnmarshal(t *testing.T) {
 	}
 }
 
+func TestReleaseEventUnmarshal(t *testing.T) {
+	jsonObject := loadFixture("testdata/webhooks/release.json")
+
+	var event *ReleaseEvent
+	err := json.Unmarshal(jsonObject, &event)
+
+	if err != nil {
+		t.Errorf("Release Event can not unmarshaled: %v\n ", err.Error())
+	}
+
+	if event == nil {
+		t.Errorf("Release Event is null")
+	}
+
+	if event.Project.ID != 327622 {
+		t.Errorf("Project.ID is %v, want %v", event.Project.ID, 327622)
+	}
+
+	if event.Commit.Title != "Merge branch 'example-branch' into 'master'" {
+		t.Errorf("Commit title is %s, want %s", event.Commit.Title, "Merge branch 'example-branch' into 'master'")
+	}
+
+	if len(event.Assets.Sources) != 4 {
+		t.Errorf("Asset sources length is %d, want %d", len(event.Assets.Sources), 4)
+	}
+
+	if event.Commit.Author.Name != "User" {
+		t.Errorf("Commit author name is %s, want %s", event.Commit.Author.Name, "User")
+	}
+}
+
 func TestIssueEventUnmarshal(t *testing.T) {
 	jsonObject := loadFixture("testdata/webhooks/issue.json")
 

--- a/event_webhook_types_test.go
+++ b/event_webhook_types_test.go
@@ -259,6 +259,18 @@ func TestReleaseEventUnmarshal(t *testing.T) {
 		t.Errorf("Asset sources length is %d, want %d", len(event.Assets.Sources), 4)
 	}
 
+	if event.Assets.Sources[0].Format != "zip" {
+		t.Errorf("First asset source format is %s, want %s", event.Assets.Sources[0].Format, "zip")
+	}
+
+	if len(event.Assets.Links) != 1 {
+		t.Errorf("Asset links length is %d, want %d", len(event.Assets.Links), 1)
+	}
+
+	if event.Assets.Links[0].Name != "Changelog" {
+		t.Errorf("First asset link name is %s, want %s", event.Assets.Links[0].Name, "Changelog")
+	}
+
 	if event.Commit.Author.Name != "User" {
 		t.Errorf("Commit author name is %s, want %s", event.Commit.Author.Name, "User")
 	}

--- a/event_webhook_types_test.go
+++ b/event_webhook_types_test.go
@@ -21,33 +21,69 @@ import (
 	"testing"
 )
 
-func TestPushEventUnmarshal(t *testing.T) {
-	jsonObject := loadFixture("testdata/webhooks/push.json")
-	var event *PushEvent
+func TestBuildEventUnmarshal(t *testing.T) {
+	jsonObject := loadFixture("testdata/webhooks/build.json")
+
+	var event *BuildEvent
 	err := json.Unmarshal(jsonObject, &event)
 
 	if err != nil {
-		t.Errorf("Push Event can not unmarshaled: %v\n ", err.Error())
+		t.Errorf("Build Event can not unmarshaled: %v\n ", err.Error())
 	}
 
 	if event == nil {
-		t.Errorf("Push Event is null")
+		t.Errorf("Build Event is null")
 	}
 
-	if event.ProjectID != 15 {
-		t.Errorf("ProjectID is %v, want %v", event.ProjectID, 15)
+	if event.BuildID != 1977 {
+		t.Errorf("BuildID is %v, want %v", event.BuildID, 1977)
+	}
+}
+
+func TestDeploymentEventUnmarshal(t *testing.T) {
+	jsonObject := loadFixture("testdata/webhooks/deployment.json")
+
+	var event *DeploymentEvent
+	err := json.Unmarshal(jsonObject, &event)
+
+	if err != nil {
+		t.Errorf("Deployment Event can not unmarshaled: %v\n ", err.Error())
 	}
 
-	if event.UserName != exampleEventUserName {
-		t.Errorf("Username is %s, want %s", event.UserName, exampleEventUserName)
+	if event == nil {
+		t.Errorf("Deployment Event is null")
 	}
 
-	if event.Commits[0] == nil || event.Commits[0].Timestamp == nil {
-		t.Errorf("Commit Timestamp isn't nil")
+	if event.Project.ID != 30 {
+		t.Errorf("Project.ID is %v, want %v", event.Project.ID, 30)
 	}
 
-	if event.Commits[0] == nil || event.Commits[0].Author.Name != "Jordi Mallach" {
-		t.Errorf("Commit Username is %s, want %s", event.UserName, "Jordi Mallach")
+	if event.User.Name == "" {
+		t.Errorf("Username is %s, want %s", event.User.Name, "Administrator")
+	}
+
+	if event.CommitTitle != "Add new file" {
+		t.Errorf("CommitTitle is %s, want %s", event.CommitTitle, "Add new file")
+	}
+}
+
+func TestIssueEventUnmarshal(t *testing.T) {
+	jsonObject := loadFixture("testdata/webhooks/issue.json")
+
+	var event *IssueEvent
+	err := json.Unmarshal(jsonObject, &event)
+
+	if err != nil {
+		t.Errorf("Deployment Event can not unmarshaled: %v\n ", err.Error())
+	}
+	if event.Project.ID != 1 {
+		t.Errorf("Project.ID is %v, want %v", event.Project.ID, 1)
+	}
+	if event.Changes.TotalTimeSpent.Previous != 8100 {
+		t.Errorf("Changes.TotalTimeSpent.Previous is %v , want %v", event.Changes.TotalTimeSpent.Previous, 8100)
+	}
+	if event.Changes.TotalTimeSpent.Current != 9900 {
+		t.Errorf("Changes.TotalTimeSpent.Current is %v , want %v", event.Changes.TotalTimeSpent.Current, 8100)
 	}
 }
 
@@ -94,56 +130,6 @@ func TestMergeEventUnmarshal(t *testing.T) {
 
 	if name := event.ObjectAttributes.LastCommit.Author.Name; name != "GitLab dev user" {
 		t.Errorf("Commit Username is %s, want %s", name, "GitLab dev user")
-	}
-}
-
-func TestPipelineEventUnmarshal(t *testing.T) {
-	jsonObject := loadFixture("testdata/webhooks/pipeline.json")
-
-	var event *PipelineEvent
-	err := json.Unmarshal(jsonObject, &event)
-
-	if err != nil {
-		t.Errorf("Pipeline Event can not unmarshaled: %v\n ", err.Error())
-	}
-
-	if event == nil {
-		t.Errorf("Pipeline Event is null")
-	}
-
-	if event.ObjectAttributes.ID != 31 {
-		t.Errorf("ObjectAttributes is %v, want %v", event.ObjectAttributes.ID, 1977)
-	}
-
-	if event.User.Name == "" {
-		t.Errorf("Username is %s, want %s", event.User.Name, "Administrator")
-	}
-
-	if event.Commit.Timestamp == nil {
-		t.Errorf("Timestamp isn't nil")
-	}
-
-	if name := event.Commit.Author.Name; name != "User" {
-		t.Errorf("Commit Username is %s, want %s", name, "User")
-	}
-}
-
-func TestBuildEventUnmarshal(t *testing.T) {
-	jsonObject := loadFixture("testdata/webhooks/build.json")
-
-	var event *BuildEvent
-	err := json.Unmarshal(jsonObject, &event)
-
-	if err != nil {
-		t.Errorf("Build Event can not unmarshaled: %v\n ", err.Error())
-	}
-
-	if event == nil {
-		t.Errorf("Build Event is null")
-	}
-
-	if event.BuildID != 1977 {
-		t.Errorf("BuildID is %v, want %v", event.BuildID, 1977)
 	}
 }
 
@@ -206,30 +192,64 @@ func TestMergeEventUnmarshalFromGroup(t *testing.T) {
 	}
 }
 
-func TestDeploymentEventUnmarshal(t *testing.T) {
-	jsonObject := loadFixture("testdata/webhooks/deployment.json")
+func TestPipelineEventUnmarshal(t *testing.T) {
+	jsonObject := loadFixture("testdata/webhooks/pipeline.json")
 
-	var event *DeploymentEvent
+	var event *PipelineEvent
 	err := json.Unmarshal(jsonObject, &event)
 
 	if err != nil {
-		t.Errorf("Deployment Event can not unmarshaled: %v\n ", err.Error())
+		t.Errorf("Pipeline Event can not unmarshaled: %v\n ", err.Error())
 	}
 
 	if event == nil {
-		t.Errorf("Deployment Event is null")
+		t.Errorf("Pipeline Event is null")
 	}
 
-	if event.Project.ID != 30 {
-		t.Errorf("Project.ID is %v, want %v", event.Project.ID, 30)
+	if event.ObjectAttributes.ID != 31 {
+		t.Errorf("ObjectAttributes is %v, want %v", event.ObjectAttributes.ID, 1977)
 	}
 
 	if event.User.Name == "" {
 		t.Errorf("Username is %s, want %s", event.User.Name, "Administrator")
 	}
 
-	if event.CommitTitle != "Add new file" {
-		t.Errorf("CommitTitle is %s, want %s", event.CommitTitle, "Add new file")
+	if event.Commit.Timestamp == nil {
+		t.Errorf("Timestamp isn't nil")
+	}
+
+	if name := event.Commit.Author.Name; name != "User" {
+		t.Errorf("Commit Username is %s, want %s", name, "User")
+	}
+}
+
+func TestPushEventUnmarshal(t *testing.T) {
+	jsonObject := loadFixture("testdata/webhooks/push.json")
+	var event *PushEvent
+	err := json.Unmarshal(jsonObject, &event)
+
+	if err != nil {
+		t.Errorf("Push Event can not unmarshaled: %v\n ", err.Error())
+	}
+
+	if event == nil {
+		t.Errorf("Push Event is null")
+	}
+
+	if event.ProjectID != 15 {
+		t.Errorf("ProjectID is %v, want %v", event.ProjectID, 15)
+	}
+
+	if event.UserName != exampleEventUserName {
+		t.Errorf("Username is %s, want %s", event.UserName, exampleEventUserName)
+	}
+
+	if event.Commits[0] == nil || event.Commits[0].Timestamp == nil {
+		t.Errorf("Commit Timestamp isn't nil")
+	}
+
+	if event.Commits[0] == nil || event.Commits[0].Author.Name != "Jordi Mallach" {
+		t.Errorf("Commit Username is %s, want %s", event.UserName, "Jordi Mallach")
 	}
 }
 
@@ -273,25 +293,5 @@ func TestReleaseEventUnmarshal(t *testing.T) {
 
 	if event.Commit.Author.Name != "User" {
 		t.Errorf("Commit author name is %s, want %s", event.Commit.Author.Name, "User")
-	}
-}
-
-func TestIssueEventUnmarshal(t *testing.T) {
-	jsonObject := loadFixture("testdata/webhooks/issue.json")
-
-	var event *IssueEvent
-	err := json.Unmarshal(jsonObject, &event)
-
-	if err != nil {
-		t.Errorf("Deployment Event can not unmarshaled: %v\n ", err.Error())
-	}
-	if event.Project.ID != 1 {
-		t.Errorf("Project.ID is %v, want %v", event.Project.ID, 1)
-	}
-	if event.Changes.TotalTimeSpent.Previous != 8100 {
-		t.Errorf("Changes.TotalTimeSpent.Previous is %v , want %v", event.Changes.TotalTimeSpent.Previous, 8100)
-	}
-	if event.Changes.TotalTimeSpent.Current != 9900 {
-		t.Errorf("Changes.TotalTimeSpent.Current is %v , want %v", event.Changes.TotalTimeSpent.Current, 8100)
 	}
 }

--- a/group_hooks.go
+++ b/group_hooks.go
@@ -40,6 +40,7 @@ type GroupHook struct {
 	PipelineEvents           bool       `json:"pipeline_events"`
 	WikiPageEvents           bool       `json:"wiki_page_events"`
 	DeploymentEvents         bool       `json:"deployment_events"`
+	ReleasesEvents           bool       `json:"releases_events"`
 	EnableSSLVerification    bool       `json:"enable_ssl_verification"`
 	CreatedAt                *time.Time `json:"created_at"`
 }
@@ -108,6 +109,7 @@ type AddGroupHookOptions struct {
 	PipelineEvents           *bool   `url:"pipeline_events,omitempty"  json:"pipeline_events,omitempty"`
 	WikiPageEvents           *bool   `url:"wiki_page_events,omitempty"  json:"wiki_page_events,omitempty"`
 	DeploymentEvents         *bool   `url:"deployment_events,omitempty" json:"deployment_events,omitempty"`
+	ReleasesEvents           *bool   `url:"releases_events,omitempty" json:"releases_events,omitempty"`
 	EnableSSLVerification    *bool   `url:"enable_ssl_verification,omitempty"  json:"enable_ssl_verification,omitempty"`
 	Token                    *string `url:"token,omitempty" json:"token,omitempty"`
 }
@@ -153,6 +155,7 @@ type EditGroupHookOptions struct {
 	PipelineEvents           *bool   `url:"pipeline_events,omitempty" json:"pipeline_events,omitempty"`
 	WikiPageEvents           *bool   `url:"wiki_page_events,omitempty" json:"wiki_page_events,omitempty"`
 	DeploymentEvents         *bool   `url:"deployment_events,omitempty" json:"deployment_events,omitempty"`
+	ReleasesEvents           *bool   `url:"releases_events,omitempty" json:"releases_events,omitempty"`
 	EnableSSLVerification    *bool   `url:"enable_ssl_verification,omitempty" json:"enable_ssl_verification,omitempty"`
 	Token                    *string `url:"token,omitempty" json:"token,omitempty"`
 }

--- a/group_hooks_test.go
+++ b/group_hooks_test.go
@@ -46,6 +46,7 @@ func TestListGroupHooks(t *testing.T) {
 		"pipeline_events": true,
 		"wiki_page_events": true,
 		"deployment_events": true,
+		"releases_events": true,
 		"enable_ssl_verification": true,
 		"created_at": "2012-10-12T17:04:47Z"
 	}
@@ -72,6 +73,7 @@ func TestListGroupHooks(t *testing.T) {
 		PipelineEvents:           true,
 		WikiPageEvents:           true,
 		DeploymentEvents:         true,
+		ReleasesEvents:           true,
 		EnableSSLVerification:    true,
 		CreatedAt:                &datePointer,
 	}}
@@ -102,6 +104,7 @@ func TestGetGroupHook(t *testing.T) {
 	"pipeline_events": true,
 	"wiki_page_events": true,
 	"deployment_events": true,
+	"releases_events": true,
 	"enable_ssl_verification": true,
 	"created_at": "2012-10-12T17:04:47Z"
 }`)
@@ -127,6 +130,7 @@ func TestGetGroupHook(t *testing.T) {
 		PipelineEvents:           true,
 		WikiPageEvents:           true,
 		DeploymentEvents:         true,
+		ReleasesEvents:           true,
 		EnableSSLVerification:    true,
 		CreatedAt:                &datePointer,
 	}
@@ -157,6 +161,7 @@ func TestAddGroupHook(t *testing.T) {
 	"pipeline_events": true,
 	"wiki_page_events": true,
 	"deployment_events": true,
+	"releases_events": true,
 	"enable_ssl_verification": true,
 	"created_at": "2012-10-12T17:04:47Z"
 }`)
@@ -188,6 +193,7 @@ func TestAddGroupHook(t *testing.T) {
 		PipelineEvents:           true,
 		WikiPageEvents:           true,
 		DeploymentEvents:         true,
+		ReleasesEvents:           true,
 		EnableSSLVerification:    true,
 		CreatedAt:                &datePointer,
 	}
@@ -218,6 +224,7 @@ func TestEditGroupHook(t *testing.T) {
 	"pipeline_events": true,
 	"wiki_page_events": true,
 	"deployment_events": true,
+	"releases_events": true,
 	"enable_ssl_verification": true,
 	"created_at": "2012-10-12T17:04:47Z"
 }`)
@@ -249,6 +256,7 @@ func TestEditGroupHook(t *testing.T) {
 		PipelineEvents:           true,
 		WikiPageEvents:           true,
 		DeploymentEvents:         true,
+		ReleasesEvents:           true,
 		EnableSSLVerification:    true,
 		CreatedAt:                &datePointer,
 	}

--- a/projects.go
+++ b/projects.go
@@ -948,6 +948,7 @@ type ProjectHook struct {
 	PipelineEvents           bool       `json:"pipeline_events"`
 	WikiPageEvents           bool       `json:"wiki_page_events"`
 	DeploymentEvents         bool       `json:"deployment_events"`
+	ReleasesEvents           bool       `json:"releases_events"`
 	EnableSSLVerification    bool       `json:"enable_ssl_verification"`
 	CreatedAt                *time.Time `json:"created_at"`
 }
@@ -1025,6 +1026,7 @@ type AddProjectHookOptions struct {
 	PipelineEvents           *bool   `url:"pipeline_events,omitempty" json:"pipeline_events,omitempty"`
 	WikiPageEvents           *bool   `url:"wiki_page_events,omitempty" json:"wiki_page_events,omitempty"`
 	DeploymentEvents         *bool   `url:"deployment_events,omitempty" json:"deployment_events,omitempty"`
+	ReleasesEvents           *bool   `url:"releases_events,omitempty" json:"releases_events,omitempty"`
 	EnableSSLVerification    *bool   `url:"enable_ssl_verification,omitempty" json:"enable_ssl_verification,omitempty"`
 	Token                    *string `url:"token,omitempty" json:"token,omitempty"`
 }
@@ -1072,6 +1074,7 @@ type EditProjectHookOptions struct {
 	PipelineEvents           *bool   `url:"pipeline_events,omitempty" json:"pipeline_events,omitempty"`
 	WikiPageEvents           *bool   `url:"wiki_page_events,omitempty" json:"wiki_page_events,omitempty"`
 	DeploymentEvents         *bool   `url:"deployment_events,omitempty" json:"deployment_events,omitempty"`
+	ReleasesEvents           *bool   `url:"releases_events,omitempty" json:"releases_events,omitempty"`
 	EnableSSLVerification    *bool   `url:"enable_ssl_verification,omitempty" json:"enable_ssl_verification,omitempty"`
 	Token                    *string `url:"token,omitempty" json:"token,omitempty"`
 }

--- a/testdata/webhooks/release.json
+++ b/testdata/webhooks/release.json
@@ -28,7 +28,15 @@
   "action": "create",
   "assets": {
 	"count": 4,
-	"links": [],
+	"links": [
+	  {
+		"id": 1,
+		"external": true,
+		"link_type": "other",
+		"name": "Changelog",
+		"url": "https://example.net/changelog"
+	  }
+	],
 	"sources": [
 	  {
 		"format": "zip",

--- a/testdata/webhooks/release.json
+++ b/testdata/webhooks/release.json
@@ -1,0 +1,62 @@
+{
+  "id": 8273642,
+  "created_at": "2021-02-25 21:23:34 UTC",
+  "description": "Release!",
+  "name": "1.0.0",
+  "released_at": "2021-02-25 21:23:34 UTC",
+  "tag": "1.0.0",
+  "object_kind": "release",
+  "project": {
+	"id": 327622,
+	"name": "Project Name",
+	"description": "",
+	"web_url": "http://example.com/exm-namespace/example-project",
+	"avatar_url": "https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon",
+	"git_ssh_url": "git@gitlab.com:exm-namespace/example-project.git",
+	"git_http_url": "http://example.com/exm-namespace/example-project.git",
+	"namespace": "exm-namespace",
+	"visibility_level": 0,
+	"path_with_namespace": "exm-namespace/example-project",
+	"default_branch": "master",
+	"ci_config_path": "",
+	"homepage": "http://example.com/exm-namespace/example-project",
+	"url": "git@gitlab.com:exm-namespace/example-project.git",
+	"ssh_url": "git@gitlab.com:exm-namespace/example-project.git",
+	"http_url": "http://example.com/exm-namespace/example-project.git"
+  },
+  "url": "http://example.com/exm-namespace/example-project/-/releases/1.0.0",
+  "action": "create",
+  "assets": {
+	"count": 4,
+	"links": [],
+	"sources": [
+	  {
+		"format": "zip",
+		"url": "http://example.com/exm-namespace/example-project/-/archive/1.0.0/example-project-1.0.0.zip"
+	  },
+	  {
+		"format": "tar.gz",
+		"url": "http://example.com/exm-namespace/example-project/-/archive/1.0.0/example-project-1.0.0.tar.gz"
+	  },
+	  {
+		"format": "tar.bz2",
+		"url": "http://example.com/exm-namespace/example-project/-/archive/1.0.0/example-project-1.0.0.tar.bz2"
+	  },
+	  {
+		"format": "tar",
+		"url": "http://example.com/exm-namespace/example-project/-/archive/1.0.0/example-project-1.0.0.tar"
+	  }
+	]
+  },
+  "commit": {
+	"id": "2626dbdb936782b5c54816b1c6d45b1279303c6d",
+	"message": "Merge branch 'example-branch' into 'master'\n\nCheck in this test",
+	"title": "Merge branch 'example-branch' into 'master'",
+	"timestamp": "2021-02-25T21:21:58+00:00",
+	"url": "http://example.com/exm-namespace/example-project/-/commit/2626dbdb936782b5c54816b1c6d45b1279303c6d",
+	"author": {
+	  "name": "User",
+	  "email": "user@gitlab.com"
+	}
+  }
+}


### PR DESCRIPTION
See docs at https://docs.gitlab.com/ce/user/project/integrations/webhooks.html#release-events

The `release.json` is an actual webhook payload from a few hours ago, the only thing I manually added was the `Assets.Links` field from the docs so I could test it

I also added the `releases_events` to various hook options. The only part I left as it is, is the [Services API](https://docs.gitlab.com/ee/api/services.html) since I couldn't find out whether it supported the flag, so I left it for now. All other changed structs are documented