### PR TITLE
Allow update of `AllowForcePush` parameter of protected branches

### DIFF
--- a/protected_branches.go
+++ b/protected_branches.go
@@ -188,6 +188,34 @@ func (s *ProtectedBranchesService) UnprotectRepositoryBranches(pid interface{}, 
 	return s.client.Do(req, nil)
 }
 
+// AllowForcePushOptions represents the available
+// AllowForcePush() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/protected_branches.html#allow_force_push # FIXME: not documented yet but this is what is done by the UI
+type AllowForcePushOptions struct {
+	AllowForcePush *bool `url:"allow_force_push,omitempty" json:"allow_force_push,omitempty"`
+}
+
+// AllowForcePush updates the allow force push option.
+//
+// Gitlab API docs:
+// https://docs.gitlab.com/ee/api/protected_branches.html#allow_force_push # FIXME: not documented yet but this is what is done by the UI
+func (s *ProtectedBranchesService) AllowForcePush(pid interface{}, branch string, opt *AllowForcePushOptions, options ...RequestOptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/protected_branches/%s", PathEscape(project), url.PathEscape(branch))
+
+	req, err := s.client.NewRequest(http.MethodPatch, u, opt, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
 // RequireCodeOwnerApprovalsOptions represents the available
 // RequireCodeOwnerApprovals() options.
 //


### PR DESCRIPTION
Allowing the update of `AllowForcePush` parameter of protected branches was reverted from https://github.com/xanzy/go-gitlab/pull/1141 as that feature was not explicitly [documented](https://docs.gitlab.com/ee/api/protected_branches.html).

I submitted an MR to document that feature: https://gitlab.com/gitlab-org/gitlab/-/merge_requests/62893

Technically, this simply reverts commit 8fe58c38039d4d482949acccfb86acc2eb2fc13a.