### PR TITLE
Fix SquashOption type

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -111,7 +111,7 @@ type Project struct {
 	AutocloseReferencedIssues                 bool                       `json:"autoclose_referenced_issues"`
 	SuggestionCommitMessage                   string                     `json:"suggestion_commit_message"`
 	CIForwardDeploymentEnabled                bool                       `json:"ci_forward_deployment_enabled"`
-	SquashOption                              *SquashOptionValue         `json:"squash_option"`
+	SquashOption                              SquashOptionValue          `json:"squash_option"`
 	SharedWithGroups                          []struct {
 		GroupID          int    `json:"group_id"`
 		GroupName        string `json:"group_name"`


### PR DESCRIPTION
Hi I just noticed that I used incorrect type in my previous pull request, it doesn't allow to convert const into string in dependent repo. Sorry for that. Could you release patch after merge? Thanks