### PR TITLE
Escaping namespace path

### DIFF
--- a/namespaces.go
+++ b/namespaces.go
@@ -116,7 +116,7 @@ func (s *NamespacesService) GetNamespace(id interface{}, options ...RequestOptio
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("namespaces/%s", namespace)
+	u := fmt.Sprintf("namespaces/%s", pathEscape(namespace))
 
 	req, err := s.client.NewRequest(http.MethodGet, u, nil, options)
 	if err != nil {


### PR DESCRIPTION
When it tries to get nested namespace, the path has to be escaped otherwise an error is occured.