### PR TITLE
Support deploy keys in protected branches

### DIFF
--- a/protected_branches.go
+++ b/protected_branches.go
@@ -138,6 +138,7 @@ type ProtectRepositoryBranchesOptions struct {
 type BranchPermissionOptions struct {
 	UserID      *int              `url:"user_id,omitempty" json:"user_id,omitempty"`
 	GroupID     *int              `url:"group_id,omitempty" json:"group_id,omitempty"`
+	DeployKeyID *int              `url:"deploy_key_id,omitempty" json:"deploy_key_id,omitempty"`
 	AccessLevel *AccessLevelValue `url:"access_level,omitempty" json:"access_level,omitempty"`
 }
 


### PR DESCRIPTION
On top of allowing specific users and groups to push to protected branches, Gitlab also gives the option to allow deploy keys using the `deploy_key_id` field.

![image](https://user-images.githubusercontent.com/2412973/132469461-c99dc424-2762-4043-819c-e23370bccfdf.png)
