### PR TITLE
feat: add markdown endpoint support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ to add new and/or missing endpoints. Currently the following services are suppor
 - [x] Keys
 - [x] Labels
 - [x] License
+- [x] Markdown
 - [x] Merge Request Approvals
 - [x] Merge Requests
 - [x] Namespaces

--- a/gitlab.go
+++ b/gitlab.go
@@ -147,6 +147,7 @@ type Client struct {
 	License               *LicenseService
 	LicenseTemplates      *LicenseTemplatesService
 	ManagedLicenses       *ManagedLicensesService
+	Markdown              *MarkdownService
 	MergeRequestApprovals *MergeRequestApprovalsService
 	MergeRequests         *MergeRequestsService
 	Milestones            *MilestonesService
@@ -338,6 +339,7 @@ func newClient(options ...ClientOptionFunc) (*Client, error) {
 	c.License = &LicenseService{client: c}
 	c.LicenseTemplates = &LicenseTemplatesService{client: c}
 	c.ManagedLicenses = &ManagedLicensesService{client: c}
+	c.Markdown = &MarkdownService{client: c}
 	c.MergeRequestApprovals = &MergeRequestApprovalsService{client: c}
 	c.MergeRequests = &MergeRequestsService{client: c, timeStats: timeStats}
 	c.Milestones = &MilestonesService{client: c}

--- a/markdown.go
+++ b/markdown.go
@@ -2,38 +2,46 @@ package gitlab
 
 import "net/http"
 
-// MarkdownService handles communication with the markdown endpoint of the gitlab API
+// MarkdownService handles communication with the markdown related methods of
+// the GitLab API.
 //
 // Gitlab API docs: https://docs.gitlab.com/ee/api/markdown.html
 type MarkdownService struct {
 	client *Client
 }
 
-// Markdown represents gitlab markdown
+// Markdown represents a markdown document.
+//
+// Gitlab API docs: https://docs.gitlab.com/ee/api/markdown.html
 type Markdown struct {
 	HTML string `json:"html"`
 }
 
-// MarkdownOptions represents the available Markdown() options.
-type MarkdownOptions struct {
-	Text                    string `json:"text,omitempty"`
-	GitlabFlavouredMarkdown bool   `json:"gfm,omitempty"`
-	Project                 string `json:"project,omitempty"`
-}
-
-// Markdown creates html from the given markdown
+// RenderOptions represents the available Render() options.
 //
 // Gitlab API docs:
-func (s *MarkdownService) Markdown(opt *MarkdownOptions, options ...RequestOptionFunc) (*Markdown, *Response, error) {
+// https://docs.gitlab.com/ee/api/markdown.html#render-an-arbitrary-markdown-document
+type RenderOptions struct {
+	Text                    *string `url:"text,omitempty" json:"text,omitempty"`
+	GitlabFlavouredMarkdown *bool   `url:"gfm,omitempty" json:"gfm,omitempty"`
+	Project                 *string `url:"project,omitempty" json:"project,omitempty"`
+}
+
+// Render an arbitrary markdown document.
+//
+// Gitlab API docs:
+// https://docs.gitlab.com/ee/api/markdown.html#render-an-arbitrary-markdown-document
+func (s *MarkdownService) Render(opt *RenderOptions, options ...RequestOptionFunc) (*Markdown, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodPost, "markdown", opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	markdown := new(Markdown)
-	response, err := s.client.Do(req, markdown)
+	md := new(Markdown)
+	response, err := s.client.Do(req, md)
 	if err != nil {
 		return nil, response, err
 	}
-	return markdown, response, nil
+
+	return md, response, nil
 }

--- a/markdown.go
+++ b/markdown.go
@@ -1,0 +1,39 @@
+package gitlab
+
+import "net/http"
+
+// MarkdownService handles communication with the markdown endpoint of the gitlab API
+//
+// Gitlab API docs: https://docs.gitlab.com/ee/api/markdown.html
+type MarkdownService struct {
+	client *Client
+}
+
+// Markdown represents gitlab markdown
+type Markdown struct {
+	HTML string `json:"html"`
+}
+
+// MarkdownOptions represents the available Markdown() options.
+type MarkdownOptions struct {
+	Text                    string `json:"text,omitempty"`
+	GitlabFlavouredMarkdown bool   `json:"gfm,omitempty"`
+	Project                 string `json:"project,omitempty"`
+}
+
+// Markdown creates html from the given markdown
+//
+// Gitlab API docs:
+func (s *MarkdownService) Markdown(opt *MarkdownOptions, options ...RequestOptionFunc) (*Markdown, *Response, error) {
+	req, err := s.client.NewRequest(http.MethodPost, "markdown", opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	markdown := new(Markdown)
+	response, err := s.client.Do(req, markdown)
+	if err != nil {
+		return nil, response, err
+	}
+	return markdown, response, nil
+}

--- a/markdown_test.go
+++ b/markdown_test.go
@@ -6,35 +6,36 @@ import (
 	"testing"
 )
 
-func TestMarkdown(t *testing.T) {
+const markdownHTMLResponse = "<h1>Testing</h1>"
+
+func TestRender(t *testing.T) {
 	mux, server, client := setup(t)
 	defer teardown(server)
-
-	const htmlResponse = "<h1>Testing</h1>"
 
 	mux.HandleFunc("/api/v4/markdown", func(writer http.ResponseWriter, request *http.Request) {
 		testMethod(t, request, http.MethodPost)
 		writer.WriteHeader(http.StatusOK)
-		markdown := Markdown{HTML: htmlResponse}
+		markdown := Markdown{HTML: markdownHTMLResponse}
 		resp, _ := json.Marshal(markdown)
 		_, _ = writer.Write(resp)
 	})
 
-	opt := &MarkdownOptions{
-		Text:                    "# Testing",
-		GitlabFlavouredMarkdown: true,
-		Project:                 "some/sub/group/project",
+	opt := &RenderOptions{
+		Text:                    String("# Testing"),
+		GitlabFlavouredMarkdown: Bool(true),
+		Project:                 String("some/sub/group/project"),
 	}
-	markdown, resp, err := client.Markdown.Markdown(opt)
+	markdown, resp, err := client.Markdown.Render(opt)
 	if err != nil {
-		t.Fatalf("GetMarkdown returned error: %v", err)
+		t.Fatalf("Render returned error: %v", err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("GetMarkdown retruned status expected %q but was %q", http.StatusOK, resp.Status)
+		t.Fatalf("Render returned status, expected %q but got %q", http.StatusOK, resp.Status)
 	}
 
-	if markdown.HTML != htmlResponse {
-		t.Fatalf("GetMarkdown returned wrong response, expected HTML to be %q but was %q", htmlResponse, markdown.HTML)
+	if markdown.HTML != markdownHTMLResponse {
+		t.Fatalf("Render returned wrong response, expected %q but got %q",
+			markdownHTMLResponse, markdown.HTML)
 	}
 }

--- a/markdown_test.go
+++ b/markdown_test.go
@@ -1,0 +1,40 @@
+package gitlab
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestMarkdown(t *testing.T) {
+	mux, server, client := setup(t)
+	defer teardown(server)
+
+	const htmlResponse = "<h1>Testing</h1>"
+
+	mux.HandleFunc("/api/v4/markdown", func(writer http.ResponseWriter, request *http.Request) {
+		testMethod(t, request, http.MethodPost)
+		writer.WriteHeader(http.StatusOK)
+		markdown := Markdown{HTML: htmlResponse}
+		resp, _ := json.Marshal(markdown)
+		_, _ = writer.Write(resp)
+	})
+
+	opt := &MarkdownOptions{
+		Text:                    "# Testing",
+		GitlabFlavouredMarkdown: true,
+		Project:                 "some/sub/group/project",
+	}
+	markdown, resp, err := client.Markdown.Markdown(opt)
+	if err != nil {
+		t.Fatalf("GetMarkdown returned error: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GetMarkdown retruned status expected %q but was %q", http.StatusOK, resp.Status)
+	}
+
+	if markdown.HTML != htmlResponse {
+		t.Fatalf("GetMarkdown returned wrong response, expected HTML to be %q but was %q", htmlResponse, markdown.HTML)
+	}
+}


### PR DESCRIPTION
I noticed that the markdown (https://docs.gitlab.com/ee/api/markdown.html) endpoint is not implemented. So I've added it, I wasn't really sure on the naming of the functions since it's not a get route and technically it retrieves HTML. However, I decided to follow the name in the url/docs of gitlab with just `Markdown`. If you like an other name please let me know, I'd be happy to change it :)