### PR TITLE
Add DirectAssetURL, FilePath & LinkType to Release Links API

### DIFF
--- a/fixtures_test.go
+++ b/fixtures_test.go
@@ -68,7 +68,9 @@ const (
 		"id":1,
 		"name":"awesome-v0.2.dmg",
 		"url":"http://192.168.10.15:3000",
-		"external":true
+		"external":true,
+		"direct_asset_url": "http://192.168.10.15:3000/namespace/example/-/releases/v0.1/downloads/awesome-v0.2.dmg",
+		"link_type": "other"
 	}`
 
 	// exampleReleaseLinkList provides fixture for Release Links tests.
@@ -83,7 +85,9 @@ const (
 			"id": 1,
 			"name": "awesome-v0.2.dmg",
 			"url": "http://192.168.10.15:3000",
-			"external": true
+			"direct_asset_url": "http://192.168.10.15:3000/namespace/example/-/releases/v0.1/downloads/awesome-v0.2.dmg",
+			"link_type": "other",
+			"external": false
 		}
 	]`
 

--- a/fixtures_test.go
+++ b/fixtures_test.go
@@ -68,8 +68,8 @@ const (
 		"id":1,
 		"name":"awesome-v0.2.dmg",
 		"url":"http://192.168.10.15:3000",
-		"external":true,
 		"direct_asset_url": "http://192.168.10.15:3000/namespace/example/-/releases/v0.1/downloads/awesome-v0.2.dmg",
+		"external":true,
 		"link_type": "other"
 	}`
 
@@ -86,8 +86,8 @@ const (
 			"name": "awesome-v0.2.dmg",
 			"url": "http://192.168.10.15:3000",
 			"direct_asset_url": "http://192.168.10.15:3000/namespace/example/-/releases/v0.1/downloads/awesome-v0.2.dmg",
-			"link_type": "other",
-			"external": false
+			"external": false,
+			"link_type": "other"
 		}
 	]`
 

