### PR TITLE
Add YouTrack service

### DIFF
--- a/services.go
+++ b/services.go
@@ -1330,3 +1330,96 @@ func (s *ServicesService) DeleteSlackService(pid interface{}, options ...Request
 
 	return s.client.Do(req, nil)
 }
+
+// YouTrackService represents YouTrack service settings.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/services.html#youtrack
+type YouTrackService struct {
+	Service
+	Properties *YouTrackServiceProperties `json:"properties"`
+}
+
+// YouTrackServiceProperties represents YouTrack specific properties.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/services.html#youtrack
+type YouTrackServiceProperties struct {
+	IssuesURL  string `json:"issues_url,omitempty"`
+	ProjectURL string `json:"project_url,omitempty"`
+}
+
+// GetYouTrackService gets YouTrack service settings for a project.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/services.html#get-youtrack-service-settings
+func (s *ServicesService) GetYouTrackService(pid interface{}, options ...RequestOptionFunc) (*YouTrackService, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/services/youtrack", pathEscape(project))
+
+	req, err := s.client.NewRequest(http.MethodGet, u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	svc := new(YouTrackService)
+	resp, err := s.client.Do(req, svc)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return svc, resp, err
+}
+
+// SetYouTrackServiceOptions represents the available SetYouTrackService()
+// options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/services.html#createedit-youtrack-service
+type SetYouTrackServiceOptions struct {
+	IssuesURL   *string `url:"issues_url,omitempty" json:"issues_url,omitempty"`
+	ProjectURL  *string `url:"project_url,omitempty" json:"project_url,omitempty"`
+	Description *string `url:"description,omitempty" json:"description,omitempty"`
+	PushEvents  *bool   `url:"push_events,omitempty" json:"push_events,omitempty"`
+}
+
+// SetYouTrackService sets YouTrack service for a project
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/services.html#createedit-youtrack-service
+func (s *ServicesService) SetYouTrackService(pid interface{}, opt *SetYouTrackServiceOptions, options ...RequestOptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/services/youtrack", pathEscape(project))
+
+	req, err := s.client.NewRequest(http.MethodPut, u, opt, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// DeleteYouTrackService deletes YouTrack service settings for a project.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/services.html#delete-youtrack-service
+func (s *ServicesService) DeleteYouTrackService(pid interface{}, options ...RequestOptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/services/youtrack", pathEscape(project))
+
+	req, err := s.client.NewRequest(http.MethodDelete, u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}

--- a/services.go
+++ b/services.go
@@ -1345,8 +1345,10 @@ type YouTrackService struct {
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/services.html#youtrack
 type YouTrackServiceProperties struct {
-	IssuesURL  string `json:"issues_url,omitempty"`
-	ProjectURL string `json:"project_url,omitempty"`
+	IssuesURL   string `json:"issues_url"`
+	ProjectURL  string `json:"project_url"`
+	Description string `json:"description"`
+	PushEvents  bool   `json:"push_events"`
 }
 
 // GetYouTrackService gets YouTrack service settings for a project.

--- a/services_test.go
+++ b/services_test.go
@@ -470,3 +470,57 @@ func TestDeleteSlackService(t *testing.T) {
 		t.Fatalf("Services.DeleteSlackService returns an error: %v", err)
 	}
 }
+
+func TestGetYouTrackService(t *testing.T) {
+	mux, server, client := setup(t)
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v4/projects/1/services/youtrack", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, `{"id":1}`)
+	})
+	want := &YouTrackService{Service: Service{ID: 1}}
+
+	service, _, err := client.Services.GetYouTrackService(1)
+	if err != nil {
+		t.Fatalf("Services.GetYouTrackService returns an error: %v", err)
+	}
+	if !reflect.DeepEqual(want, service) {
+		t.Errorf("Services.GetYouTrackService returned %+v, want %+v", service, want)
+	}
+}
+
+func TestSetYouTrackService(t *testing.T) {
+	mux, server, client := setup(t)
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v4/projects/1/services/youtrack", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPut)
+	})
+
+	opt := &SetYouTrackServiceOptions{
+		IssuesURL:   String("https://example.org/youtrack/issue/:id"),
+		ProjectURL:  String("https://example.org/youtrack/projects/1"),
+		Description: String("description"),
+		PushEvents:  Bool(true),
+	}
+
+	_, err := client.Services.SetYouTrackService(1, opt)
+	if err != nil {
+		t.Fatalf("Services.SetYouTrackService returns an error: %v", err)
+	}
+}
+
+func TestDeleteYouTrackService(t *testing.T) {
+	mux, server, client := setup(t)
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v4/projects/1/services/youtrack", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodDelete)
+	})
+
+	_, err := client.Services.DeleteYouTrackService(1)
+	if err != nil {
+		t.Fatalf("Services.DeleteYouTrackService returns an error: %v", err)
+	}
+}


### PR DESCRIPTION
This patch adds support for the [YouTrack service](https://docs.gitlab.com/ce/api/services.html#youtrack).