### PR TITLE
client_options: let user pass custom Logger and LeveledLogger

### DIFF
--- a/client_options.go
+++ b/client_options.go
@@ -40,12 +40,28 @@ func WithCustomBackoff(backoff retryablehttp.Backoff) ClientOptionFunc {
 	}
 }
 
+// WithCustomLogger can be used to configure a custom retryablehttp leveled logger
+func WithCustomLeveledLogger(leveledLogger retryablehttp.LeveledLogger) ClientOptionFunc {
+	return func(c *Client) error {
+		c.client.Logger = leveledLogger
+		return nil
+	}
+}
+
 // WithCustomLimiter injects a custom rate limiter to the client.
 func WithCustomLimiter(limiter RateLimiter) ClientOptionFunc {
 	return func(c *Client) error {
 		c.configureLimiterOnce.Do(func() {
 			c.limiter = limiter
 		})
+		return nil
+	}
+}
+
+// WithCustomLogger can be used to configure a custom retryablehttp logger
+func WithCustomLogger(logger retryablehttp.Logger) ClientOptionFunc {
+	return func(c *Client) error {
+		c.client.Logger = logger
 		return nil
 	}
 }


### PR DESCRIPTION
go-retryablehttp has the option to add a custom Logger and LeveledLogger,
allowing users to pass their own implementation of them and possibly
silencing HTTP debug messages in case of retry or timeouts.

This patch adds two HTTP client options for setting these Loggers.

Signed-off-by: Bruno Meneguele <bmeneg@redhat.com>