### PR TITLE
Add none documented response property

### DIFF
--- a/merge_request_approvals.go
+++ b/merge_request_approvals.go
@@ -100,6 +100,7 @@ type MergeRequestApprovalRule struct {
 	Users                []*BasicUser         `json:"users"`
 	Groups               []*Group             `json:"groups"`
 	ContainsHiddenGroups bool                 `json:"contains_hidden_groups"`
+	Section              string               `json:"section"`
 	ApprovedBy           []*BasicUser         `json:"approved_by"`
 	Approved             bool                 `json:"approved"`
 }

--- a/merge_request_approvals_test.go
+++ b/merge_request_approvals_test.go
@@ -85,6 +85,7 @@ func TestGetApprovalState(t *testing.T) {
 					}
 				],
 				"contains_hidden_groups": false,
+				"section": "test",
 				"approved_by": [
 					{
 						"id": 5,
@@ -157,6 +158,7 @@ func TestGetApprovalState(t *testing.T) {
 						FullPath:             "group1",
 					},
 				},
+				Section: "test",
 				ApprovedBy: []*BasicUser{
 					{
 						ID:        5,
@@ -236,7 +238,8 @@ func TestGetApprovalRules(t *testing.T) {
 						"ldap_access": null
 					}
 				],
-				"contains_hidden_groups": false
+				"contains_hidden_groups": false,
+				"section": "test"
 			}
 		]`)
 	})
@@ -295,6 +298,7 @@ func TestGetApprovalRules(t *testing.T) {
 					FullPath:             "group1",
 				},
 			},
+			Section: "test",
 		},
 	}
 


### PR DESCRIPTION
Hi! 

First of all thank you for the great package. 
As I used it, I discovered a missing property which is not documented in the official GitLab API docs. 
If you defined a [CODEOWNERS](https://docs.gitlab.com/ee/user/project/code_owners.html) file you get as "rule_type" "code_owner" and also the property "section". I only added the property to the response.