### PR TITLE
Add url/description fields to all webhook note events and commit title to commit note event

### DIFF
--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -106,6 +106,8 @@ type CommitCommentEvent struct {
 			RenamedFile bool   `json:"renamed_file"`
 			DeletedFile bool   `json:"deleted_file"`
 		} `json:"st_diff"`
+		Description string `json:"description"`
+		URL         string `json:"url"`
 	} `json:"object_attributes"`
 	Commit *struct {
 		ID        string     `json:"id"`
@@ -193,6 +195,7 @@ type IssueCommentEvent struct {
 		NoteableID   int     `json:"noteable_id"`
 		System       bool    `json:"system"`
 		StDiff       []*Diff `json:"st_diff"`
+		Description  string  `json:"description"`
 		URL          string  `json:"url"`
 	} `json:"object_attributes"`
 	Issue struct {
@@ -849,6 +852,7 @@ type SnippetCommentEvent struct {
 		NoteableID   int    `json:"noteable_id"`
 		System       bool   `json:"system"`
 		StDiff       *Diff  `json:"st_diff"`
+		Description  string `json:"description"`
 		URL          string `json:"url"`
 	} `json:"object_attributes"`
 	Snippet *Snippet `json:"snippet"`

--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -111,6 +111,7 @@ type CommitCommentEvent struct {
 	} `json:"object_attributes"`
 	Commit *struct {
 		ID        string     `json:"id"`
+		Title     string     `json:"title"`
 		Message   string     `json:"message"`
 		Timestamp *time.Time `json:"timestamp"`
 		URL       string     `json:"url"`

--- a/testdata/webhooks/note_commit.json
+++ b/testdata/webhooks/note_commit.json
@@ -59,6 +59,7 @@
   },
   "commit": {
     "id": "cfe32cf61b73a0d5e9f13e774abde7ff789b1660",
+    "title": "Add submodule",
     "message": "Add submodule\n\nSigned-off-by: Dmitriy Zaporozhets \u003cdmitriy.zaporozhets@gmail.com\u003e\n",
     "timestamp": "2014-02-27T10:06:20+02:00",
     "url": "http://example.com/gitlab-org/gitlab-test/commit/cfe32cf61b73a0d5e9f13e774abde7ff789b1660",

--- a/testdata/webhooks/note_commit.json
+++ b/testdata/webhooks/note_commit.json
@@ -54,6 +54,7 @@
       "renamed_file": false,
       "deleted_file": false
     },
+    "description": "This is a commit comment. How does this work?",
     "url": "http://example.com/gitlab-org/gitlab-test/commit/cfe32cf61b73a0d5e9f13e774abde7ff789b1660#note_1243"
   },
   "commit": {

--- a/testdata/webhooks/note_issue.json
+++ b/testdata/webhooks/note_issue.json
@@ -45,6 +45,7 @@
     "noteable_id": 92,
     "system": false,
     "st_diff": null,
+    "description": "Hello world",
     "url": "http://example.com/gitlab-org/gitlab-test/issues/17#note_1241"
   },
   "issue": {

--- a/testdata/webhooks/note_merge_request.json
+++ b/testdata/webhooks/note_merge_request.json
@@ -45,6 +45,7 @@
     "noteable_id": 7,
     "system": false,
     "st_diff": null,
+    "description": "This MR needs work.",
     "url": "http://example.com/gitlab-org/gitlab-test/merge_requests/1#note_1244"
   },
   "merge_request": {

--- a/testdata/webhooks/note_snippet.json
+++ b/testdata/webhooks/note_snippet.json
@@ -45,6 +45,7 @@
     "noteable_id": 53,
     "system": false,
     "st_diff": null,
+    "description": "Is this snippet doing what it's supposed to be doing?",
     "url": "http://example.com/gitlab-org/gitlab-test/snippets/53#note_1245"
   },
   "snippet": {


### PR DESCRIPTION
Hey, sorry me again 😁 

1. I tried to find info on the `description` field but I'm not too familiar with the GitLab source code and only found this: https://gitlab.com/gitlab-org/gitlab/-/blob/master/lib/gitlab/hook_data/note_builder.rb#L33-42 maybe it's related. It's already included in the [`MergeCommentEvent`](https://github.com/xanzy/go-gitlab/blob/a945c3aa172a8f237fcded4c77ae6834b3402997/event_webhook_types.go#L387), the difference compared to the `note` field is that it contains absolute image URLs.
```json
{
  "note":        "Test\n\n![image](/uploads/2389hf9238fh2387gf2738gf237/image.png)",
  "description": "Test\n\n![image](https://gitlab.com/org/uploads/2389hf9238fh2387gf2738gf237/image.png)",
}
```
2. This also adds the commit title to the commit comment event, here's the commit part of a commit comment event hook from a few minutes ago:
```json
{
  "commit": {
	"id": "f9ec7ad703ad7307210163ee8886dd98745fbe16",
	"message": "Title\n\nMessage\n",
	"title": "Title",
	"timestamp": "2021-09-16T16:57:07+02:00",
	"url": "https://gitlab.com/org/-/commit/f9ec7ad703ad7307210163ee8886dd98745fbe16",
	"author": {
	  "name": "…",
	  "email": "…"
	}
  }
}
```

Thanks!