### PR TITLE
added missing project_id on the PipelineInfo struct

### DIFF
--- a/pipelines.go
+++ b/pipelines.go
@@ -131,6 +131,7 @@ func (p PipelineTestReport) String() string {
 // on other assets, like Commit.
 type PipelineInfo struct {
 	ID        int        `json:"id"`
+	ProjectID int        `json:"project_id"`
 	Status    string     `json:"status"`
 	Ref       string     `json:"ref"`
 	SHA       string     `json:"sha"`


### PR DESCRIPTION
I am not sure if it is available in all cases as this struct is being used in various places but at least for `Bridge.DownstreamPipeline` it is actually the case. eg:

```json
...
"downstream_pipeline": {
  "id": 22074,
  "project_id": 200,
  "sha": "a254644edfc891b618fc8b7c745494fbff389f82",
  "ref": "main",
  "status": "manual",
  "created_at": "2021-05-13T16:03:41.783Z",
  "updated_at": "2021-05-13T16:04:49.039Z",
  "web_url": "https://git.example.com/foo/bar/-/pipelines/22074"
}
```