### PR TITLE
removing user_id from personal access token struct

### DIFF
--- a/users.go
+++ b/users.go
@@ -838,7 +838,6 @@ type PersonalAccessToken struct {
 	Revoked   bool       `json:"revoked"`
 	CreatedAt *time.Time `json:"created_at"`
 	Scopes    []string   `json:"scopes"`
-	UserID    string     `json:"user_id"`
 	Active    bool       `json:"active"`
 	ExpiresAt *ISOTime   `json:"expires_at"`
 	Token     string     `json:"token"`

--- a/users.go
+++ b/users.go
@@ -838,6 +838,7 @@ type PersonalAccessToken struct {
 	Revoked   bool       `json:"revoked"`
 	CreatedAt *time.Time `json:"created_at"`
 	Scopes    []string   `json:"scopes"`
+	UserID    int        `json:"user_id"`
 	Active    bool       `json:"active"`
 	ExpiresAt *ISOTime   `json:"expires_at"`
 	Token     string     `json:"token"`


### PR DESCRIPTION
I honestly dont know, why we run into 

`&json.UnmarshalTypeError{Value:"number", Type:(*reflect.rtype)(0x9765e0), Offset:107, Struct:"PersonalAccessToken", Field:"user_id"}` 

when creating a personal access token, although the gitlab docs do return a `user_id` value:

```json

    "id": 3,
    "name": "mytoken",
    "revoked": false,
    "created_at": "2020-10-14T11:58:53.526Z",
    "scopes": [
        "api"
    ],
    "user_id": 42,
    "active": true,
    "expires_at": "2020-12-31",
    "token": "ggbfKkC4n-Lujy8jwCR2"
}
```
[https://docs.gitlab.com/ee/api/users.html#create-a-personal-access-token](https://docs.gitlab.com/ee/api/users.html#create-a-personal-access-token)

I removed the field, it works now, ..
sorry for this..