### PR TITLE
Support Environment list parameters in ListOptions

### DIFF
--- a/environments.go
+++ b/environments.go
@@ -50,7 +50,12 @@ func (env Environment) String() string {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/environments.html#list-environments
-type ListEnvironmentsOptions ListOptions
+type ListEnvironmentsOptions struct {
+	ListOptions
+	Name   *string `url:"name,omitempty" json:"name,omitempty"`
+	Search *string `url:"search,omitempty" json:"search,omitempty"`
+	States *string `url:"states,omitempty" json:"states,omitempty"`
+}
 
 // ListEnvironments gets a list of environments from a project, sorted by name
 // alphabetically.

--- a/environments_test.go
+++ b/environments_test.go
@@ -33,11 +33,11 @@ func TestListEnvironments(t *testing.T) {
 
 	mux.HandleFunc("/api/v4/projects/1/environments", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
-		testURL(t, r, "/api/v4/projects/1/environments?page=1&per_page=10")
+		testURL(t, r, "/api/v4/projects/1/environments?name=review%2Ffix-foo&page=1&per_page=10")
 		fmt.Fprint(w, `[{"id": 1,"name": "review/fix-foo", "slug": "review-fix-foo-dfjre3", "external_url": "https://review-fix-foo-dfjre3.example.gitlab.com"}]`)
 	})
 
-	envs, _, err := client.Environments.ListEnvironments(1, &ListEnvironmentsOptions{Page: 1, PerPage: 10})
+	envs, _, err := client.Environments.ListEnvironments(1, &ListEnvironmentsOptions{Name: String("review/fix-foo"), ListOptions: ListOptions{Page: 1, PerPage: 10}})
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Hey,

this PR adds the `name`, `search` and `states` parameters for the environments list API. See https://docs.gitlab.com/ee/api/environments.html#list-environments

btw, could I ask if I can do anything further to get #1082 possibly merged?

Thanks!