### PR TITLE
support the FirstContribution in `MergeRequest`

### DIFF
--- a/merge_requests.go
+++ b/merge_requests.go
@@ -100,6 +100,7 @@ type MergeRequest struct {
 	RebaseInProgress     bool   `json:"rebase_in_progress"`
 	ApprovalsBeforeMerge int    `json:"approvals_before_merge"`
 	Reference            string `json:"reference"`
+	FirstContribution    bool   `json:"first_contribution"`
 	TaskCompletionStatus struct {
 		Count          int `json:"count"`
 		CompletedCount int `json:"completed_count"`

--- a/merge_requests_test.go
+++ b/merge_requests_test.go
@@ -140,6 +140,7 @@ func TestGetMergeRequest(t *testing.T) {
 	require.Equal(t, mergeRequest.CreatedAt, &mrCreation)
 	mrUpdate := time.Date(2019, 8, 20, 9, 9, 56, 690000000, time.UTC)
 	require.Equal(t, mergeRequest.UpdatedAt, &mrUpdate)
+	require.Equal(t, mergeRequest.FirstContribution, true)
 	require.Equal(t, mergeRequest.HasConflicts, true)
 }
 

--- a/testdata/get_merge_request.json
+++ b/testdata/get_merge_request.json
@@ -158,6 +158,7 @@
   "user": {
     "can_merge": false
   },
+  "first_contribution": true,
   "approvals_before_merge": 1,
   "has_conflicts": true
 }


### PR DESCRIPTION
`FirstContribution`  is a boolean that indicates whether the author of the Merge Request is making its first contribution (true) or already has commits in the repository (false).

This is required for our bot to know when to ping a team of mentors that are better prepared to help a new contributor navigate its way to having its merge request accepted (https://gitlab.alpinelinux.org/Cogitri/aports-qa-bot/-/issues/14)