### PR TITLE
Add allow_failure field to Pipeline webhook event

### DIFF
--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -678,17 +678,18 @@ type PipelineEvent struct {
 		} `json:"author"`
 	} `json:"commit"`
 	Builds []struct {
-		ID         int        `json:"id"`
-		Stage      string     `json:"stage"`
-		Name       string     `json:"name"`
-		Status     string     `json:"status"`
-		CreatedAt  string     `json:"created_at"`
-		StartedAt  string     `json:"started_at"`
-		FinishedAt string     `json:"finished_at"`
-		When       string     `json:"when"`
-		Manual     bool       `json:"manual"`
-		User       *EventUser `json:"user"`
-		Runner     struct {
+		ID           int        `json:"id"`
+		Stage        string     `json:"stage"`
+		Name         string     `json:"name"`
+		Status       string     `json:"status"`
+		CreatedAt    string     `json:"created_at"`
+		StartedAt    string     `json:"started_at"`
+		FinishedAt   string     `json:"finished_at"`
+		When         string     `json:"when"`
+		Manual       bool       `json:"manual"`
+		AllowFailure bool       `json:"allow_failure"`
+		User         *EventUser `json:"user"`
+		Runner       struct {
 			ID          int    `json:"id"`
 			Description string `json:"description"`
 			Active      bool   `json:"active"`

--- a/event_webhook_types_test.go
+++ b/event_webhook_types_test.go
@@ -327,6 +327,14 @@ func TestPipelineEventUnmarshal(t *testing.T) {
 	if name := event.Commit.Author.Name; name != "User" {
 		t.Errorf("Commit Username is %s, want %s", name, "User")
 	}
+
+	if len(event.Builds) != 5 {
+		t.Errorf("Builds length is %d, want %d", len(event.Builds), 5)
+	}
+
+	if event.Builds[0].AllowFailure != true {
+		t.Errorf("Builds.0.AllowFailure is %v, want %v", event.Builds[0].AllowFailure, true)
+	}
 }
 
 func TestPushEventUnmarshal(t *testing.T) {

--- a/testdata/webhooks/pipeline.json
+++ b/testdata/webhooks/pipeline.json
@@ -78,7 +78,7 @@
         "finished_at": null,
         "when": "manual",
         "manual": true,
-        "allow_failure": false,
+        "allow_failure": true,
         "user":{
            "id": 42,
            "name": "User1",


### PR DESCRIPTION
As documented in https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#pipeline-events, it's part of `builds` in pipeline events:

```json
{
  "builds": [
	{
	  "id": 380,
	  "stage": "deploy",
	  "name": "production",
	  "status": "skipped",
	  "created_at": "2016-08-12 15:23:28 UTC",
	  "started_at": null,
	  "finished_at": null,
	  "when": "manual",
	  "manual": true,
 >	  "allow_failure": false,
	  "user": {
		"id": 1,
		"name": "Administrator",
		"username": "root",
		"avatar_url": "http://www.gravatar.com/avatar/e32bd13e2add097461cb96824b7a829c?s=80\u0026d=identicon",
		"email": "admin@example.com"
	  },
	  "runner": null,
	  "artifacts_file": {
		"filename": null,
		"size": null
	  },
	  "environment": {
		"name": "production",
		"action": "start",
		"deployment_tier": "production"
	  }
	}
  ],
}
```

Thank you for the support and the quick merges 🙂