### PR TITLE
Add JOB-TOKEN support

### DIFF
--- a/gitlab.go
+++ b/gitlab.go
@@ -60,6 +60,7 @@ const (
 	basicAuth authType = iota
 	oAuthToken
 	privateToken
+	jobToken
 )
 
 // A Client manages communication with the GitLab API.
@@ -210,6 +211,18 @@ func NewClient(token string, options ...ClientOptionFunc) (*Client, error) {
 		return nil, err
 	}
 	client.authType = privateToken
+	client.token = token
+	return client, nil
+}
+
+// NewJobClient returns a new GitLab API client. To use API methods which require
+// authentication, provide a valid job token.
+func NewJobClient(token string, options ...ClientOptionFunc) (*Client, error) {
+	client, err := newClient(options...)
+	if err != nil {
+		return nil, err
+	}
+	client.authType = jobToken
 	client.token = token
 	return client, nil
 }
@@ -649,6 +662,8 @@ func (c *Client) Do(req *retryablehttp.Request, v interface{}) (*Response, error
 		req.Header.Set("Authorization", "Bearer "+c.token)
 	case privateToken:
 		req.Header.Set("PRIVATE-TOKEN", c.token)
+	case jobToken:
+		req.Header.Set("JOB-TOKEN", c.token)
 	}
 
 	resp, err := c.client.Do(req)


### PR DESCRIPTION
Container Registry API can be used within a Job using $CI_JOB_TOKEN. When using $CI_JOB_TOKEN, one should set `JOB-TOKEN` header instead of `PRIVATE-TOKEN` .

See: https://docs.gitlab.com/ee/api/container_registry.html