### PR TITLE
Added UserUsername (sic) to tag push events.

### DIFF
--- a/event_parsing_webhook_test.go
+++ b/event_parsing_webhook_test.go
@@ -381,7 +381,11 @@ func TestParseTagHook(t *testing.T) {
 	}
 
 	if event.UserName != exampleEventUserName {
-		t.Errorf("Username is %s, want %s", event.UserName, exampleEventUserName)
+		t.Errorf("Name is %s, want %s", event.UserName, exampleEventUserName)
+	}
+
+	if event.UserUsername != exampleEventUserUsername {
+		t.Errorf("Username is %s, want %s", event.UserUsername, exampleEventUserUsername)
 	}
 
 	if event.Ref != "refs/tags/v1.0.0" {

--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -855,18 +855,19 @@ type SnippetCommentEvent struct {
 // GitLab API docs:
 // https://docs.gitlab.com/ce/user/project/integrations/webhooks.html#tag-events
 type TagEvent struct {
-	ObjectKind  string `json:"object_kind"`
-	Before      string `json:"before"`
-	After       string `json:"after"`
-	Ref         string `json:"ref"`
-	CheckoutSHA string `json:"checkout_sha"`
-	UserID      int    `json:"user_id"`
-	UserName    string `json:"user_name"`
-	UserAvatar  string `json:"user_avatar"`
-	UserEmail   string `json:"user_email"`
-	ProjectID   int    `json:"project_id"`
-	Message     string `json:"message"`
-	Project     struct {
+	ObjectKind   string `json:"object_kind"`
+	Before       string `json:"before"`
+	After        string `json:"after"`
+	Ref          string `json:"ref"`
+	CheckoutSHA  string `json:"checkout_sha"`
+	UserID       int    `json:"user_id"`
+	UserName     string `json:"user_name"`
+	UserUsername string `json:"user_username"`
+	UserAvatar   string `json:"user_avatar"`
+	UserEmail    string `json:"user_email"`
+	ProjectID    int    `json:"project_id"`
+	Message      string `json:"message"`
+	Project      struct {
 		Name              string          `json:"name"`
 		Description       string          `json:"description"`
 		AvatarURL         string          `json:"avatar_url"`

--- a/fixtures_test.go
+++ b/fixtures_test.go
@@ -51,8 +51,11 @@ const (
 		"locked": false
 	}`
 
-	// exampleEventUserName provides a fixture for a event username.
+	// exampleEventUserName provides a fixture for a event user's name.
 	exampleEventUserName = "John Smith"
+
+	// exampleEventUserUsername provides a ficture for the event username.
+	exampleEventUserUsername = "jsmith"
 
 	// exampleProjectName provides a fixture for a project name.
 	exampleProjectName = "example-project"

--- a/testdata/webhooks/tag_push.json
+++ b/testdata/webhooks/tag_push.json
@@ -5,6 +5,7 @@
   "ref": "refs/tags/v1.0.0",
   "checkout_sha": "82b3d5ae55f7080f1e6022629cdb57bfae7cccc7",
   "user_id": 1,
+  "user_username": "jsmith",
   "user_name": "John Smith",
   "user_avatar": "https://s.gravatar.com/avatar/d4c74594d841139328695756648b6bd6?s=8://s.gravatar.com/avatar/d4c74594d841139328695756648b6bd6?s=80",
   "project_id": 1,


### PR DESCRIPTION
While the documentation does not list the field user_username in
https://docs.gitlab.com/ce/user/project/integrations/webhooks.html#tag-events
it was added 4 years ago in https://gitlab.com/gitlab-org/gitlab-foss/-/merge_requests/11272
and can still be seen in: https://gitlab.com/gitlab-org/gitlab-foss/-/blob/9e16447c7c4cec7373bb2df0d94b4dc8b8300b08/lib/gitlab/data_builder/push.rb#L123

I have also verified locally that the webhook does indeed receive the
field in question for a tag_push.