### PR TITLE
feat: Add HeadPipelineID In MergeEvent

### DIFF
--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -499,6 +499,7 @@ type MergeEvent struct {
 		TimeEstimate             int          `json:"time_estimate"`
 		Source                   *Repository  `json:"source"`
 		Target                   *Repository  `json:"target"`
+		HeadPipelineID           *int         `json:"head_pipeline_id"`
 		LastCommit               struct {
 			ID        string     `json:"id"`
 			Message   string     `json:"message"`


### PR DESCRIPTION
Like this

```json
{
    "object_attributes": {
        "head_pipeline_id": null
    }
}
```

```json
{
    "object_attributes": {
        "head_pipeline_id": 123
    }
}
```