### PR TITLE
Add the ability to remove a billable user from a group.

### DIFF
--- a/group_members.go
+++ b/group_members.go
@@ -205,7 +205,7 @@ func (s *GroupsService) ListBillableGroupMembers(gid interface{}, opt *ListBilla
 }
 
 // RemoveBillableGroupMember Removes a given group members that count as billable.
-// The list includes removal from all subgroup or subproject.
+// This includes removal from all subgroup or subproject.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/members.html#remove-a-billable-member-from-a-group

--- a/group_members.go
+++ b/group_members.go
@@ -204,6 +204,26 @@ func (s *GroupsService) ListBillableGroupMembers(gid interface{}, opt *ListBilla
 	return bgm, resp, err
 }
 
+// RemoveBillableGroupMember Removes a given group members that count as billable.
+// The list includes removal from all subgroup or subproject.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/members.html#remove-a-billable-member-from-a-group
+func (s *GroupsService) RemoveBillableGroupMember(gid interface{}, user int, options ...RequestOptionFunc) (*Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("groups/%s/billable_members/%d", pathEscape(group), user)
+
+	req, err := s.client.NewRequest(http.MethodDelete, u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
 // AddGroupMember adds a user to the list of group members.
 //
 // GitLab API docs:


### PR DESCRIPTION
As documented in API: https://docs.gitlab.com/ee/api/members.html#remove-a-billable-member-from-a-group

Takes a groupID and userID, returns a success of failure HTTP response.

Signed-off-by: Philip Marc Schwartz <Philip.Schwartz1@T-Mobile.com>