### PR TITLE
Add missing ReleasedAt field to Release struct

### DIFF
--- a/releases.go
+++ b/releases.go
@@ -40,6 +40,7 @@ type Release struct {
 	Description     string     `json:"description,omitempty"`
 	DescriptionHTML string     `json:"description_html,omitempty"`
 	CreatedAt       *time.Time `json:"created_at,omitempty"`
+	ReleasedAt      *time.Time `json:"released_at,omitempty"`
 	Author          struct {
 		ID        int    `json:"id"`
 		Name      string `json:"name"`


### PR DESCRIPTION
From [the docs](https://docs.gitlab.com/ee/api/releases/#list-releases), the ReleasedAt field was missing in the Releases struct.