### PR TITLE
adding group access token

### DIFF
--- a/gitlab.go
+++ b/gitlab.go
@@ -127,6 +127,7 @@ type Client struct {
 	GenericPackages       *GenericPackagesService
 	GeoNodes              *GeoNodesService
 	GitIgnoreTemplates    *GitIgnoreTemplatesService
+	GroupAccessTokens     *GroupAccessTokensService
 	GroupBadges           *GroupBadgesService
 	GroupCluster          *GroupClustersService
 	GroupImportExport     *GroupImportExportService
@@ -321,6 +322,7 @@ func newClient(options ...ClientOptionFunc) (*Client, error) {
 	c.GenericPackages = &GenericPackagesService{client: c}
 	c.GeoNodes = &GeoNodesService{client: c}
 	c.GitIgnoreTemplates = &GitIgnoreTemplatesService{client: c}
+	c.GroupAccessTokens = &GroupAccessTokensService{client: c}
 	c.GroupBadges = &GroupBadgesService{client: c}
 	c.GroupCluster = &GroupClustersService{client: c}
 	c.GroupImportExport = &GroupImportExportService{client: c}

--- a/group_access_tokens.go
+++ b/group_access_tokens.go
@@ -1,0 +1,140 @@
+//
+// Copyright 2022, Masahiro Yoshida
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package gitlab
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// GroupAccessTokensService handles communication with the
+// groups access tokens related methods of the GitLab API.
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/group_access_tokens.html
+type GroupAccessTokensService struct {
+	client *Client
+}
+
+// GroupAccessToken represents a GitLab Group Access Token.
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/group_access_tokens.html
+type GroupAccessToken struct {
+	ID          int              `json:"id"`
+	UserID      int              `json:"user_id"`
+	Name        string           `json:"name"`
+	Scopes      []string         `json:"scopes"`
+	CreatedAt   *time.Time       `json:"created_at"`
+	ExpiresAt   *ISOTime         `json:"expires_at"`
+	Active      bool             `json:"active"`
+	Revoked     bool             `json:"revoked"`
+	Token       string           `json:"token"`
+	AccessLevel AccessLevelValue `json:"access_level"`
+}
+
+func (v GroupAccessToken) String() string {
+	return Stringify(v)
+}
+
+// ListGroupAccessTokensOptions represents the available options for
+// listing variables in a group.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/group_access_tokens.html#list-group-access-tokens
+type ListGroupAccessTokensOptions ListOptions
+
+// ListGroupAccessTokens gets a list of all Group Access Tokens in a
+// group.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/group_access_tokens.html#list-group-access-tokens
+func (s *GroupAccessTokensService) ListGroupAccessTokens(gid interface{}, opt *ListGroupAccessTokensOptions, options ...RequestOptionFunc) ([]*GroupAccessToken, *Response, error) {
+	groups, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/access_tokens", PathEscape(groups))
+
+	req, err := s.client.NewRequest(http.MethodGet, u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var gats []*GroupAccessToken
+	resp, err := s.client.Do(req, &gats)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return gats, resp, err
+}
+
+// CreateGroupAccessTokenOptions represents the available CreateVariable()
+// options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/group_access_tokens.html#create-a-group-access-token
+type CreateGroupAccessTokenOptions struct {
+	Name        *string           `url:"name,omitempty" json:"name,omitempty"`
+	Scopes      *[]string         `url:"scopes,omitempty" json:"scopes,omitempty"`
+	AccessLevel *AccessLevelValue `url:"access_level,omitempty" json:"access_level,omitempty"`
+	ExpiresAt   *ISOTime          `url:"expires_at,omitempty" json:"expires_at,omitempty"`
+}
+
+// CreateGroupAccessToken creates a new Group Access Token.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/group_access_tokens.html#create-a-group-access-token
+func (s *GroupAccessTokensService) CreateGroupAccessToken(gid interface{}, opt *CreateGroupAccessTokenOptions, options ...RequestOptionFunc) (*GroupAccessToken, *Response, error) {
+	groups, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/access_tokens", PathEscape(groups))
+
+	req, err := s.client.NewRequest(http.MethodPost, u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pat := new(GroupAccessToken)
+	resp, err := s.client.Do(req, pat)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return pat, resp, err
+}
+
+// DeleteGroupAccessToken deletes a Group Access Token.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/group_access_tokens.html#revoke-a-group-access-token
+func (s *GroupAccessTokensService) DeleteGroupAccessToken(gid interface{}, id int, options ...RequestOptionFunc) (*Response, error) {
+	groups, err := parseID(gid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("groups/%s/access_tokens/%d", PathEscape(groups), id)
+
+	req, err := s.client.NewRequest(http.MethodDelete, u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}

--- a/group_access_tokens_test.go
+++ b/group_access_tokens_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2021, Patrick Webster
+// Copyright 2022, Masahiro Yoshida
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,30 +23,30 @@ import (
 	"time"
 )
 
-func TestListProjectAccessTokens(t *testing.T) {
+func TestListGroupAccessTokens(t *testing.T) {
 	mux, server, client := setup(t)
 	defer teardown(server)
 
-	mux.HandleFunc("/api/v4/projects/1/access_tokens", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v4/groups/1/access_tokens", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
-		mustWriteHTTPResponse(t, w, "testdata/list_project_access_tokens.json")
+		mustWriteHTTPResponse(t, w, "testdata/list_group_access_tokens.json")
 	})
 
-	projectAccessTokens, _, err := client.ProjectAccessTokens.ListProjectAccessTokens(1, &ListProjectAccessTokensOptions{Page: 1, PerPage: 20})
+	groupAccessTokens, _, err := client.GroupAccessTokens.ListGroupAccessTokens(1, &ListGroupAccessTokensOptions{Page: 1, PerPage: 20})
 	if err != nil {
-		t.Errorf("ProjectAccessTokens.ListProjectAccessTokens returned error: %v", err)
+		t.Errorf("GroupAccessTokens.ListGroupAccessTokens returned error: %v", err)
 	}
 
 	time1, err := time.Parse(time.RFC3339, "2021-03-09T21:11:47.271Z")
 	if err != nil {
-		t.Errorf("ProjectAccessTokens.ListProjectAccessTokens returned error: %v", err)
+		t.Errorf("GroupAccessTokens.ListGroupAccessTokens returned error: %v", err)
 	}
 	time2, err := time.Parse(time.RFC3339, "2021-03-09T21:11:47.340Z")
 	if err != nil {
-		t.Errorf("ProjectAccessTokens.ListProjectAccessTokens returned error: %v", err)
+		t.Errorf("GroupAccessTokens.ListGroupAccessTokens returned error: %v", err)
 	}
 
-	want := []*ProjectAccessToken{
+	want := []*GroupAccessToken{
 		{
 			ID:          1876,
 			UserID:      2453,
@@ -69,30 +69,30 @@ func TestListProjectAccessTokens(t *testing.T) {
 		},
 	}
 
-	if !reflect.DeepEqual(want, projectAccessTokens) {
-		t.Errorf("ProjectAccessTokens.ListProjectAccessTokens returned %+v, want %+v", projectAccessTokens, want)
+	if !reflect.DeepEqual(want, groupAccessTokens) {
+		t.Errorf("GroupAccessTokens.ListGroupAccessTokens returned %+v, want %+v", groupAccessTokens, want)
 	}
 }
 
-func TestCreateProjectAccessToken(t *testing.T) {
+func TestCreateGroupAccessToken(t *testing.T) {
 	mux, server, client := setup(t)
 	defer teardown(server)
 
-	mux.HandleFunc("/api/v4/projects/1/access_tokens", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v4/groups/1/access_tokens", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
-		mustWriteHTTPResponse(t, w, "testdata/create_project_access_token.json")
+		mustWriteHTTPResponse(t, w, "testdata/create_group_access_token.json")
 	})
 
-	projectAccessToken, _, err := client.ProjectAccessTokens.CreateProjectAccessToken(1, nil)
+	groupAccessToken, _, err := client.GroupAccessTokens.CreateGroupAccessToken(1, nil)
 	if err != nil {
-		t.Errorf("ProjectAccessTokens.CreateProjectAccessToken returned error: %v", err)
+		t.Errorf("GroupAccessTokens.CreateGroupAccessToken returned error: %v", err)
 	}
 
 	time1, err := time.Parse(time.RFC3339, "2021-03-09T21:11:47.271Z")
 	if err != nil {
-		t.Errorf("ProjectAccessTokens.CreateProjectAccessToken returned error: %v", err)
+		t.Errorf("GroupAccessTokens.CreateGroupAccessToken returned error: %v", err)
 	}
-	want := &ProjectAccessToken{
+	want := &GroupAccessToken{
 		ID:          1876,
 		UserID:      2453,
 		Name:        "token 10",
@@ -105,21 +105,21 @@ func TestCreateProjectAccessToken(t *testing.T) {
 		AccessLevel: AccessLevelValue(40),
 	}
 
-	if !reflect.DeepEqual(want, projectAccessToken) {
-		t.Errorf("ProjectAccessTokens.CreateProjectAccessToken returned %+v, want %+v", projectAccessToken, want)
+	if !reflect.DeepEqual(want, groupAccessToken) {
+		t.Errorf("GroupAccessTokens.CreateGroupAccessToken returned %+v, want %+v", groupAccessToken, want)
 	}
 }
 
-func TestDeleteProjectAccessToken(t *testing.T) {
+func TestDeleteGroupAccessToken(t *testing.T) {
 	mux, server, client := setup(t)
 	defer teardown(server)
 
-	mux.HandleFunc("/api/v4/projects/1/access_tokens/1234", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v4/groups/1/access_tokens/1234", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
 	})
 
-	_, err := client.ProjectAccessTokens.DeleteProjectAccessToken("1", 1234)
+	_, err := client.GroupAccessTokens.DeleteGroupAccessToken("1", 1234)
 	if err != nil {
-		t.Errorf("ProjectAccessTokens.DeleteProjectAccessToken returned error: %v", err)
+		t.Errorf("GroupAccessTokens.DeleteGroupAccessToken returned error: %v", err)
 	}
 }

--- a/testdata/create_group_access_token.json
+++ b/testdata/create_group_access_token.json
@@ -1,0 +1,17 @@
+{
+  "id": 1876,
+  "name": "token 10",
+  "revoked": false,
+  "created_at": "2021-03-09T21:11:47.271Z",
+  "scopes": [
+      "api",
+      "read_api",
+      "read_repository",
+      "write_repository"
+  ],
+  "user_id": 2453,
+  "active": true,
+  "expires_at": null,
+  "token": "2UsevZE1x1ZdFZW4MNzH",
+  "access_level": 40
+}

--- a/testdata/list_group_access_tokens.json
+++ b/testdata/list_group_access_tokens.json
@@ -1,0 +1,34 @@
+[
+  {
+      "id": 1876,
+      "name": "token 10",
+      "revoked": false,
+      "created_at": "2021-03-09T21:11:47.271Z",
+      "scopes": [
+          "api",
+          "read_api",
+          "read_repository",
+          "write_repository"
+      ],
+      "user_id": 2453,
+      "active": true,
+      "expires_at": null,
+      "access_level": 40
+  },
+  {
+      "id": 1877,
+      "name": "token 8",
+      "revoked": false,
+      "created_at": "2021-03-09T21:11:47.340Z",
+      "scopes": [
+          "api",
+          "read_api",
+          "read_repository",
+          "write_repository"
+      ],
+      "user_id": 2456,
+      "active": true,
+      "expires_at": null,
+      "access_level": 30
+  }
+]


### PR DESCRIPTION
adding group access token, introduced in 14.7 
[API document](https://docs.gitlab.com/ee/api/group_access_tokens.html)

I have not tested with gitlab instance yet. If anyone can test it, it's great

```
go test -v ./... | grep GroupAccessToken
=== RUN   TestListGroupAccessTokens
--- PASS: TestListGroupAccessTokens (0.00s)
=== RUN   TestCreateGroupAccessToken
--- PASS: TestCreateGroupAccessToken (0.00s)
=== RUN   TestDeleteGroupAccessToken
--- PASS: TestDeleteGroupAccessToken (0.00s)
```

close #1347