### PR TITLE
Add GetUser with_custom_attributes option

### DIFF
--- a/users.go
+++ b/users.go
@@ -147,8 +147,6 @@ func (s *UsersService) ListUsers(opt *ListUsersOptions, options ...RequestOption
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/users.html#single-user
 type GetUsersOptions struct {
-
-	// The options below are only available for admins.
 	WithCustomAttributes *bool `url:"with_custom_attributes,omitempty" json:"with_custom_attributes,omitempty"`
 }
 

--- a/users.go
+++ b/users.go
@@ -143,13 +143,22 @@ func (s *UsersService) ListUsers(opt *ListUsersOptions, options ...RequestOption
 	return usr, resp, err
 }
 
+// GetUsersOptions represents the available GetUser() options.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#single-user
+type GetUsersOptions struct {
+
+	// The options below are only available for admins.
+	WithCustomAttributes *bool `url:"with_custom_attributes,omitempty" json:"with_custom_attributes,omitempty"`
+}
+
 // GetUser gets a single user.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/users.html#single-user
-func (s *UsersService) GetUser(user int, options ...RequestOptionFunc) (*User, *Response, error) {
+func (s *UsersService) GetUser(user int, opt GetUsersOptions, options ...RequestOptionFunc) (*User, *Response, error) {
 	u := fmt.Sprintf("users/%d", user)
 
-	req, err := s.client.NewRequest(http.MethodGet, u, nil, options)
+	req, err := s.client.NewRequest(http.MethodGet, u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Add missing `with_custom_attributes` option for `GetUser` (need admin account)

Gitlab docs:

![image](https://user-images.githubusercontent.com/30216166/113615068-ac2cc800-9653-11eb-8520-6a69958bbb18.png)
