### PR TITLE
adding variables to pipeline event webhook object attributes

### DIFF
--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -640,6 +640,10 @@ type PipelineEvent struct {
 		FinishedAt     string   `json:"finished_at"`
 		Duration       int      `json:"duration"`
 		QueuedDuration int      `json:"queued_duration"`
+		Variables      []struct {
+			Key   string `json:"key"`
+			Value string `json:"value"`
+		} `json:"variables"`
 	} `json:"object_attributes"`
 	MergeRequest struct {
 		ID                 int    `json:"id"`

--- a/event_webhook_types_test.go
+++ b/event_webhook_types_test.go
@@ -312,6 +312,10 @@ func TestPipelineEventUnmarshal(t *testing.T) {
 		t.Errorf("ObjectAttributes.QueuedDuration is %v, want %v", event.ObjectAttributes.QueuedDuration, 12)
 	}
 
+	if event.ObjectAttributes.Variables[0].Key != "NESTOR_PROD_ENVIRONMENT" {
+		t.Errorf("ObjectAttributes.Variables[0].Key is %v, want %v", event.ObjectAttributes.Variables[0].Key, "NESTOR_PROD_ENVIRONMENT")
+	}
+
 	if event.User.ID != 42 {
 		t.Errorf("User ID is %d, want %d", event.User.ID, 42)
 	}


### PR DESCRIPTION
close #1120 

Note: not tested against actual webhook. Based on the payload, this works. I'm not sure how it behaves when a variable is masked. let me know if you need me to test on that behavior