### PR TITLE
ListJobsOptions: support include_retried parameter

### DIFF
--- a/jobs.go
+++ b/jobs.go
@@ -103,8 +103,8 @@ type Bridge struct {
 // ListJobsOptions are options for two list apis
 type ListJobsOptions struct {
 	ListOptions
-	IncludeRetried bool              `url:"include_retried,omitempty" json:"include_retried,omitempty"`
 	Scope          []BuildStateValue `url:"scope[],omitempty" json:"scope,omitempty"`
+	IncludeRetried bool              `url:"include_retried,omitempty" json:"include_retried,omitempty"`
 }
 
 // ListProjectJobs gets a list of jobs in a project.

--- a/jobs.go
+++ b/jobs.go
@@ -103,7 +103,8 @@ type Bridge struct {
 // ListJobsOptions are options for two list apis
 type ListJobsOptions struct {
 	ListOptions
-	Scope []BuildStateValue `url:"scope[],omitempty" json:"scope,omitempty"`
+	IncludeRetried bool              `url:"include_retried,omitempty" json:"include_retried,omitempty"`
+	Scope          []BuildStateValue `url:"scope[],omitempty" json:"scope,omitempty"`
 }
 
 // ListProjectJobs gets a list of jobs in a project.


### PR DESCRIPTION
The `include_retried` parameter of the List pipeline jobs API call was introduced in Gitlab 13.9: https://docs.gitlab.com/ee/api/jobs.html#list-pipeline-jobs