### PR TITLE
Add support for instance-level audit events

### DIFF
--- a/audit_events.go
+++ b/audit_events.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-// AuditEvent represents an audit event for a group or project.
+// AuditEvent represents an audit event for a group, a project or the instance.
 //
 // GitLab API docs: https://docs.gitlab.com/ee/api/audit_events.html
 type AuditEvent struct {
@@ -19,7 +19,7 @@ type AuditEvent struct {
 }
 
 // AuditEventDetails represents the details portion of an audit event for
-// a group or project. The exact fields that are returned for an audit event
+// a group, a project or the instance. The exact fields that are returned for an audit event
 // depend on the action being recorded.
 //
 // GitLab API docs: https://docs.gitlab.com/ee/api/audit_events.html
@@ -38,9 +38,10 @@ type AuditEventDetails struct {
 	TargetDetails string      `json:"target_details"`
 	IPAddress     string      `json:"ip_address"`
 	EntityPath    string      `json:"entity_path"`
+	FailedLogin   string      `json:"failed_login"`
 }
 
-// AuditEventsService handles communication with the project/group audit
+// AuditEventsService handles communication with the project/group/instance audit
 // event related methods of the GitLab API.
 //
 // GitLab API docs: https://docs.gitlab.com/ee/api/audit_events.html
@@ -48,8 +49,8 @@ type AuditEventsService struct {
 	client *Client
 }
 
-// ListAuditEventsOptions represents the available ListProjectAuditEvents()
-// or ListGroupAuditEvents() options.
+// ListAuditEventsOptions represents the available ListProjectAuditEvents(),
+// ListGroupAuditEvents() or ListInstanceAuditEvents() options.
 //
 // GitLab API docs: https://docs.gitlab.com/ee/api/audit_events.html
 type ListAuditEventsOptions struct {
@@ -142,6 +143,46 @@ func (s *AuditEventsService) GetProjectAuditEvent(pid interface{}, event int, op
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/audit_events/%d", pathEscape(project), event)
+
+	req, err := s.client.NewRequest(http.MethodGet, u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ae := new(AuditEvent)
+	resp, err := s.client.Do(req, ae)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return ae, resp, err
+}
+
+// ListInstanceAuditEvents gets a list of audit events for instance.
+// Authentication as Administrator is required.
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/audit_events.html
+func (s *AuditEventsService) ListInstanceAuditEvents(opt *ListAuditEventsOptions, options ...RequestOptionFunc) ([]*AuditEvent, *Response, error) {
+	req, err := s.client.NewRequest(http.MethodGet, "audit_events", opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var aes []*AuditEvent
+	resp, err := s.client.Do(req, &aes)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return aes, resp, err
+}
+
+// GetInstanceAuditEvent gets a specific instance audit event.
+// Authentication as Administrator is required.
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/audit_events.html
+func (s *AuditEventsService) GetInstanceAuditEvent(event int, options ...RequestOptionFunc) (*AuditEvent, *Response, error) {
+	u := fmt.Sprintf("audit_events/%d", event)
 
 	req, err := s.client.NewRequest(http.MethodGet, u, nil, options)
 	if err != nil {


### PR DESCRIPTION
- Mostly naive Copy/Paste
- The `failed_login` field in the event details is relevant for me
- I searched for other possible fields in the API docs and skimmed through a bunch of responses, but was not able to find other new fields