### PR TITLE
Add detailed_status and queued_duration to pipeline webhook

### DIFF
--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -622,17 +622,19 @@ func (p *MergeParams) UnmarshalJSON(b []byte) error {
 type PipelineEvent struct {
 	ObjectKind       string `json:"object_kind"`
 	ObjectAttributes struct {
-		ID         int      `json:"id"`
-		Ref        string   `json:"ref"`
-		Tag        bool     `json:"tag"`
-		SHA        string   `json:"sha"`
-		BeforeSHA  string   `json:"before_sha"`
-		Source     string   `json:"source"`
-		Status     string   `json:"status"`
-		Stages     []string `json:"stages"`
-		CreatedAt  string   `json:"created_at"`
-		FinishedAt string   `json:"finished_at"`
-		Duration   int      `json:"duration"`
+		ID             int      `json:"id"`
+		Ref            string   `json:"ref"`
+		Tag            bool     `json:"tag"`
+		SHA            string   `json:"sha"`
+		BeforeSHA      string   `json:"before_sha"`
+		Source         string   `json:"source"`
+		Status         string   `json:"status"`
+		DetailedStatus string   `json:"detailed_status"`
+		Stages         []string `json:"stages"`
+		CreatedAt      string   `json:"created_at"`
+		FinishedAt     string   `json:"finished_at"`
+		Duration       int      `json:"duration"`
+		QueuedDuration int      `json:"queued_duration"`
 	} `json:"object_attributes"`
 	MergeRequest struct {
 		ID                 int    `json:"id"`

--- a/event_webhook_types_test.go
+++ b/event_webhook_types_test.go
@@ -301,7 +301,15 @@ func TestPipelineEventUnmarshal(t *testing.T) {
 	}
 
 	if event.ObjectAttributes.ID != 31 {
-		t.Errorf("ObjectAttributes is %v, want %v", event.ObjectAttributes.ID, 1977)
+		t.Errorf("ObjectAttributes.ID is %v, want %v", event.ObjectAttributes.ID, 1977)
+	}
+
+	if event.ObjectAttributes.DetailedStatus != "passed" {
+		t.Errorf("ObjectAttributes.DetailedStatus is %v, want %v", event.ObjectAttributes.DetailedStatus, "passed")
+	}
+
+	if event.ObjectAttributes.QueuedDuration != 12 {
+		t.Errorf("ObjectAttributes.QueuedDuration is %v, want %v", event.ObjectAttributes.QueuedDuration, 12)
 	}
 
 	if event.User.ID != 42 {

--- a/testdata/webhooks/pipeline.json
+++ b/testdata/webhooks/pipeline.json
@@ -8,6 +8,7 @@
      "before_sha": "bcbb5ec396a2c0f828686f14fac9b80b780504f2",
      "source": "merge_request_event",
      "status": "success",
+     "detailed_status": "passed",
      "stages":[
         "build",
         "test",
@@ -16,6 +17,7 @@
      "created_at": "2016-08-12 15:23:28 UTC",
      "finished_at": "2016-08-12 15:26:29 UTC",
      "duration": 63,
+     "queued_duration": 12,
      "variables": [
        {
          "key": "NESTOR_PROD_ENVIRONMENT",


### PR DESCRIPTION
Hey, this adds the `detailed_status` and `queued_duration` fields to the event type. They are undocumented [here](https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#pipeline-events) but appear in my Gitlab.com webhooks:

```json
"object_attributes": {
  "id": 123,
  "ref": "branch",
  "tag": false,
  "sha": "5b0170179ee7a82811566ec5fedf813afbb69ea3",
  "before_sha": "5b0170179ee7a82811566ec5fedf813afbb69ea3",
  "source": "merge_request_event",
  "status": "success",
> "detailed_status": "passed with warnings",
  "stages": [
	...
  ],
  "created_at": "2021-09-02 15:15:06 UTC",
  "finished_at": "2021-09-02 15:59:08 UTC",
  "duration": 400,
> "queued_duration": 123,
  "variables": []
}
```