### PR TITLE
Add GetGroupOptions

### DIFF
--- a/groups.go
+++ b/groups.go
@@ -127,8 +127,8 @@ func (s *GroupsService) ListGroups(opt *ListGroupsOptions, options ...RequestOpt
 // GitLab API docs: https://docs.gitlab.com/ce/api/groups.html#details-of-a-group
 type GetGroupOptions struct {
 	ListOptions
-	WithProjects         *string `url:"with_projects,omitempty" json:"with_projects,omitempty"`
-	WithCustomAttributes *bool   `url:"with_custom_attributes,omitempty" json:"with_custom_attributes,omitempty"`
+	WithProjects         *bool `url:"with_projects,omitempty" json:"with_projects,omitempty"`
+	WithCustomAttributes *bool `url:"with_custom_attributes,omitempty" json:"with_custom_attributes,omitempty"`
 }
 
 // GetGroup gets all details of a group.

--- a/groups.go
+++ b/groups.go
@@ -127,8 +127,8 @@ func (s *GroupsService) ListGroups(opt *ListGroupsOptions, options ...RequestOpt
 // GitLab API docs: https://docs.gitlab.com/ce/api/groups.html#details-of-a-group
 type GetGroupOptions struct {
 	ListOptions
-	WithProjects         *bool `url:"with_projects,omitempty" json:"with_projects,omitempty"`
 	WithCustomAttributes *bool `url:"with_custom_attributes,omitempty" json:"with_custom_attributes,omitempty"`
+	WithProjects         *bool `url:"with_projects,omitempty" json:"with_projects,omitempty"`
 }
 
 // GetGroup gets all details of a group.

--- a/groups.go
+++ b/groups.go
@@ -122,17 +122,26 @@ func (s *GroupsService) ListGroups(opt *ListGroupsOptions, options ...RequestOpt
 	return g, resp, err
 }
 
+// GetGroupOptions represents the available GetGroup() options.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/groups.html#details-of-a-group
+type GetGroupOptions struct {
+	ListOptions
+	WithProjects         *string `url:"with_projects,omitempty" json:"with_projects,omitempty"`
+	WithCustomAttributes *bool   `url:"with_custom_attributes,omitempty" json:"with_custom_attributes,omitempty"`
+}
+
 // GetGroup gets all details of a group.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/groups.html#details-of-a-group
-func (s *GroupsService) GetGroup(gid interface{}, options ...RequestOptionFunc) (*Group, *Response, error) {
+func (s *GroupsService) GetGroup(gid interface{}, opt *GetGroupOptions, options ...RequestOptionFunc) (*Group, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("groups/%s", pathEscape(group))
 
-	req, err := s.client.NewRequest(http.MethodGet, u, nil, options)
+	req, err := s.client.NewRequest(http.MethodGet, u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/groups_test.go
+++ b/groups_test.go
@@ -38,7 +38,7 @@ func TestGetGroup(t *testing.T) {
 			fmt.Fprint(w, `{"id": 1, "name": "g"}`)
 		})
 
-	group, _, err := client.Groups.GetGroup("g")
+	group, _, err := client.Groups.GetGroup("g", &GetGroupOptions{})
 	if err != nil {
 		t.Errorf("Groups.GetGroup returned error: %v", err)
 	}


### PR DESCRIPTION
The `/groups/:id` endpoint actually has a limited set of options available which aren't reflected in the library currently. See: https://docs.gitlab.com/ee/api/groups.html#details-of-a-group

Also noting that this is a backwards incompatible change since the GetGroup function didn't previously require an options struct sent with it. Shouldn't affect users that pin to their specific versions with go modules, but to those upgrading it might be a tiny bit of surprise cleanup.