### PR TITLE
Add support for webhook subgroup events

### DIFF
--- a/event_parsing.go
+++ b/event_parsing.go
@@ -39,6 +39,7 @@ const (
 	EventTypePush          EventType = "Push Hook"
 	EventTypeRelease       EventType = "Release Hook"
 	EventTypeServiceHook   EventType = "Service Hook"
+	EventTypeSubGroup      EventType = "Subgroup Hook"
 	EventTypeSystemHook    EventType = "System Hook"
 	EventTypeTagPush       EventType = "Tag Push Hook"
 	EventTypeWikiPage      EventType = "Wiki Page Hook"
@@ -265,6 +266,8 @@ func ParseWebhook(eventType EventType, payload []byte) (event interface{}, err e
 		default:
 			return nil, fmt.Errorf("unexpected service type %s", service.ObjectKind)
 		}
+	case EventTypeSubGroup:
+		event = &SubGroupEvent{}
 	case EventTypeTagPush:
 		event = &TagEvent{}
 	case EventTypeWikiPage:

--- a/event_parsing_webhook_test.go
+++ b/event_parsing_webhook_test.go
@@ -387,6 +387,24 @@ func TestParseSnippetCommentHook(t *testing.T) {
 	}
 }
 
+func TestParseSubGroupHook(t *testing.T) {
+	raw := loadFixture("testdata/webhooks/subgroup.json")
+
+	parsedEvent, err := ParseWebhook("Subgroup Hook", raw)
+	if err != nil {
+		t.Errorf("Error parsing subgroup hook: %s", err)
+	}
+
+	event, ok := parsedEvent.(*SubGroupEvent)
+	if !ok {
+		t.Errorf("Expected SubGroupEvent, but parsing produced %T", parsedEvent)
+	}
+
+	if event.EventName != "subgroup_create" {
+		t.Errorf("EventName is %v, want %v", event.EventName, "subgroup_create")
+	}
+}
+
 func TestParseTagHook(t *testing.T) {
 	raw := loadFixture("testdata/webhooks/tag_push.json")
 

--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -61,7 +61,7 @@ type BuildEvent struct {
 // CommitCommentEvent represents a comment on a commit event.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/user/project/integrations/webhooks.html#comment-on-commit
+// https://docs.gitlab.com/ce/user/project/integrations/webhook_events.html#comment-on-a-commit
 type CommitCommentEvent struct {
 	ObjectKind string `json:"object_kind"`
 	User       *User  `json:"user"`
@@ -125,7 +125,7 @@ type CommitCommentEvent struct {
 // DeploymentEvent represents a deployment event
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/user/project/integrations/webhooks.html#deployment-events
+// https://docs.gitlab.com/ce/user/project/integrations/webhook_events.html#deployment-events
 type DeploymentEvent struct {
 	ObjectKind    string `json:"object_kind"`
 	Status        string `json:"status"`
@@ -160,7 +160,7 @@ type DeploymentEvent struct {
 // IssueCommentEvent represents a comment on an issue event.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/user/project/integrations/webhooks.html#comment-on-issue
+// https://docs.gitlab.com/ce/user/project/integrations/webhook_events.html#comment-on-an-issue
 type IssueCommentEvent struct {
 	ObjectKind string `json:"object_kind"`
 	User       *User  `json:"user"`
@@ -230,7 +230,7 @@ type IssueCommentEvent struct {
 // IssueEvent represents a issue event.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/user/project/integrations/webhooks.html#issues-events
+// https://docs.gitlab.com/ce/user/project/integrations/webhook_events.html#issue-events
 type IssueEvent struct {
 	ObjectKind string     `json:"object_kind"`
 	User       *EventUser `json:"user"`
@@ -344,7 +344,7 @@ type JobEvent struct {
 // MergeCommentEvent represents a comment on a merge event.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/user/project/integrations/webhooks.html#comment-on-merge-request
+// https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#comment-on-a-merge-request
 type MergeCommentEvent struct {
 	ObjectKind string     `json:"object_kind"`
 	User       *EventUser `json:"user"`
@@ -447,7 +447,7 @@ type MergeCommentEvent struct {
 // MergeEvent represents a merge event.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/user/project/integrations/webhooks.html#merge-request-events
+// https://docs.gitlab.com/ce/user/project/integrations/webhook_events.html#merge-request-events
 type MergeEvent struct {
 	ObjectKind string     `json:"object_kind"`
 	User       *EventUser `json:"user"`
@@ -623,7 +623,7 @@ func (p *MergeParams) UnmarshalJSON(b []byte) error {
 // PipelineEvent represents a pipeline event.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/user/project/integrations/webhooks.html#pipeline-events
+// https://docs.gitlab.com/ce/user/project/integrations/webhook_events.html#pipeline-events
 type PipelineEvent struct {
 	ObjectKind       string `json:"object_kind"`
 	ObjectAttributes struct {
@@ -720,7 +720,7 @@ type PipelineEvent struct {
 // PushEvent represents a push event.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/user/project/integrations/webhooks.html#push-events
+// https://docs.gitlab.com/ce/user/project/integrations/webhook_events.html#push-events
 type PushEvent struct {
 	ObjectKind   string `json:"object_kind"`
 	Before       string `json:"before"`
@@ -770,7 +770,7 @@ type PushEvent struct {
 // ReleaseEvent represents a release event
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/user/project/integrations/webhooks.html#release-events
+// https://docs.gitlab.com/ce/user/project/integrations/webhook_events.html#release-events
 type ReleaseEvent struct {
 	ID          int    `json:"id"`
 	CreatedAt   string `json:"created_at"` // Should be *time.Time (see Gitlab issue #21468)
@@ -829,7 +829,7 @@ type ReleaseEvent struct {
 // SnippetCommentEvent represents a comment on a snippet event.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/user/project/integrations/webhooks.html#comment-on-code-snippet
+// https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#comment-on-a-code-snippet
 type SnippetCommentEvent struct {
 	ObjectKind string     `json:"object_kind"`
 	User       *EventUser `json:"user"`
@@ -874,7 +874,7 @@ type SnippetCommentEvent struct {
 // TagEvent represents a tag event.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/user/project/integrations/webhooks.html#tag-events
+// https://docs.gitlab.com/ce/user/project/integrations/webhook_events.html#tag-events
 type TagEvent struct {
 	ObjectKind   string `json:"object_kind"`
 	Before       string `json:"before"`
@@ -925,7 +925,7 @@ type TagEvent struct {
 // WikiPageEvent represents a wiki page event.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/user/project/integrations/webhooks.html#wiki-page-events
+// https://docs.gitlab.com/ce/user/project/integrations/webhook_events.html#wiki-page-events
 type WikiPageEvent struct {
 	ObjectKind string     `json:"object_kind"`
 	User       *EventUser `json:"user"`

--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -871,6 +871,24 @@ type SnippetCommentEvent struct {
 	Snippet *Snippet `json:"snippet"`
 }
 
+// SubGroupEvent represents a subgroup event.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#subgroup-events
+type SubGroupEvent struct {
+	CreatedAt      *time.Time `json:"created_at"`
+	UpdatedAt      *time.Time `json:"updated_at"`
+	EventName      string     `json:"event_name"`
+	Name           string     `json:"name"`
+	Path           string     `json:"path"`
+	FullPath       string     `json:"full_path"`
+	GroupID        int        `json:"group_id"`
+	ParentGroupID  int        `json:"parent_group_id"`
+	ParentName     string     `json:"parent_name"`
+	ParentPath     string     `json:"parent_path"`
+	ParentFullPath string     `json:"parent_full_path"`
+}
+
 // TagEvent represents a tag event.
 //
 // GitLab API docs:

--- a/event_webhook_types_test.go
+++ b/event_webhook_types_test.go
@@ -19,6 +19,7 @@ package gitlab
 import (
 	"encoding/json"
 	"testing"
+	"time"
 )
 
 const (
@@ -339,7 +340,7 @@ func TestPipelineEventUnmarshal(t *testing.T) {
 	if event.Builds[0].AllowFailure != true {
 		t.Errorf("Builds.0.AllowFailure is %v, want %v", event.Builds[0].AllowFailure, true)
 	}
-	
+
 	if event.Builds[0].Environment.Name != "production" {
 		t.Errorf("Builds.0.Environment.Name is %v, want %v", event.Builds[0].Environment.Name, "production")
 	}
@@ -383,44 +384,6 @@ func TestPushEventUnmarshal(t *testing.T) {
 	}
 }
 
-func TestTagEventUnmarshal(t *testing.T) {
-	jsonObject := loadFixture("testdata/webhooks/tag_push.json")
-	var event *TagEvent
-	err := json.Unmarshal(jsonObject, &event)
-
-	if err != nil {
-		t.Errorf("Tag Event can not unmarshaled: %v\n ", err.Error())
-	}
-
-	if event == nil {
-		t.Errorf("Tag Event is null")
-	}
-
-	if event.ProjectID != 1 {
-		t.Errorf("ProjectID is %v, want %v", event.ProjectID, 1)
-	}
-
-	if event.UserName != exampleEventUserName {
-		t.Errorf("Username is %s, want %s", event.UserName, exampleEventUserName)
-	}
-
-	if event.Commits[0] == nil || event.Commits[0].Timestamp == nil {
-		t.Errorf("Commit Timestamp isn't nil")
-	}
-
-	if event.Commits[0] == nil || event.Commits[0].Message != exampleCommitMessage {
-		t.Errorf("Commit Message is %s, want %s", event.Commits[0].Message, exampleCommitMessage)
-	}
-
-	if event.Commits[0] == nil || event.Commits[0].Title != exampleCommitTitle {
-		t.Errorf("Commit Title is %s, want %s", event.Commits[0].Title, exampleCommitTitle)
-	}
-
-	if event.Commits[0] == nil || event.Commits[0].Author.Name != exampleEventUserName {
-		t.Errorf("Commit Username is %s, want %s", event.UserName, exampleEventUserName)
-	}
-}
-
 func TestReleaseEventUnmarshal(t *testing.T) {
 	jsonObject := loadFixture("testdata/webhooks/release.json")
 
@@ -461,5 +424,74 @@ func TestReleaseEventUnmarshal(t *testing.T) {
 
 	if event.Commit.Author.Name != "User" {
 		t.Errorf("Commit author name is %s, want %s", event.Commit.Author.Name, "User")
+	}
+}
+
+func TestSubGroupEventUnmarshal(t *testing.T) {
+	jsonObject := loadFixture("testdata/webhooks/subgroup.json")
+
+	var event *SubGroupEvent
+	err := json.Unmarshal(jsonObject, &event)
+
+	if err != nil {
+		t.Errorf("SubGroup Event can not unmarshaled: %v\n ", err.Error())
+	}
+
+	if event == nil {
+		t.Errorf("SubGroup Event is null")
+	}
+
+	if event.Name != "Subgroup 1" {
+		t.Errorf("Name is %v, want %v", event.Name, "Subgroup 1")
+	}
+
+	if event.GroupID != 2 {
+		t.Errorf("GroupID is %v, want %v", event.GroupID, 2)
+	}
+
+	if event.ParentGroupID != 1 {
+		t.Errorf("ParentGroupID is %v, want %v", event.ParentGroupID, 1)
+	}
+
+	if event.CreatedAt.Format(time.RFC3339) != "2022-01-24T14:23:59Z" {
+		t.Errorf("CreatedAt is %v, want %v", event.CreatedAt.Format(time.RFC3339), "2022-01-24T14:23:59Z")
+	}
+}
+
+func TestTagEventUnmarshal(t *testing.T) {
+	jsonObject := loadFixture("testdata/webhooks/tag_push.json")
+	var event *TagEvent
+	err := json.Unmarshal(jsonObject, &event)
+
+	if err != nil {
+		t.Errorf("Tag Event can not unmarshaled: %v\n ", err.Error())
+	}
+
+	if event == nil {
+		t.Errorf("Tag Event is null")
+	}
+
+	if event.ProjectID != 1 {
+		t.Errorf("ProjectID is %v, want %v", event.ProjectID, 1)
+	}
+
+	if event.UserName != exampleEventUserName {
+		t.Errorf("Username is %s, want %s", event.UserName, exampleEventUserName)
+	}
+
+	if event.Commits[0] == nil || event.Commits[0].Timestamp == nil {
+		t.Errorf("Commit Timestamp isn't nil")
+	}
+
+	if event.Commits[0] == nil || event.Commits[0].Message != exampleCommitMessage {
+		t.Errorf("Commit Message is %s, want %s", event.Commits[0].Message, exampleCommitMessage)
+	}
+
+	if event.Commits[0] == nil || event.Commits[0].Title != exampleCommitTitle {
+		t.Errorf("Commit Title is %s, want %s", event.Commits[0].Title, exampleCommitTitle)
+	}
+
+	if event.Commits[0] == nil || event.Commits[0].Author.Name != exampleEventUserName {
+		t.Errorf("Commit Username is %s, want %s", event.UserName, exampleEventUserName)
 	}
 }

--- a/testdata/webhooks/subgroup.json
+++ b/testdata/webhooks/subgroup.json
@@ -1,0 +1,13 @@
+{
+  "created_at": "2022-01-24T14:23:59Z",
+  "updated_at": "2022-01-24T14:23:59Z",
+  "event_name": "subgroup_create",
+  "name": "Subgroup 1",
+  "path": "subgroup-1",
+  "full_path": "group-1/subgroup-1",
+  "group_id": 2,
+  "parent_group_id": 1,
+  "parent_name": "Group 1",
+  "parent_path": "group-1",
+  "parent_full_path": "group-1"
+}


### PR DESCRIPTION
Docs are 100% up-to-date with the current payload: https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#subgroup-events. I also updated all links to the other webhook events since they have been moved.

I tried to look at existing capitalizations of SubGroup and align it with those, hope it's okay