### PR TITLE
Add `Warnings` field to `LintResult` struct

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -33,8 +33,9 @@ type ValidateService struct {
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/lint.html
 type LintResult struct {
-	Status string   `json:"status"`
-	Errors []string `json:"errors"`
+	Status 	 string   `json:"status"`
+	Errors 	 []string `json:"errors"`
+	Warnings []string `json:"warnings"`
 }
 
 // ProjectLintResult represents the linting results by project.


### PR DESCRIPTION
The `ci/lint` endpoint does not only return `status` and `errors` but returns `warnings` as well in the response payload and shouldn't be ignored