### PR TITLE
Add Title field to PushEvent and TagEvent structs

### DIFF
--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -742,6 +742,7 @@ type PushEvent struct {
 	Commits    []*struct {
 		ID        string     `json:"id"`
 		Message   string     `json:"message"`
+		Title     string     `json:"title"`
 		Timestamp *time.Time `json:"timestamp"`
 		URL       string     `json:"url"`
 		Author    struct {
@@ -896,6 +897,7 @@ type TagEvent struct {
 	Commits    []*struct {
 		ID        string     `json:"id"`
 		Message   string     `json:"message"`
+		Title     string     `json:"title"`
 		Timestamp *time.Time `json:"timestamp"`
 		URL       string     `json:"url"`
 		Author    struct {

--- a/event_webhook_types_test.go
+++ b/event_webhook_types_test.go
@@ -362,8 +362,54 @@ func TestPushEventUnmarshal(t *testing.T) {
 		t.Errorf("Commit Timestamp isn't nil")
 	}
 
+	if event.Commits[0] == nil || event.Commits[0].Message != exampleCommitMessage {
+		t.Errorf("Commit Message is %s, want %s", event.Commits[0].Message, exampleCommitMessage)
+	}
+
+	if event.Commits[0] == nil || event.Commits[0].Title != exampleCommitTitle {
+		t.Errorf("Commit Title is %s, want %s", event.Commits[0].Title, exampleCommitTitle)
+	}
+
 	if event.Commits[0] == nil || event.Commits[0].Author.Name != "Jordi Mallach" {
 		t.Errorf("Commit Username is %s, want %s", event.UserName, "Jordi Mallach")
+	}
+}
+
+func TestTagEventUnmarshal(t *testing.T) {
+	jsonObject := loadFixture("testdata/webhooks/tag_push.json")
+	var event *TagEvent
+	err := json.Unmarshal(jsonObject, &event)
+
+	if err != nil {
+		t.Errorf("Tag Event can not unmarshaled: %v\n ", err.Error())
+	}
+
+	if event == nil {
+		t.Errorf("Tag Event is null")
+	}
+
+	if event.ProjectID != 1 {
+		t.Errorf("ProjectID is %v, want %v", event.ProjectID, 1)
+	}
+
+	if event.UserName != exampleEventUserName {
+		t.Errorf("Username is %s, want %s", event.UserName, exampleEventUserName)
+	}
+
+	if event.Commits[0] == nil || event.Commits[0].Timestamp == nil {
+		t.Errorf("Commit Timestamp isn't nil")
+	}
+
+	if event.Commits[0] == nil || event.Commits[0].Message != exampleCommitMessage {
+		t.Errorf("Commit Message is %s, want %s", event.Commits[0].Message, exampleCommitMessage)
+	}
+
+	if event.Commits[0] == nil || event.Commits[0].Title != exampleCommitTitle {
+		t.Errorf("Commit Title is %s, want %s", event.Commits[0].Title, exampleCommitTitle)
+	}
+
+	if event.Commits[0] == nil || event.Commits[0].Author.Name != exampleEventUserName {
+		t.Errorf("Commit Username is %s, want %s", event.UserName, exampleEventUserName)
 	}
 }
 

--- a/fixtures_test.go
+++ b/fixtures_test.go
@@ -17,6 +17,12 @@
 package gitlab
 
 const (
+	// exampleCommitMessage provides fixture for a commit message.
+	exampleCommitMessage = "Merge branch 'some-feature' into 'master'\n\nRelease v1.0.0\n\nSee merge request jsmith/example!1"
+
+	// exampleCommitTitle provides fixture for a commit title.
+	exampleCommitTitle = "Merge branch 'some-feature' into 'master'"
+
 	// exampleDetailResponse provides fixture for Runners tests.
 	exampleDetailResponse = `{
 		"active": true,

--- a/testdata/webhooks/push.json
+++ b/testdata/webhooks/push.json
@@ -39,7 +39,8 @@
   "commits": [
     {
       "id": "b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
-      "message": "Update Catalan translation to e38cb41.",
+      "message": "Merge branch 'some-feature' into 'master'\n\nRelease v1.0.0\n\nSee merge request jsmith/example!1",
+      "title": "Merge branch 'some-feature' into 'master'",
       "timestamp": "2011-12-12T14:27:31+02:00",
       "url": "http://example.com/mike/diaspora/commit/b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
       "author": {
@@ -52,7 +53,8 @@
     },
     {
       "id": "da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
-      "message": "fixed readme",
+      "message": "fixed readme\n",
+      "title": "fixed readme",
       "timestamp": "2012-01-03T23:36:29+02:00",
       "url": "http://example.com/mike/diaspora/commit/da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
       "author": {

--- a/testdata/webhooks/tag_push.json
+++ b/testdata/webhooks/tag_push.json
@@ -35,6 +35,21 @@
     "git_ssh_url":"git@example.com:jsmith/example.git",
     "visibility_level":0
   },
-  "commits": [],
-  "total_commits_count": 0
+  "commits": [
+    {
+      "id": "82b3d5ae55f7080f1e6022629cdb57bfae7cccc7",
+      "message": "Merge branch 'some-feature' into 'master'\n\nRelease v1.0.0\n\nSee merge request jsmith/example!1",
+      "title": "Merge branch 'some-feature' into 'master'",
+      "timestamp": "2012-01-03T23:36:29+02:00",
+      "url": "http://example.com/jsmith/example/commit/82b3d5ae55f7080f1e6022629cdb57bfae7cccc7",
+      "author": {
+        "name": "John Smith",
+        "email": "johnsmith@example.com"
+      },
+      "added": ["CHANGELOG"],
+      "modified": ["UPGRADE.md"],
+      "removed": []
+    }
+  ],
+  "total_commits_count": 1
 }


### PR DESCRIPTION
This PR adds the `Title` field to the `PushEvent.Commits` and `TagEvent.Commits` webhook structs, populated from the corresponding Gitlab event payloads :

- https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#push-events
- https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#tag-events

I'm currently working on a project and I need to get the commit titles from the webhook event.
Instead of using the `Message` field (which can contain several lines), I'd like to rely on the `Title` field, the one which is used by Gitlab itself in the commit history.