### PR TITLE
Remove obsolete Public field in projects

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -42,7 +42,6 @@ type Project struct {
 	ID                                        int                        `json:"id"`
 	Description                               string                     `json:"description"`
 	DefaultBranch                             string                     `json:"default_branch"`
-	Public                                    bool                       `json:"public"`
 	Visibility                                VisibilityValue            `json:"visibility"`
 	SSHURLToRepo                              string                     `json:"ssh_url_to_repo"`
 	HTTPURLToRepo                             string                     `json:"http_url_to_repo"`


### PR DESCRIPTION
This looks like a breaking change, but this field is not an API v4 one:
https://docs.gitlab.com/ee/api/projects.html

It leads to confusing results like:

```json
{
   "id": 123456,
   "description": "",
   "default_branch": "main",
   "public": false,
   "visibility": "public",
[...]
}
```