--- a/releaselinks.go
+++ b/releaselinks.go
@@ -103,7 +103,7 @@ func (s *ReleaseLinksService) GetReleaseLink(pid interface{}, tagName string, li
 type CreateReleaseLinkOptions struct {
 	Name     *string `url:"name" json:"name"`
 	URL      *string `url:"url" json:"url"`
-	FilePath *string `url:"file_path,omitempty" json:"file_path,omitempty"`
+	FilePath *string `url:"filepath,omitempty" json:"filepath,omitempty"`
 	LinkType *string `url:"link_type,omitempty" json:"link_type,omitempty"`
 }
 
@@ -139,7 +139,7 @@ func (s *ReleaseLinksService) CreateReleaseLink(pid interface{}, tagName string,
 type UpdateReleaseLinkOptions struct {
 	Name     *string `url:"name,omitempty" json:"name,omitempty"`
 	URL      *string `url:"url,omitempty" json:"url,omitempty"`
-	FilePath *string `url:"file_path,omitempty" json:"file_path,omitempty"`
+	FilePath *string `url:"filepath,omitempty" json:"filepath,omitempty"`
 	LinkType *string `url:"link_type,omitempty" json:"link_type,omitempty"`
 }
 

--- a/releaselinks.go
+++ b/releaselinks.go
@@ -33,12 +33,12 @@ type ReleaseLinksService struct {
 //
 // GitLab API docs: https://docs.gitlab.com/ee/api/releases/links.html
 type ReleaseLink struct {
-	ID             int    `json:"id"`
-	Name           string `json:"name"`
-	URL            string `json:"url"`
-	External       bool   `json:"external"`
-	DirectAssetURL string `json:"direct_asset_url,omitempty"`
-	LinkType       string `json:"link_type,omitempty"`
+	ID             int                  `json:"id"`
+	Name           string               `json:"name"`
+	URL            string               `json:"url"`
+	DirectAssetURL string               `json:"direct_asset_url"`
+	External       bool                 `json:"external"`
+	LinkType       ReleaseLinkTypeValue `json:"link_type"`
 }
 
 // ListReleaseLinksOptions represents ListReleaseLinks() options.
@@ -101,10 +101,10 @@ func (s *ReleaseLinksService) GetReleaseLink(pid interface{}, tagName string, li
 //
 // GitLab API docs: https://docs.gitlab.com/ee/api/releases/links.html#create-a-link
 type CreateReleaseLinkOptions struct {
-	Name     *string `url:"name" json:"name"`
-	URL      *string `url:"url" json:"url"`
-	FilePath *string `url:"filepath,omitempty" json:"filepath,omitempty"`
-	LinkType *string `url:"link_type,omitempty" json:"link_type,omitempty"`
+	Name     *string               `url:"name" json:"name"`
+	URL      *string               `url:"url" json:"url"`
+	FilePath *string               `url:"filepath,omitempty" json:"filepath,omitempty"`
+	LinkType *ReleaseLinkTypeValue `url:"link_type,omitempty" json:"link_type,omitempty"`
 }
 
 // CreateReleaseLink creates a link.
@@ -137,10 +137,10 @@ func (s *ReleaseLinksService) CreateReleaseLink(pid interface{}, tagName string,
 //
 // GitLab API docs: https://docs.gitlab.com/ee/api/releases/links.html#update-a-link
 type UpdateReleaseLinkOptions struct {
-	Name     *string `url:"name,omitempty" json:"name,omitempty"`
-	URL      *string `url:"url,omitempty" json:"url,omitempty"`
-	FilePath *string `url:"filepath,omitempty" json:"filepath,omitempty"`
-	LinkType *string `url:"link_type,omitempty" json:"link_type,omitempty"`
+	Name     *string               `url:"name,omitempty" json:"name,omitempty"`
+	URL      *string               `url:"url,omitempty" json:"url,omitempty"`
+	FilePath *string               `url:"filepath,omitempty" json:"filepath,omitempty"`
+	LinkType *ReleaseLinkTypeValue `url:"link_type,omitempty" json:"link_type,omitempty"`
 }
 
 // UpdateReleaseLink updates an asset link.

--- a/releaselinks.go
+++ b/releaselinks.go
@@ -33,12 +33,12 @@ type ReleaseLinksService struct {
 //
 // GitLab API docs: https://docs.gitlab.com/ee/api/releases/links.html
 type ReleaseLink struct {
-	ID             int                  `json:"id"`
-	Name           string               `json:"name"`
-	URL            string               `json:"url"`
-	DirectAssetURL string               `json:"direct_asset_url"`
-	External       bool                 `json:"external"`
-	LinkType       ReleaseLinkTypeValue `json:"link_type"`
+	ID             int           `json:"id"`
+	Name           string        `json:"name"`
+	URL            string        `json:"url"`
+	DirectAssetURL string        `json:"direct_asset_url"`
+	External       bool          `json:"external"`
+	LinkType       LinkTypeValue `json:"link_type"`
 }
 
 // ListReleaseLinksOptions represents ListReleaseLinks() options.
@@ -101,10 +101,10 @@ func (s *ReleaseLinksService) GetReleaseLink(pid interface{}, tagName string, li
 //
 // GitLab API docs: https://docs.gitlab.com/ee/api/releases/links.html#create-a-link
 type CreateReleaseLinkOptions struct {
-	Name     *string               `url:"name,omitempty" json:"name,omitempty"`
-	URL      *string               `url:"url,omitempty" json:"url,omitempty"`
-	FilePath *string               `url:"filepath,omitempty" json:"filepath,omitempty"`
-	LinkType *ReleaseLinkTypeValue `url:"link_type,omitempty" json:"link_type,omitempty"`
+	Name     *string        `url:"name,omitempty" json:"name,omitempty"`
+	URL      *string        `url:"url,omitempty" json:"url,omitempty"`
+	FilePath *string        `url:"filepath,omitempty" json:"filepath,omitempty"`
+	LinkType *LinkTypeValue `url:"link_type,omitempty" json:"link_type,omitempty"`
 }
 
 // CreateReleaseLink creates a link.
@@ -137,10 +137,10 @@ func (s *ReleaseLinksService) CreateReleaseLink(pid interface{}, tagName string,
 //
 // GitLab API docs: https://docs.gitlab.com/ee/api/releases/links.html#update-a-link
 type UpdateReleaseLinkOptions struct {
-	Name     *string               `url:"name,omitempty" json:"name,omitempty"`
-	URL      *string               `url:"url,omitempty" json:"url,omitempty"`
-	FilePath *string               `url:"filepath,omitempty" json:"filepath,omitempty"`
-	LinkType *ReleaseLinkTypeValue `url:"link_type,omitempty" json:"link_type,omitempty"`
+	Name     *string        `url:"name,omitempty" json:"name,omitempty"`
+	URL      *string        `url:"url,omitempty" json:"url,omitempty"`
+	FilePath *string        `url:"filepath,omitempty" json:"filepath,omitempty"`
+	LinkType *LinkTypeValue `url:"link_type,omitempty" json:"link_type,omitempty"`
 }
 
 // UpdateReleaseLink updates an asset link.

--- a/releaselinks.go
+++ b/releaselinks.go
@@ -33,10 +33,12 @@ type ReleaseLinksService struct {
 //
 // GitLab API docs: https://docs.gitlab.com/ee/api/releases/links.html
 type ReleaseLink struct {
-	ID       int    `json:"id"`
-	Name     string `json:"name"`
-	URL      string `json:"url"`
-	External bool   `json:"external"`
+	ID             int    `json:"id"`
+	Name           string `json:"name"`
+	URL            string `json:"url"`
+	External       bool   `json:"external"`
+	DirectAssetURL string `json:"direct_asset_url,omitempty"`
+	LinkType       string `json:"link_type,omitempty"`
 }
 
 // ListReleaseLinksOptions represents ListReleaseLinks() options.
@@ -99,8 +101,10 @@ func (s *ReleaseLinksService) GetReleaseLink(pid interface{}, tagName string, li
 //
 // GitLab API docs: https://docs.gitlab.com/ee/api/releases/links.html#create-a-link
 type CreateReleaseLinkOptions struct {
-	Name *string `url:"name" json:"name"`
-	URL  *string `url:"url" json:"url"`
+	Name     *string `url:"name" json:"name"`
+	URL      *string `url:"url" json:"url"`
+	FilePath *string `url:"file_path,omitempty" json:"file_path,omitempty"`
+	LinkType *string `url:"link_type,omitempty" json:"link_type,omitempty"`
 }
 
 // CreateReleaseLink creates a link.
@@ -133,8 +137,10 @@ func (s *ReleaseLinksService) CreateReleaseLink(pid interface{}, tagName string,
 //
 // GitLab API docs: https://docs.gitlab.com/ee/api/releases/links.html#update-a-link
 type UpdateReleaseLinkOptions struct {
-	Name *string `url:"name,omitempty" json:"name,omitempty"`
-	URL  *string `url:"url,omitempty" json:"url,omitempty"`
+	Name     *string `url:"name,omitempty" json:"name,omitempty"`
+	URL      *string `url:"url,omitempty" json:"url,omitempty"`
+	FilePath *string `url:"file_path,omitempty" json:"file_path,omitempty"`
+	LinkType *string `url:"link_type,omitempty" json:"link_type,omitempty"`
 }
 
 // UpdateReleaseLink updates an asset link.

--- a/releaselinks.go
+++ b/releaselinks.go
@@ -101,8 +101,8 @@ func (s *ReleaseLinksService) GetReleaseLink(pid interface{}, tagName string, li
 //
 // GitLab API docs: https://docs.gitlab.com/ee/api/releases/links.html#create-a-link
 type CreateReleaseLinkOptions struct {
-	Name     *string               `url:"name" json:"name"`
-	URL      *string               `url:"url" json:"url"`
+	Name     *string               `url:"name,omitempty" json:"name,omitempty"`
+	URL      *string               `url:"url,omitempty" json:"url,omitempty"`
 	FilePath *string               `url:"filepath,omitempty" json:"filepath,omitempty"`
 	LinkType *ReleaseLinkTypeValue `url:"link_type,omitempty" json:"link_type,omitempty"`
 }

--- a/releaselinks_test.go
+++ b/releaselinks_test.go
@@ -53,7 +53,7 @@ func TestReleaseLinksService_ListReleaseLinks(t *testing.T) {
 			URL:            "http://192.168.10.15:3000",
 			DirectAssetURL: "http://192.168.10.15:3000/namespace/example/-/releases/v0.1/downloads/awesome-v0.2.dmg",
 			External:       false,
-			LinkType:       OtherReleaseLinkType,
+			LinkType:       OtherLinkType,
 		},
 	}
 	assert.Equal(t, expectedReleaseLinks, releaseLinks)
@@ -90,7 +90,7 @@ func TestReleaseLinksService_CreateReleaseLink(t *testing.T) {
 				Name:     String("release-notes.md"),
 				URL:      String("http://192.168.10.15:3000"),
 				FilePath: String("docs/release-notes.md"),
-				LinkType: ReleaseLinkType(OtherReleaseLinkType),
+				LinkType: LinkType(OtherLinkType),
 			},
 			response: `{
 				"id":1,
@@ -106,7 +106,7 @@ func TestReleaseLinksService_CreateReleaseLink(t *testing.T) {
 				URL:            "http://192.168.10.15:3000",
 				DirectAssetURL: "http://192.168.10.15:3000/namespace/example/-/releases/v0.1/downloads/docs/release-notes.md",
 				External:       false,
-				LinkType:       OtherReleaseLinkType,
+				LinkType:       OtherLinkType,
 			},
 		},
 	}
@@ -164,7 +164,7 @@ func TestReleaseLinksService_UpdateReleaseLink(t *testing.T) {
 		&UpdateReleaseLinkOptions{
 			Name:     String(exampleReleaseName),
 			FilePath: String("http://192.168.10.15:3000/namespace/example/-/releases/v0.1/downloads/awesome-v0.2.dmg"),
-			LinkType: ReleaseLinkType(OtherReleaseLinkType),
+			LinkType: LinkType(OtherLinkType),
 		})
 
 	require.NoError(t, err)
@@ -174,7 +174,7 @@ func TestReleaseLinksService_UpdateReleaseLink(t *testing.T) {
 		URL:            "http://192.168.10.15:3000",
 		DirectAssetURL: "http://192.168.10.15:3000/namespace/example/-/releases/v0.1/downloads/awesome-v0.2.dmg",
 		External:       true,
-		LinkType:       OtherReleaseLinkType,
+		LinkType:       OtherLinkType,
 	}
 	assert.Equal(t, expectedRelease, releaseLink)
 }

--- a/releaselinks_test.go
+++ b/releaselinks_test.go
@@ -51,9 +51,9 @@ func TestReleaseLinksService_ListReleaseLinks(t *testing.T) {
 			ID:             1,
 			Name:           "awesome-v0.2.dmg",
 			URL:            "http://192.168.10.15:3000",
-			External:       false,
 			DirectAssetURL: "http://192.168.10.15:3000/namespace/example/-/releases/v0.1/downloads/awesome-v0.2.dmg",
-			LinkType:       "other",
+			External:       false,
+			LinkType:       OtherReleaseLinkType,
 		},
 	}
 	assert.Equal(t, expectedReleaseLinks, releaseLinks)
@@ -90,7 +90,7 @@ func TestReleaseLinksService_CreateReleaseLink(t *testing.T) {
 				Name:     String("release-notes.md"),
 				URL:      String("http://192.168.10.15:3000"),
 				FilePath: String("docs/release-notes.md"),
-				LinkType: String("other"),
+				LinkType: ReleaseLinkType(OtherReleaseLinkType),
 			},
 			response: `{
 				"id":1,
@@ -105,8 +105,8 @@ func TestReleaseLinksService_CreateReleaseLink(t *testing.T) {
 				Name:           "release-notes.md",
 				URL:            "http://192.168.10.15:3000",
 				DirectAssetURL: "http://192.168.10.15:3000/namespace/example/-/releases/v0.1/downloads/docs/release-notes.md",
-				LinkType:       "other",
 				External:       false,
+				LinkType:       OtherReleaseLinkType,
 			},
 		},
 	}
@@ -164,7 +164,7 @@ func TestReleaseLinksService_UpdateReleaseLink(t *testing.T) {
 		&UpdateReleaseLinkOptions{
 			Name:     String(exampleReleaseName),
 			FilePath: String("http://192.168.10.15:3000/namespace/example/-/releases/v0.1/downloads/awesome-v0.2.dmg"),
-			LinkType: String("other"),
+			LinkType: ReleaseLinkType(OtherReleaseLinkType),
 		})
 
 	require.NoError(t, err)
@@ -172,9 +172,9 @@ func TestReleaseLinksService_UpdateReleaseLink(t *testing.T) {
 		ID:             1,
 		Name:           "awesome-v0.2.dmg",
 		URL:            "http://192.168.10.15:3000",
-		External:       true,
 		DirectAssetURL: "http://192.168.10.15:3000/namespace/example/-/releases/v0.1/downloads/awesome-v0.2.dmg",
-		LinkType:       "other",
+		External:       true,
+		LinkType:       OtherReleaseLinkType,
 	}
 	assert.Equal(t, expectedRelease, releaseLink)
 }

--- a/releaselinks_test.go
+++ b/releaselinks_test.go
@@ -20,6 +20,9 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestReleaseLinksService_ListReleaseLinks(t *testing.T) {
@@ -35,40 +38,94 @@ func TestReleaseLinksService_ListReleaseLinks(t *testing.T) {
 	releaseLinks, _, err := client.ReleaseLinks.ListReleaseLinks(
 		1, exampleTagName, &ListReleaseLinksOptions{},
 	)
-	if err != nil {
-		t.Error(err)
+
+	require.NoError(t, err)
+	expectedReleaseLinks := []*ReleaseLink{
+		{
+			ID:       2,
+			Name:     "awesome-v0.2.msi",
+			URL:      "http://192.168.10.15:3000/msi",
+			External: true,
+		},
+		{
+			ID:             1,
+			Name:           "awesome-v0.2.dmg",
+			URL:            "http://192.168.10.15:3000",
+			External:       false,
+			DirectAssetURL: "http://192.168.10.15:3000/namespace/example/-/releases/v0.1/downloads/awesome-v0.2.dmg",
+			LinkType:       "other",
+		},
 	}
-	if len(releaseLinks) != 2 {
-		t.Error("expected 2 links")
-	}
-	if releaseLinks[0].Name != "awesome-v0.2.msi" {
-		t.Errorf("release link name, expected '%s', got '%s'", "awesome-v0.2.msi",
-			releaseLinks[0].Name)
-	}
+	assert.Equal(t, expectedReleaseLinks, releaseLinks)
 }
 
 func TestReleaseLinksService_CreateReleaseLink(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
-
-	mux.HandleFunc("/api/v4/projects/1/releases/v0.1/assets/links",
-		func(w http.ResponseWriter, r *http.Request) {
-			testMethod(t, r, http.MethodPost)
-			fmt.Fprint(w, exampleReleaseLink)
-		})
-
-	releaseLink, _, err := client.ReleaseLinks.CreateReleaseLink(
-		1, exampleTagName,
-		&CreateReleaseLinkOptions{
-			Name: String(exampleReleaseName),
-			URL:  String("http://192.168.10.15:3000"),
-		})
-	if err != nil {
-		t.Error(err)
+	testCases := []struct {
+		description string
+		options     *CreateReleaseLinkOptions
+		response    string
+		want        *ReleaseLink
+	}{
+		{
+			description: "Mandatory Attributes",
+			options: &CreateReleaseLinkOptions{
+				Name: String("awesome-v0.2.dmg"),
+				URL:  String("http://192.168.10.15:3000")},
+			response: `{
+				"id":1,
+				"name":"awesome-v0.2.dmg",
+				"url":"http://192.168.10.15:3000",
+				"external":true
+			}`,
+			want: &ReleaseLink{
+				ID:       1,
+				Name:     "awesome-v0.2.dmg",
+				URL:      "http://192.168.10.15:3000",
+				External: true,
+			},
+		},
+		{
+			description: "Optional Attributes",
+			options: &CreateReleaseLinkOptions{
+				Name:     String("release-notes.md"),
+				URL:      String("http://192.168.10.15:3000"),
+				FilePath: String("docs/release-notes.md"),
+				LinkType: String("other"),
+			},
+			response: `{
+				"id":1,
+				"name":"release-notes.md",
+				"url":"http://192.168.10.15:3000",
+				"direct_asset_url": "http://192.168.10.15:3000/namespace/example/-/releases/v0.1/downloads/docs/release-notes.md",
+				"external": false,
+				"link_type": "other"
+			}`,
+			want: &ReleaseLink{
+				ID:             1,
+				Name:           "release-notes.md",
+				URL:            "http://192.168.10.15:3000",
+				DirectAssetURL: "http://192.168.10.15:3000/namespace/example/-/releases/v0.1/downloads/docs/release-notes.md",
+				LinkType:       "other",
+				External:       false,
+			},
+		},
 	}
-	if releaseLink.Name != exampleReleaseName {
-		t.Errorf("release link name, expected '%s', got '%s'", exampleReleaseName,
-			releaseLink.Name)
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			mux, server, client := setup(t)
+			defer teardown(server)
+
+			mux.HandleFunc("/api/v4/projects/1/releases/v0.1/assets/links",
+				func(w http.ResponseWriter, r *http.Request) {
+					testMethod(t, r, http.MethodPost)
+					fmt.Fprint(w, tc.response)
+				})
+
+			releaseLink, _, err := client.ReleaseLinks.CreateReleaseLink(1, exampleTagName, tc.options)
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, releaseLink)
+		})
 	}
 }
 
@@ -105,15 +162,21 @@ func TestReleaseLinksService_UpdateReleaseLink(t *testing.T) {
 	releaseLink, _, err := client.ReleaseLinks.UpdateReleaseLink(
 		1, exampleTagName, 1,
 		&UpdateReleaseLinkOptions{
-			Name: String(exampleReleaseName),
+			Name:     String(exampleReleaseName),
+			FilePath: String("http://192.168.10.15:3000/namespace/example/-/releases/v0.1/downloads/awesome-v0.2.dmg"),
+			LinkType: String("other"),
 		})
-	if err != nil {
-		t.Error(err)
+
+	require.NoError(t, err)
+	expectedRelease := &ReleaseLink{
+		ID:             1,
+		Name:           "awesome-v0.2.dmg",
+		URL:            "http://192.168.10.15:3000",
+		External:       true,
+		DirectAssetURL: "http://192.168.10.15:3000/namespace/example/-/releases/v0.1/downloads/awesome-v0.2.dmg",
+		LinkType:       "other",
 	}
-	if releaseLink.Name != exampleReleaseName {
-		t.Errorf("release link name, expected '%s', got '%s'", exampleReleaseName,
-			releaseLink.Name)
-	}
+	assert.Equal(t, expectedRelease, releaseLink)
 }
 
 func TestReleaseLinksService_DeleteReleaseLink(t *testing.T) {

--- a/types.go
+++ b/types.go
@@ -121,6 +121,42 @@ func DeploymentStatus(v DeploymentStatusValue) *DeploymentStatusValue {
 	return p
 }
 
+// EventTypeValue represents actions type for contribution events
+type EventTypeValue string
+
+// List of available action type
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/events.html#action-types
+const (
+	CreatedEventType   EventTypeValue = "created"
+	UpdatedEventType   EventTypeValue = "updated"
+	ClosedEventType    EventTypeValue = "closed"
+	ReopenedEventType  EventTypeValue = "reopened"
+	PushedEventType    EventTypeValue = "pushed"
+	CommentedEventType EventTypeValue = "commented"
+	MergedEventType    EventTypeValue = "merged"
+	JoinedEventType    EventTypeValue = "joined"
+	LeftEventType      EventTypeValue = "left"
+	DestroyedEventType EventTypeValue = "destroyed"
+	ExpiredEventType   EventTypeValue = "expired"
+)
+
+// EventTargetTypeValue represents actions type value for contribution events
+type EventTargetTypeValue string
+
+// List of available action type
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/events.html#target-types
+const (
+	IssueEventTargetType        EventTargetTypeValue = "issue"
+	MilestoneEventTargetType    EventTargetTypeValue = "milestone"
+	MergeRequestEventTargetType EventTargetTypeValue = "merge_request"
+	NoteEventTargetType         EventTargetTypeValue = "note"
+	ProjectEventTargetType      EventTargetTypeValue = "project"
+	SnippetEventTargetType      EventTargetTypeValue = "snippet"
+	UserEventTargetType         EventTargetTypeValue = "user"
+)
+
 // FileActionValue represents the available actions that can be performed on a file.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/commits.html#create-a-commit-with-multiple-files-and-actions
@@ -189,6 +225,50 @@ func (t *ISOTime) EncodeValues(key string, v *url.Values) error {
 // String implements the Stringer interface
 func (t ISOTime) String() string {
 	return time.Time(t).Format(iso8601)
+}
+
+// LinkTypeValue represents a release link type.
+type LinkTypeValue string
+
+// List of available release link types
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/releases/links.html#create-a-link
+const (
+	ImageLinkType   LinkTypeValue = "image"
+	OtherLinkType   LinkTypeValue = "other"
+	PackageLinkType LinkTypeValue = "package"
+	RunbookLinkType LinkTypeValue = "runbook"
+)
+
+// LinkType is a helper routine that allocates a new LinkType value
+// to store v and returns a pointer to it.
+func LinkType(v LinkTypeValue) *LinkTypeValue {
+	p := new(LinkTypeValue)
+	*p = v
+	return p
+}
+
+// MergeMethodValue represents a project merge type within GitLab.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#project-merge-method
+type MergeMethodValue string
+
+// List of available merge type
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#project-merge-method
+const (
+	NoFastForwardMerge MergeMethodValue = "merge"
+	FastForwardMerge   MergeMethodValue = "ff"
+	RebaseMerge        MergeMethodValue = "rebase_merge"
+)
+
+// MergeMethod is a helper routine that allocates a new MergeMethod
+// to sotre v and returns a pointer to it.
+func MergeMethod(v MergeMethodValue) *MergeMethodValue {
+	p := new(MergeMethodValue)
+	*p = v
+	return p
 }
 
 // NotificationLevelValue represents a notification level.
@@ -261,28 +341,6 @@ func NotificationLevel(v NotificationLevelValue) *NotificationLevelValue {
 	return p
 }
 
-// VisibilityValue represents a visibility level within GitLab.
-//
-// GitLab API docs: https://docs.gitlab.com/ce/api/
-type VisibilityValue string
-
-// List of available visibility levels.
-//
-// GitLab API docs: https://docs.gitlab.com/ce/api/
-const (
-	PrivateVisibility  VisibilityValue = "private"
-	InternalVisibility VisibilityValue = "internal"
-	PublicVisibility   VisibilityValue = "public"
-)
-
-// Visibility is a helper routine that allocates a new VisibilityValue
-// to store v and returns a pointer to it.
-func Visibility(v VisibilityValue) *VisibilityValue {
-	p := new(VisibilityValue)
-	*p = v
-	return p
-}
-
 // ProjectCreationLevelValue represents a project creation level within GitLab.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/
@@ -347,6 +405,28 @@ func VariableType(v VariableTypeValue) *VariableTypeValue {
 	return p
 }
 
+// VisibilityValue represents a visibility level within GitLab.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/
+type VisibilityValue string
+
+// List of available visibility levels.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/
+const (
+	PrivateVisibility  VisibilityValue = "private"
+	InternalVisibility VisibilityValue = "internal"
+	PublicVisibility   VisibilityValue = "public"
+)
+
+// Visibility is a helper routine that allocates a new VisibilityValue
+// to store v and returns a pointer to it.
+func Visibility(v VisibilityValue) *VisibilityValue {
+	p := new(VisibilityValue)
+	*p = v
+	return p
+}
+
 // WikiFormatValue represents the available wiki formats.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/wikis.html
@@ -367,64 +447,6 @@ func WikiFormat(v WikiFormatValue) *WikiFormatValue {
 	*p = v
 	return p
 }
-
-// MergeMethodValue represents a project merge type within GitLab.
-//
-// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#project-merge-method
-type MergeMethodValue string
-
-// List of available merge type
-//
-// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#project-merge-method
-const (
-	NoFastForwardMerge MergeMethodValue = "merge"
-	FastForwardMerge   MergeMethodValue = "ff"
-	RebaseMerge        MergeMethodValue = "rebase_merge"
-)
-
-// MergeMethod is a helper routine that allocates a new MergeMethod
-// to sotre v and returns a pointer to it.
-func MergeMethod(v MergeMethodValue) *MergeMethodValue {
-	p := new(MergeMethodValue)
-	*p = v
-	return p
-}
-
-// EventTypeValue represents actions type for contribution events
-type EventTypeValue string
-
-// List of available action type
-//
-// GitLab API docs: https://docs.gitlab.com/ce/api/events.html#action-types
-const (
-	CreatedEventType   EventTypeValue = "created"
-	UpdatedEventType   EventTypeValue = "updated"
-	ClosedEventType    EventTypeValue = "closed"
-	ReopenedEventType  EventTypeValue = "reopened"
-	PushedEventType    EventTypeValue = "pushed"
-	CommentedEventType EventTypeValue = "commented"
-	MergedEventType    EventTypeValue = "merged"
-	JoinedEventType    EventTypeValue = "joined"
-	LeftEventType      EventTypeValue = "left"
-	DestroyedEventType EventTypeValue = "destroyed"
-	ExpiredEventType   EventTypeValue = "expired"
-)
-
-// EventTargetTypeValue represents actions type value for contribution events
-type EventTargetTypeValue string
-
-// List of available action type
-//
-// GitLab API docs: https://docs.gitlab.com/ce/api/events.html#target-types
-const (
-	IssueEventTargetType        EventTargetTypeValue = "issue"
-	MilestoneEventTargetType    EventTargetTypeValue = "milestone"
-	MergeRequestEventTargetType EventTargetTypeValue = "merge_request"
-	NoteEventTargetType         EventTargetTypeValue = "note"
-	ProjectEventTargetType      EventTargetTypeValue = "project"
-	SnippetEventTargetType      EventTargetTypeValue = "snippet"
-	UserEventTargetType         EventTargetTypeValue = "user"
-)
 
 // Bool is a helper routine that allocates a new bool value
 // to store v and returns a pointer to it.
@@ -487,25 +509,4 @@ func (t *BoolValue) UnmarshalJSON(b []byte) error {
 		*t = BoolValue(v)
 		return err
 	}
-}
-
-// ReleaseLinkTypeValue represents a release link type.
-type ReleaseLinkTypeValue string
-
-// List of available release link types
-//
-// GitLab API docs: https://docs.gitlab.com/ee/api/releases/links.html#create-a-link
-const (
-	OtherReleaseLinkType   ReleaseLinkTypeValue = "other"
-	RunbookReleaseLinkType ReleaseLinkTypeValue = "runbook"
-	ImageReleaseLinkType   ReleaseLinkTypeValue = "image"
-	PackageReleaseLinkType ReleaseLinkTypeValue = "package"
-)
-
-// ReleaseLinkType is a helper routine that allocates a new ReleaseLinkType value
-// to store v and returns a pointer to it.
-func ReleaseLinkType(v ReleaseLinkTypeValue) *ReleaseLinkTypeValue {
-	p := new(ReleaseLinkTypeValue)
-	*p = v
-	return p
 }

--- a/types.go
+++ b/types.go
@@ -488,3 +488,24 @@ func (t *BoolValue) UnmarshalJSON(b []byte) error {
 		return err
 	}
 }
+
+// ReleaseLinkTypeValue represents a release link type.
+type ReleaseLinkTypeValue string
+
+// List of available release link types
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/releases/links.html#create-a-link
+const (
+	OtherReleaseLinkType   ReleaseLinkTypeValue = "other"
+	RunbookReleaseLinkType ReleaseLinkTypeValue = "runbook"
+	ImageReleaseLinkType   ReleaseLinkTypeValue = "image"
+	PackageReleaseLinkType ReleaseLinkTypeValue = "package"
+)
+
+// ReleaseLinkType is a helper routine that allocates a new ReleaseLinkType value
+// to store v and returns a pointer to it.
+func ReleaseLinkType(v ReleaseLinkTypeValue) *ReleaseLinkTypeValue {
+	p := new(ReleaseLinkTypeValue)
+	*p = v
+	return p
+}


### PR DESCRIPTION
Add optional DirectAssetURL and LinkType for Release Links response data.

Add optional FilePath and LinkType to creation and updating of release links.

See https://docs.gitlab.com/13.10/ee/api/releases/links.html#create-a-link for documentation