### PR TITLE
Add CommitID to CreateMergeRequestDiscussionOptions

### DIFF
--- a/discussions.go
+++ b/discussions.go
@@ -725,6 +725,7 @@ func (s *DiscussionsService) GetMergeRequestDiscussion(pid interface{}, mergeReq
 // https://docs.gitlab.com/ce/api/discussions.html#create-new-merge-request-thread
 type CreateMergeRequestDiscussionOptions struct {
 	Body      *string       `url:"body,omitempty" json:"body,omitempty"`
+	CommitID  *string       `url:"commit_id,omitempty" json:"commit_id,omitempty"`
 	CreatedAt *time.Time    `url:"created_at,omitempty" json:"created_at,omitempty"`
 	Position  *NotePosition `url:"position,omitempty" json:"position,omitempty"`
 }


### PR DESCRIPTION
While not explicitly stated in the documentation [1] the commit_id field
must be specified when creating a MR discussion (aka thread) with comments
on a commit.

Add a CommitID to the CreateMergeRequestDiscussionOptions struct.

[1] https://docs.gitlab.com/ee/api/discussions.html#create-new-merge-request-thread
Signed-off-by: Prarit Bhargava <prarit@redhat.com>