### PR TITLE
Support for managing licenses

### DIFF
--- a/gitlab.go
+++ b/gitlab.go
@@ -141,6 +141,7 @@ type Client struct {
 	Labels                *LabelsService
 	License               *LicenseService
 	LicenseTemplates      *LicenseTemplatesService
+	ManagedLicenses       *ManagedLicensesService
 	MergeRequestApprovals *MergeRequestApprovalsService
 	MergeRequests         *MergeRequestsService
 	Milestones            *MilestonesService
@@ -313,6 +314,7 @@ func newClient(options ...ClientOptionFunc) (*Client, error) {
 	c.Labels = &LabelsService{client: c}
 	c.License = &LicenseService{client: c}
 	c.LicenseTemplates = &LicenseTemplatesService{client: c}
+	c.ManagedLicenses = &ManagedLicensesService{client: c}
 	c.MergeRequestApprovals = &MergeRequestApprovalsService{client: c}
 	c.MergeRequests = &MergeRequestsService{client: c, timeStats: timeStats}
 	c.Milestones = &MilestonesService{client: c}

--- a/project_managed_licenses.go
+++ b/project_managed_licenses.go
@@ -21,42 +21,28 @@ import (
 	"net/http"
 )
 
-// ProjectManagedLicensesService handles communication with the managed
-// licenses methods of the GitLab API.
+// ManagedLicensesService handles communication with the managed licenses
+// methods of the GitLab API.
 //
-// GitLab API docs:
-// https://docs.gitlab.com/ee/api/managed_licenses.html
-type ProjectManagedLicensesService struct {
+// GitLab API docs: https://docs.gitlab.com/ee/api/managed_licenses.html
+type ManagedLicensesService struct {
 	client *Client
 }
 
-// ManagedLicenseApprovalStatus describe the approval statuses of a license.
-//
-// GitLab API docs:
-// https://docs.gitlab.com/ee/api/managed_licenses.html
-type ManagedLicenseApprovalStatus string
-
-// Values of ManagedLicenseApprovalStatus.
-const (
-	ManagedLicenseApproved    ManagedLicenseApprovalStatus = "approved"
-	ManagedLicenseBlacklisted ManagedLicenseApprovalStatus = "blacklisted"
-)
-
 // ManagedLicense represents a managed license.
 //
-// GitLab API docs:
-// https://docs.gitlab.com/ee/api/managed_licenses.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/managed_licenses.html
 type ManagedLicense struct {
-	ID             int                          `json:"id"`
-	Name           string                       `json:"name"`
-	ApprovalStatus ManagedLicenseApprovalStatus `json:"approval_status"`
+	ID             int                        `json:"id"`
+	Name           string                     `json:"name"`
+	ApprovalStatus LicenseApprovalStatusValue `json:"approval_status"`
 }
 
 // ListManagedLicenses returns a list of managed licenses from a project.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/managed_licenses.html#list-managed-licenses
-func (s *ProjectManagedLicensesService) ListManagedLicenses(pid interface{}, options ...RequestOptionFunc) ([]*ManagedLicense, *Response, error) {
+func (s *ManagedLicensesService) ListManagedLicenses(pid interface{}, options ...RequestOptionFunc) ([]*ManagedLicense, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
@@ -77,16 +63,16 @@ func (s *ProjectManagedLicensesService) ListManagedLicenses(pid interface{}, opt
 	return mls, resp, err
 }
 
-// GetManagedLicense returns a single managed license for a project.
+// GetManagedLicense returns an existing managed license.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/managed_licenses.html#show-an-existing-managed-license
-func (s *ProjectManagedLicensesService) GetManagedLicense(pid, lid interface{}, options ...RequestOptionFunc) (*ManagedLicense, *Response, error) {
+func (s *ManagedLicensesService) GetManagedLicense(pid, mlid interface{}, options ...RequestOptionFunc) (*ManagedLicense, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
-	license, err := parseID(lid)
+	license, err := parseID(mlid)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -106,20 +92,20 @@ func (s *ProjectManagedLicensesService) GetManagedLicense(pid, lid interface{}, 
 	return ml, resp, err
 }
 
-// AddManagedLicenseOptions represents the available options to add a managed license.
+// AddManagedLicenseOptions represents the available AddManagedLicense() options.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/managed_licenses.html#create-a-new-managed-license
 type AddManagedLicenseOptions struct {
-	Name           string                       `json:"name"`
-	ApprovalStatus ManagedLicenseApprovalStatus `json:"approval_status"`
+	Name           *string                     `url:"name,omitempty" json:"name,omitempty"`
+	ApprovalStatus *LicenseApprovalStatusValue `url:"approval_status,omitempty" json:"approval_status,omitempty"`
 }
 
 // AddManagedLicense adds a managed license to a project.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/managed_licenses.html#create-a-new-managed-license
-func (s *ProjectManagedLicensesService) AddManagedLicense(pid interface{}, opt *AddManagedLicenseOptions, options ...RequestOptionFunc) (*ManagedLicense, *Response, error) {
+func (s *ManagedLicensesService) AddManagedLicense(pid interface{}, opt *AddManagedLicenseOptions, options ...RequestOptionFunc) (*ManagedLicense, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
@@ -140,16 +126,16 @@ func (s *ProjectManagedLicensesService) AddManagedLicense(pid interface{}, opt *
 	return ml, resp, err
 }
 
-// RemoveManagedLicense removes a managed license from a project.
+// DeleteManagedLicense deletes a managed license with a given ID.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/managed_licenses.html#delete-a-managed-license
-func (s *ProjectManagedLicensesService) RemoveManagedLicense(pid, lid interface{}, options ...RequestOptionFunc) (*Response, error) {
+func (s *ManagedLicensesService) DeleteManagedLicense(pid, mlid interface{}, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, err
 	}
-	license, err := parseID(lid)
+	license, err := parseID(mlid)
 	if err != nil {
 		return nil, err
 	}
@@ -163,24 +149,25 @@ func (s *ProjectManagedLicensesService) RemoveManagedLicense(pid, lid interface{
 	return s.client.Do(req, nil)
 }
 
-// EditManagedLicenceOptions represents the available options to edit a managed license.
+// EditManagedLicenceOptions represents the available EditManagedLicense() options.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/managed_licenses.html#edit-an-existing-managed-license
 type EditManagedLicenceOptions struct {
-	ApprovalStatus ManagedLicenseApprovalStatus `url:"approval_status"`
+	ApprovalStatus *LicenseApprovalStatusValue `url:"approval_status,omitempty" json:"approval_status,omitempty"`
 }
 
-// EditManagedLicense updates an existing managed license in a project.
+// EditManagedLicense updates an existing managed license with a new approval
+// status.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/managed_licenses.html#edit-an-existing-managed-license
-func (s *ProjectManagedLicensesService) EditManagedLicense(pid, lid interface{}, opt *EditManagedLicenceOptions, options ...RequestOptionFunc) (*ManagedLicense, *Response, error) {
+func (s *ManagedLicensesService) EditManagedLicense(pid, mlid interface{}, opt *EditManagedLicenceOptions, options ...RequestOptionFunc) (*ManagedLicense, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
-	license, err := parseID(lid)
+	license, err := parseID(mlid)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/project_managed_licenses.go
+++ b/project_managed_licenses.go
@@ -1,0 +1,201 @@
+//
+// Copyright 2021, Andrea Perizzato
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package gitlab
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// ProjectManagedLicensesService handles communication with the managed
+// licenses methods of the GitLab API.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/managed_licenses.html
+type ProjectManagedLicensesService struct {
+	client *Client
+}
+
+// ManagedLicenseApprovalStatus describe the approval statuses of a license.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/managed_licenses.html
+type ManagedLicenseApprovalStatus string
+
+// Values of ManagedLicenseApprovalStatus.
+const (
+	ManagedLicenseApproved    ManagedLicenseApprovalStatus = "approved"
+	ManagedLicenseBlacklisted ManagedLicenseApprovalStatus = "blacklisted"
+)
+
+// ManagedLicense represents a managed license.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/managed_licenses.html
+type ManagedLicense struct {
+	ID             int                          `json:"id"`
+	Name           string                       `json:"name"`
+	ApprovalStatus ManagedLicenseApprovalStatus `json:"approval_status"`
+}
+
+// ListManagedLicenses returns a list of managed licenses from a project.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/managed_licenses.html#list-managed-licenses
+func (s *ProjectManagedLicensesService) ListManagedLicenses(pid interface{}, options ...RequestOptionFunc) ([]*ManagedLicense, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/managed_licenses", pathEscape(project))
+
+	req, err := s.client.NewRequest(http.MethodGet, u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var mls []*ManagedLicense
+	resp, err := s.client.Do(req, &mls)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return mls, resp, err
+}
+
+// GetManagedLicense returns a single managed license for a project.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/managed_licenses.html#show-an-existing-managed-license
+func (s *ProjectManagedLicensesService) GetManagedLicense(pid, lid interface{}, options ...RequestOptionFunc) (*ManagedLicense, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	license, err := parseID(lid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/managed_licenses/%s", pathEscape(project), pathEscape(license))
+
+	req, err := s.client.NewRequest(http.MethodGet, u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ml := new(ManagedLicense)
+	resp, err := s.client.Do(req, ml)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return ml, resp, err
+}
+
+// AddManagedLicenseOptions represents the available options to add a managed license.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/managed_licenses.html#create-a-new-managed-license
+type AddManagedLicenseOptions struct {
+	Name           string                       `json:"name"`
+	ApprovalStatus ManagedLicenseApprovalStatus `json:"approval_status"`
+}
+
+// AddManagedLicense adds a managed license to a project.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/managed_licenses.html#create-a-new-managed-license
+func (s *ProjectManagedLicensesService) AddManagedLicense(pid interface{}, opt *AddManagedLicenseOptions, options ...RequestOptionFunc) (*ManagedLicense, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/managed_licenses", pathEscape(project))
+
+	req, err := s.client.NewRequest(http.MethodPost, u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ml := new(ManagedLicense)
+	resp, err := s.client.Do(req, ml)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return ml, resp, err
+}
+
+// RemoveManagedLicense removes a managed license from a project.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/managed_licenses.html#delete-a-managed-license
+func (s *ProjectManagedLicensesService) RemoveManagedLicense(pid, lid interface{}, options ...RequestOptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	license, err := parseID(lid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/managed_licenses/%s", pathEscape(project), pathEscape(license))
+
+	req, err := s.client.NewRequest(http.MethodDelete, u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// EditManagedLicenceOptions represents the available options to edit a managed license.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/managed_licenses.html#edit-an-existing-managed-license
+type EditManagedLicenceOptions struct {
+	ApprovalStatus ManagedLicenseApprovalStatus `url:"approval_status"`
+}
+
+// EditManagedLicense updates an existing managed license in a project.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/managed_licenses.html#edit-an-existing-managed-license
+func (s *ProjectManagedLicensesService) EditManagedLicense(pid, lid interface{}, opt *EditManagedLicenceOptions, options ...RequestOptionFunc) (*ManagedLicense, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	license, err := parseID(lid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/managed_licenses/%s", pathEscape(project), pathEscape(license))
+
+	req, err := s.client.NewRequest(http.MethodPatch, u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ml := new(ManagedLicense)
+	resp, err := s.client.Do(req, ml)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return ml, resp, err
+}

--- a/project_managed_licenses_test.go
+++ b/project_managed_licenses_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 )
 
-func TestListProjectManagedLicenses(t *testing.T) {
+func TestListManagedLicenses(t *testing.T) {
 	mux, server, client := setup(t)
 	defer teardown(server)
 
@@ -31,30 +31,30 @@ func TestListProjectManagedLicenses(t *testing.T) {
 		mustWriteHTTPResponse(t, w, "testdata/list_project_managed_licenses.json")
 	})
 
-	licenses, _, err := client.ProjectManagedLicenses.ListManagedLicenses(1)
+	licenses, _, err := client.ManagedLicenses.ListManagedLicenses(1)
 	if err != nil {
-		t.Errorf("ProjectManagedLicenses.ListManagedLicenses returned error: %v", err)
+		t.Errorf("ManagedLicenses.ListManagedLicenses returned error: %v", err)
 	}
 
 	want := []*ManagedLicense{
 		{
 			ID:             1,
 			Name:           "MIT",
-			ApprovalStatus: ManagedLicenseApproved,
+			ApprovalStatus: LicenseApproved,
 		},
 		{
 			ID:             3,
 			Name:           "ISC",
-			ApprovalStatus: ManagedLicenseBlacklisted,
+			ApprovalStatus: LicenseBlacklisted,
 		},
 	}
 
 	if !reflect.DeepEqual(want, licenses) {
-		t.Errorf("ProjectManagedLicenses.ListManagedLicenses returned %+v, want %+v", licenses, want)
+		t.Errorf("ManagedLicenses.ListManagedLicenses returned %+v, want %+v", licenses, want)
 	}
 }
 
-func TestGetProjectManagedLicenses(t *testing.T) {
+func TestGetManagedLicenses(t *testing.T) {
 	mux, server, client := setup(t)
 	defer teardown(server)
 
@@ -63,23 +63,23 @@ func TestGetProjectManagedLicenses(t *testing.T) {
 		mustWriteHTTPResponse(t, w, "testdata/get_project_managed_license.json")
 	})
 
-	license, _, err := client.ProjectManagedLicenses.GetManagedLicense(1, 3)
+	license, _, err := client.ManagedLicenses.GetManagedLicense(1, 3)
 	if err != nil {
-		t.Errorf("ProjectManagedLicenses.GetManagedLicense returned error: %v", err)
+		t.Errorf("ManagedLicenses.GetManagedLicense returned error: %v", err)
 	}
 
 	want := &ManagedLicense{
 		ID:             3,
 		Name:           "ISC",
-		ApprovalStatus: ManagedLicenseBlacklisted,
+		ApprovalStatus: LicenseBlacklisted,
 	}
 
 	if !reflect.DeepEqual(want, license) {
-		t.Errorf("ProjectManagedLicenses.GetManagedLicense returned %+v, want %+v", license, want)
+		t.Errorf("ManagedLicenses.GetManagedLicense returned %+v, want %+v", license, want)
 	}
 }
 
-func TestAddProjectManagedLicenses(t *testing.T) {
+func TestAddManagedLicenses(t *testing.T) {
 	mux, server, client := setup(t)
 	defer teardown(server)
 
@@ -90,26 +90,26 @@ func TestAddProjectManagedLicenses(t *testing.T) {
 	})
 
 	ops := AddManagedLicenseOptions{
-		Name:           "MIT",
-		ApprovalStatus: ManagedLicenseApproved,
+		Name:           String("MIT"),
+		ApprovalStatus: LicenseApprovalStatus(LicenseApproved),
 	}
-	license, _, err := client.ProjectManagedLicenses.AddManagedLicense(1, &ops)
+	license, _, err := client.ManagedLicenses.AddManagedLicense(1, &ops)
 	if err != nil {
-		t.Errorf("ProjectManagedLicenses.AddManagedLicense returned error: %v", err)
+		t.Errorf("ManagedLicenses.AddManagedLicense returned error: %v", err)
 	}
 
 	want := &ManagedLicense{
 		ID:             123,
 		Name:           "MIT",
-		ApprovalStatus: ManagedLicenseApproved,
+		ApprovalStatus: LicenseApproved,
 	}
 
 	if !reflect.DeepEqual(want, license) {
-		t.Errorf("ProjectManagedLicenses.AddManagedLicense returned %+v, want %+v", license, want)
+		t.Errorf("ManagedLicenses.AddManagedLicense returned %+v, want %+v", license, want)
 	}
 }
 
-func TestRemoveProjectManagedLicenses(t *testing.T) {
+func TestDeleteManagedLicenses(t *testing.T) {
 	mux, server, client := setup(t)
 	defer teardown(server)
 
@@ -117,13 +117,13 @@ func TestRemoveProjectManagedLicenses(t *testing.T) {
 		testMethod(t, r, http.MethodDelete)
 	})
 
-	_, err := client.ProjectManagedLicenses.RemoveManagedLicense(1, 3)
+	_, err := client.ManagedLicenses.DeleteManagedLicense(1, 3)
 	if err != nil {
-		t.Errorf("ProjectManagedLicenses.RemoveManagedLicense returned error: %v", err)
+		t.Errorf("ManagedLicenses.RemoveManagedLicense returned error: %v", err)
 	}
 }
 
-func TestEditProjectManagedLicenses(t *testing.T) {
+func TestEditManagedLicenses(t *testing.T) {
 	mux, server, client := setup(t)
 	defer teardown(server)
 
@@ -137,20 +137,20 @@ func TestEditProjectManagedLicenses(t *testing.T) {
 	})
 
 	ops := EditManagedLicenceOptions{
-		ApprovalStatus: ManagedLicenseBlacklisted,
+		ApprovalStatus: LicenseApprovalStatus(LicenseBlacklisted),
 	}
-	license, _, err := client.ProjectManagedLicenses.EditManagedLicense(1, 3, &ops)
+	license, _, err := client.ManagedLicenses.EditManagedLicense(1, 3, &ops)
 	if err != nil {
-		t.Errorf("ProjectManagedLicenses.EditManagedLicense returned error: %v", err)
+		t.Errorf("ManagedLicenses.EditManagedLicense returned error: %v", err)
 	}
 
 	want := &ManagedLicense{
 		ID:             3,
 		Name:           "CUSTOM",
-		ApprovalStatus: ManagedLicenseBlacklisted,
+		ApprovalStatus: LicenseBlacklisted,
 	}
 
 	if !reflect.DeepEqual(want, license) {
-		t.Errorf("ProjectManagedLicenses.EditManagedLicense returned %+v, want %+v", license, want)
+		t.Errorf("ManagedLicenses.EditManagedLicense returned %+v, want %+v", license, want)
 	}
 }

--- a/project_managed_licenses_test.go
+++ b/project_managed_licenses_test.go
@@ -1,0 +1,156 @@
+//
+// Copyright 2021, Andrea Perizzato
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package gitlab
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestListProjectManagedLicenses(t *testing.T) {
+	mux, server, client := setup(t)
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v4/projects/1/managed_licenses", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		mustWriteHTTPResponse(t, w, "testdata/list_project_managed_licenses.json")
+	})
+
+	licenses, _, err := client.ProjectManagedLicenses.ListManagedLicenses(1)
+	if err != nil {
+		t.Errorf("ProjectManagedLicenses.ListManagedLicenses returned error: %v", err)
+	}
+
+	want := []*ManagedLicense{
+		{
+			ID:             1,
+			Name:           "MIT",
+			ApprovalStatus: ManagedLicenseApproved,
+		},
+		{
+			ID:             3,
+			Name:           "ISC",
+			ApprovalStatus: ManagedLicenseBlacklisted,
+		},
+	}
+
+	if !reflect.DeepEqual(want, licenses) {
+		t.Errorf("ProjectManagedLicenses.ListManagedLicenses returned %+v, want %+v", licenses, want)
+	}
+}
+
+func TestGetProjectManagedLicenses(t *testing.T) {
+	mux, server, client := setup(t)
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v4/projects/1/managed_licenses/3", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		mustWriteHTTPResponse(t, w, "testdata/get_project_managed_license.json")
+	})
+
+	license, _, err := client.ProjectManagedLicenses.GetManagedLicense(1, 3)
+	if err != nil {
+		t.Errorf("ProjectManagedLicenses.GetManagedLicense returned error: %v", err)
+	}
+
+	want := &ManagedLicense{
+		ID:             3,
+		Name:           "ISC",
+		ApprovalStatus: ManagedLicenseBlacklisted,
+	}
+
+	if !reflect.DeepEqual(want, license) {
+		t.Errorf("ProjectManagedLicenses.GetManagedLicense returned %+v, want %+v", license, want)
+	}
+}
+
+func TestAddProjectManagedLicenses(t *testing.T) {
+	mux, server, client := setup(t)
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v4/projects/1/managed_licenses", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		testBody(t, r, `{"name":"MIT","approval_status":"approved"}`)
+		mustWriteHTTPResponse(t, w, "testdata/add_project_managed_license.json")
+	})
+
+	ops := AddManagedLicenseOptions{
+		Name:           "MIT",
+		ApprovalStatus: ManagedLicenseApproved,
+	}
+	license, _, err := client.ProjectManagedLicenses.AddManagedLicense(1, &ops)
+	if err != nil {
+		t.Errorf("ProjectManagedLicenses.AddManagedLicense returned error: %v", err)
+	}
+
+	want := &ManagedLicense{
+		ID:             123,
+		Name:           "MIT",
+		ApprovalStatus: ManagedLicenseApproved,
+	}
+
+	if !reflect.DeepEqual(want, license) {
+		t.Errorf("ProjectManagedLicenses.AddManagedLicense returned %+v, want %+v", license, want)
+	}
+}
+
+func TestRemoveProjectManagedLicenses(t *testing.T) {
+	mux, server, client := setup(t)
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v4/projects/1/managed_licenses/3", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodDelete)
+	})
+
+	_, err := client.ProjectManagedLicenses.RemoveManagedLicense(1, 3)
+	if err != nil {
+		t.Errorf("ProjectManagedLicenses.RemoveManagedLicense returned error: %v", err)
+	}
+}
+
+func TestEditProjectManagedLicenses(t *testing.T) {
+	mux, server, client := setup(t)
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v4/projects/1/managed_licenses/3", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPatch)
+		approvalStatus := r.URL.Query().Get("approval_status")
+		if approvalStatus != "blacklisted" {
+			t.Errorf("query param approval_status should be blacklisted but was %s", approvalStatus)
+		}
+		mustWriteHTTPResponse(t, w, "testdata/edit_project_managed_license.json")
+	})
+
+	ops := EditManagedLicenceOptions{
+		ApprovalStatus: ManagedLicenseBlacklisted,
+	}
+	license, _, err := client.ProjectManagedLicenses.EditManagedLicense(1, 3, &ops)
+	if err != nil {
+		t.Errorf("ProjectManagedLicenses.EditManagedLicense returned error: %v", err)
+	}
+
+	want := &ManagedLicense{
+		ID:             3,
+		Name:           "CUSTOM",
+		ApprovalStatus: ManagedLicenseBlacklisted,
+	}
+
+	if !reflect.DeepEqual(want, license) {
+		t.Errorf("ProjectManagedLicenses.EditManagedLicense returned %+v, want %+v", license, want)
+	}
+}

--- a/testdata/add_project_managed_license.json
+++ b/testdata/add_project_managed_license.json
@@ -1,0 +1,5 @@
+{
+  "id": 123,
+  "name": "MIT",
+  "approval_status": "approved"
+}

--- a/testdata/edit_project_managed_license.json
+++ b/testdata/edit_project_managed_license.json
@@ -1,0 +1,5 @@
+{
+  "id": 3,
+  "name": "CUSTOM",
+  "approval_status": "blacklisted"
+}

--- a/testdata/get_project_managed_license.json
+++ b/testdata/get_project_managed_license.json
@@ -1,0 +1,5 @@
+{
+  "id": 3,
+  "name": "ISC",
+  "approval_status": "blacklisted"
+}

--- a/testdata/list_project_managed_licenses.json
+++ b/testdata/list_project_managed_licenses.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": 1,
+    "name": "MIT",
+    "approval_status": "approved"
+  },
+  {
+    "id": 3,
+    "name": "ISC",
+    "approval_status": "blacklisted"
+  }
+]

--- a/types.go
+++ b/types.go
@@ -249,6 +249,25 @@ func LinkType(v LinkTypeValue) *LinkTypeValue {
 	return p
 }
 
+// LicenseApprovalStatusValue describe the approval statuses of a license.
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/managed_licenses.html
+type LicenseApprovalStatusValue string
+
+// List of available license approval statuses.
+const (
+	LicenseApproved    LicenseApprovalStatusValue = "approved"
+	LicenseBlacklisted LicenseApprovalStatusValue = "blacklisted"
+)
+
+// LicenseApprovalStatus is a helper routine that allocates a new license
+// approval status value to store v and returns a pointer to it.
+func LicenseApprovalStatus(v LicenseApprovalStatusValue) *LicenseApprovalStatusValue {
+	p := new(LicenseApprovalStatusValue)
+	*p = v
+	return p
+}
+
 // MergeMethodValue represents a project merge type within GitLab.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#project-merge-method


### PR DESCRIPTION
This PR adds support for [project-level managed licenses](https://docs.gitlab.com/ee/api/managed_licenses.html).

Specifically:
- Adds a new `ProjectManagedLicensesService` service
- Adds functionality to:
  - List managed licenses
  - Get managed license
  - Edit existing managed license
  - Add/Remove managed licenses to project

All requests are covered by tests.