### PR TITLE
fix: update pipeline webhook event type payload

### DIFF
--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -698,15 +698,22 @@ type PipelineEvent struct {
 		AllowFailure bool       `json:"allow_failure"`
 		User         *EventUser `json:"user"`
 		Runner       struct {
-			ID          int    `json:"id"`
-			Description string `json:"description"`
-			Active      bool   `json:"active"`
-			IsShared    bool   `json:"is_shared"`
+			ID          int      `json:"id"`
+			Description string   `json:"description"`
+			Active      bool     `json:"active"`
+			IsShared    bool     `json:"is_shared"`
+			RunnerType  bool     `json:"runner_type"`
+			Tags        []string `json:"tags"`
 		} `json:"runner"`
 		ArtifactsFile struct {
 			Filename string `json:"filename"`
 			Size     int    `json:"size"`
 		} `json:"artifacts_file"`
+		Environment struct {
+			Name           string `json:"name"`
+			Action         string `json:"action"`
+			DeploymentTier string `json:"deployment_tier"`
+		} `json:"environment"`
 	} `json:"builds"`
 }
 

--- a/event_webhook_types_test.go
+++ b/event_webhook_types_test.go
@@ -339,6 +339,10 @@ func TestPipelineEventUnmarshal(t *testing.T) {
 	if event.Builds[0].AllowFailure != true {
 		t.Errorf("Builds.0.AllowFailure is %v, want %v", event.Builds[0].AllowFailure, true)
 	}
+	
+	if event.Builds[0].Environment.Name != "production" {
+		t.Errorf("Builds.0.Environment.Name is %v, want %v", event.Builds[0].Environment.Name, "production")
+	}
 }
 
 func TestPushEventUnmarshal(t *testing.T) {

--- a/testdata/webhooks/pipeline.json
+++ b/testdata/webhooks/pipeline.json
@@ -90,7 +90,12 @@
         "artifacts_file":{
            "filename": null,
            "size": null
-        }
+        },
+        "environment": {
+             "name": "production",
+             "action": "start",
+             "deployment_tier": "production"
+         }
      },
      {
         "id": 377,


### PR DESCRIPTION
This change brings in `Environment` struct as part of the Pipeline Event Payload. Recent versions of the gitlab api's pipeline event payload contain the environment details which would be useful to expose via this sdk.