### PR TITLE
Fix: Label and Group Label name escaping

### DIFF
--- a/group_labels.go
+++ b/group_labels.go
@@ -81,7 +81,7 @@ func (s *GroupLabelsService) GetGroupLabel(gid interface{}, labelID interface{},
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("groups/%s/labels/%s", PathEscape(group), label)
+	u := fmt.Sprintf("groups/%s/labels/%s", PathEscape(group), PathEscape(label))
 
 	req, err := s.client.NewRequest(http.MethodGet, u, nil, options)
 	if err != nil {
@@ -200,7 +200,7 @@ func (s *GroupLabelsService) SubscribeToGroupLabel(gid interface{}, labelID inte
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("groups/%s/labels/%s/subscribe", PathEscape(group), label)
+	u := fmt.Sprintf("groups/%s/labels/%s/subscribe", PathEscape(group), PathEscape(label))
 
 	req, err := s.client.NewRequest(http.MethodPost, u, nil, options)
 	if err != nil {
@@ -231,7 +231,7 @@ func (s *GroupLabelsService) UnsubscribeFromGroupLabel(gid interface{}, labelID 
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("groups/%s/labels/%s/unsubscribe", PathEscape(group), label)
+	u := fmt.Sprintf("groups/%s/labels/%s/unsubscribe", PathEscape(group), PathEscape(label))
 
 	req, err := s.client.NewRequest(http.MethodPost, u, nil, options)
 	if err != nil {

--- a/group_labels_test.go
+++ b/group_labels_test.go
@@ -30,11 +30,11 @@ func TestCreateGroupGroupLabel(t *testing.T) {
 
 	mux.HandleFunc("/api/v4/groups/1/labels", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
-		fmt.Fprint(w, `{"id":1, "name": "My GroupLabel", "color" : "#11FF22"}`)
+		fmt.Fprint(w, `{"id":1, "name": "My / GroupLabel", "color" : "#11FF22"}`)
 	})
 
 	l := &CreateGroupLabelOptions{
-		Name:  String("My GroupLabel"),
+		Name:  String("My / GroupLabel"),
 		Color: String("#11FF22"),
 	}
 	label, _, err := client.GroupLabels.CreateGroupLabel("1", l)
@@ -42,7 +42,7 @@ func TestCreateGroupGroupLabel(t *testing.T) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	want := &GroupLabel{ID: 1, Name: "My GroupLabel", Color: "#11FF22"}
+	want := &GroupLabel{ID: 1, Name: "My / GroupLabel", Color: "#11FF22"}
 	if !reflect.DeepEqual(want, label) {
 		t.Errorf("GroupLabels.CreateGroupLabel returned %+v, want %+v", label, want)
 	}
@@ -57,7 +57,7 @@ func TestDeleteGroupLabel(t *testing.T) {
 	})
 
 	label := &DeleteGroupLabelOptions{
-		Name: String("My GroupLabel"),
+		Name: String("My / GroupLabel"),
 	}
 
 	_, err := client.GroupLabels.DeleteGroupLabel("1", label)
@@ -72,12 +72,12 @@ func TestUpdateGroupLabel(t *testing.T) {
 
 	mux.HandleFunc("/api/v4/groups/1/labels", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
-		fmt.Fprint(w, `{"id":1, "name": "New GroupLabel", "color" : "#11FF23" , "description":"This is updated label"}`)
+		fmt.Fprint(w, `{"id":1, "name": "New / GroupLabel", "color" : "#11FF23" , "description":"This is updated label"}`)
 	})
 
 	l := &UpdateGroupLabelOptions{
-		Name:        String("My GroupLabel"),
-		NewName:     String("New GroupLabel"),
+		Name:        String("My / GroupLabel"),
+		NewName:     String("New / GroupLabel"),
 		Color:       String("#11FF23"),
 		Description: String("This is updated label"),
 	}
@@ -91,7 +91,7 @@ func TestUpdateGroupLabel(t *testing.T) {
 		log.Fatal(err)
 	}
 
-	want := &GroupLabel{ID: 1, Name: "New GroupLabel", Color: "#11FF23", Description: "This is updated label"}
+	want := &GroupLabel{ID: 1, Name: "New / GroupLabel", Color: "#11FF23", Description: "This is updated label"}
 
 	if !reflect.DeepEqual(want, label) {
 		t.Errorf("GroupLabels.UpdateGroupLabel returned %+v, want %+v", label, want)
@@ -104,14 +104,14 @@ func TestSubscribeToGroupLabel(t *testing.T) {
 
 	mux.HandleFunc("/api/v4/groups/1/labels/5/subscribe", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
-		fmt.Fprint(w, `{  "id" : 5, "name" : "bug", "color" : "#d9534f", "description": "Bug reported by user", "open_issues_count": 1, "closed_issues_count": 0, "open_merge_requests_count": 1, "subscribed": true,"priority": null}`)
+		fmt.Fprint(w, `{  "id" : 5, "name" : "kind/bug", "color" : "#d9534f", "description": "Bug reported by user", "open_issues_count": 1, "closed_issues_count": 0, "open_merge_requests_count": 1, "subscribed": true,"priority": null}`)
 	})
 
 	label, _, err := client.GroupLabels.SubscribeToGroupLabel("1", "5")
 	if err != nil {
 		log.Fatal(err)
 	}
-	want := &GroupLabel{ID: 5, Name: "bug", Color: "#d9534f", Description: "Bug reported by user", OpenIssuesCount: 1, ClosedIssuesCount: 0, OpenMergeRequestsCount: 1, Subscribed: true}
+	want := &GroupLabel{ID: 5, Name: "kind/bug", Color: "#d9534f", Description: "Bug reported by user", OpenIssuesCount: 1, ClosedIssuesCount: 0, OpenMergeRequestsCount: 1, Subscribed: true}
 	if !reflect.DeepEqual(want, label) {
 		t.Errorf("GroupLabels.SubscribeToGroupLabel returned %+v, want %+v", label, want)
 	}
@@ -137,7 +137,7 @@ func TestListGroupLabels(t *testing.T) {
 
 	mux.HandleFunc("/api/v4/groups/1/labels", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
-		fmt.Fprint(w, `[{  "id" : 5, "name" : "bug", "color" : "#d9534f", "description": "Bug reported by user", "open_issues_count": 1, "closed_issues_count": 0, "open_merge_requests_count": 1, "subscribed": true,"priority": null}]`)
+		fmt.Fprint(w, `[{  "id" : 5, "name" : "kind/bug", "color" : "#d9534f", "description": "Bug reported by user", "open_issues_count": 1, "closed_issues_count": 0, "open_merge_requests_count": 1, "subscribed": true,"priority": null}]`)
 	})
 
 	o := &ListGroupLabelsOptions{
@@ -148,7 +148,7 @@ func TestListGroupLabels(t *testing.T) {
 	if err != nil {
 		t.Log(err.Error() == "invalid ID type 1.1, the ID must be an int or a string")
 	}
-	want := []*GroupLabel{{ID: 5, Name: "bug", Color: "#d9534f", Description: "Bug reported by user", OpenIssuesCount: 1, ClosedIssuesCount: 0, OpenMergeRequestsCount: 1, Subscribed: true}}
+	want := []*GroupLabel{{ID: 5, Name: "kind/bug", Color: "#d9534f", Description: "Bug reported by user", OpenIssuesCount: 1, ClosedIssuesCount: 0, OpenMergeRequestsCount: 1, Subscribed: true}}
 	if !reflect.DeepEqual(want, label) {
 		t.Errorf("GroupLabels.ListGroupLabels returned %+v, want %+v", label, want)
 	}
@@ -160,7 +160,7 @@ func TestGetGroupLabel(t *testing.T) {
 
 	mux.HandleFunc("/api/v4/groups/1/labels/5", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
-		fmt.Fprint(w, `{  "id" : 5, "name" : "bug", "color" : "#d9534f", "description": "Bug reported by user", "open_issues_count": 1, "closed_issues_count": 0, "open_merge_requests_count": 1, "subscribed": true,"priority": null}`)
+		fmt.Fprint(w, `{  "id" : 5, "name" : "kind/bug", "color" : "#d9534f", "description": "Bug reported by user", "open_issues_count": 1, "closed_issues_count": 0, "open_merge_requests_count": 1, "subscribed": true,"priority": null}`)
 	})
 
 	label, _, err := client.GroupLabels.GetGroupLabel("1", 5)
@@ -168,7 +168,7 @@ func TestGetGroupLabel(t *testing.T) {
 		t.Log(err)
 	}
 
-	want := &GroupLabel{ID: 5, Name: "bug", Color: "#d9534f", Description: "Bug reported by user", OpenIssuesCount: 1, ClosedIssuesCount: 0, OpenMergeRequestsCount: 1, Subscribed: true}
+	want := &GroupLabel{ID: 5, Name: "kind/bug", Color: "#d9534f", Description: "Bug reported by user", OpenIssuesCount: 1, ClosedIssuesCount: 0, OpenMergeRequestsCount: 1, Subscribed: true}
 	if !reflect.DeepEqual(want, label) {
 		t.Errorf("GroupLabels.GetGroupLabel returned %+v, want %+v", label, want)
 	}

--- a/labels.go
+++ b/labels.go
@@ -117,7 +117,7 @@ func (s *LabelsService) GetLabel(pid interface{}, labelID interface{}, options .
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/labels/%s", PathEscape(project), label)
+	u := fmt.Sprintf("projects/%s/labels/%s", PathEscape(project), PathEscape(label))
 
 	req, err := s.client.NewRequest(http.MethodGet, u, nil, options)
 	if err != nil {
@@ -242,7 +242,7 @@ func (s *LabelsService) SubscribeToLabel(pid interface{}, labelID interface{}, o
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/labels/%s/subscribe", PathEscape(project), label)
+	u := fmt.Sprintf("projects/%s/labels/%s/subscribe", PathEscape(project), PathEscape(label))
 
 	req, err := s.client.NewRequest(http.MethodPost, u, nil, options)
 	if err != nil {
@@ -273,7 +273,7 @@ func (s *LabelsService) UnsubscribeFromLabel(pid interface{}, labelID interface{
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/labels/%s/unsubscribe", PathEscape(project), label)
+	u := fmt.Sprintf("projects/%s/labels/%s/unsubscribe", PathEscape(project), PathEscape(label))
 
 	req, err := s.client.NewRequest(http.MethodPost, u, nil, options)
 	if err != nil {
@@ -296,7 +296,7 @@ func (s *LabelsService) PromoteLabel(pid interface{}, labelID interface{}, optio
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/labels/%s/promote", PathEscape(project), label)
+	u := fmt.Sprintf("projects/%s/labels/%s/promote", PathEscape(project), PathEscape(label))
 
 	req, err := s.client.NewRequest(http.MethodPut, u, nil, options)
 	if err != nil {

--- a/labels_test.go
+++ b/labels_test.go
@@ -107,14 +107,14 @@ func TestSubscribeToLabel(t *testing.T) {
 
 	mux.HandleFunc("/api/v4/projects/1/labels/5/subscribe", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
-		fmt.Fprint(w, `{  "id" : 5, "name" : "bug", "color" : "#d9534f", "description": "Bug reported by user", "open_issues_count": 1, "closed_issues_count": 0, "open_merge_requests_count": 1, "subscribed": true,"priority": null}`)
+		fmt.Fprint(w, `{  "id" : 5, "name" : "kind/bug", "color" : "#d9534f", "description": "Bug reported by user", "open_issues_count": 1, "closed_issues_count": 0, "open_merge_requests_count": 1, "subscribed": true,"priority": null}`)
 	})
 
 	label, _, err := client.Labels.SubscribeToLabel("1", "5")
 	if err != nil {
 		log.Fatal(err)
 	}
-	want := &Label{ID: 5, Name: "bug", Color: "#d9534f", Description: "Bug reported by user", OpenIssuesCount: 1, ClosedIssuesCount: 0, OpenMergeRequestsCount: 1, Subscribed: true}
+	want := &Label{ID: 5, Name: "kind/bug", Color: "#d9534f", Description: "Bug reported by user", OpenIssuesCount: 1, ClosedIssuesCount: 0, OpenMergeRequestsCount: 1, Subscribed: true}
 	if !reflect.DeepEqual(want, label) {
 		t.Errorf("Labels.SubscribeToLabel returned %+v, want %+v", label, want)
 	}
@@ -140,7 +140,7 @@ func TestListLabels(t *testing.T) {
 
 	mux.HandleFunc("/api/v4/projects/1/labels", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
-		fmt.Fprint(w, `[{  "id" : 5, "name" : "bug", "color" : "#d9534f", "description": "Bug reported by user", "open_issues_count": 1, "closed_issues_count": 0, "open_merge_requests_count": 1, "subscribed": true,"priority": null}]`)
+		fmt.Fprint(w, `[{  "id" : 5, "name" : "kind/bug", "color" : "#d9534f", "description": "Bug reported by user", "open_issues_count": 1, "closed_issues_count": 0, "open_merge_requests_count": 1, "subscribed": true,"priority": null}]`)
 	})
 
 	o := &ListLabelsOptions{
@@ -153,7 +153,7 @@ func TestListLabels(t *testing.T) {
 	if err != nil {
 		t.Log(err.Error() == "invalid ID type 1.1, the ID must be an int or a string")
 	}
-	want := []*Label{{ID: 5, Name: "bug", Color: "#d9534f", Description: "Bug reported by user", OpenIssuesCount: 1, ClosedIssuesCount: 0, OpenMergeRequestsCount: 1, Subscribed: true}}
+	want := []*Label{{ID: 5, Name: "kind/bug", Color: "#d9534f", Description: "Bug reported by user", OpenIssuesCount: 1, ClosedIssuesCount: 0, OpenMergeRequestsCount: 1, Subscribed: true}}
 	if !reflect.DeepEqual(want, label) {
 		t.Errorf("Labels.ListLabels returned %+v, want %+v", label, want)
 	}
@@ -165,14 +165,14 @@ func TestGetLabel(t *testing.T) {
 
 	mux.HandleFunc("/api/v4/projects/1/labels/5", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
-		fmt.Fprint(w, `{  "id" : 5, "name" : "bug", "color" : "#d9534f", "description": "Bug reported by user", "open_issues_count": 1, "closed_issues_count": 0, "open_merge_requests_count": 1, "subscribed": true,"priority": null}`)
+		fmt.Fprint(w, `{  "id" : 5, "name" : "kind/bug", "color" : "#d9534f", "description": "Bug reported by user", "open_issues_count": 1, "closed_issues_count": 0, "open_merge_requests_count": 1, "subscribed": true,"priority": null}`)
 	})
 
 	label, _, err := client.Labels.GetLabel("1", 5)
 	if err != nil {
 		t.Log(err)
 	}
-	want := &Label{ID: 5, Name: "bug", Color: "#d9534f", Description: "Bug reported by user", OpenIssuesCount: 1, ClosedIssuesCount: 0, OpenMergeRequestsCount: 1, Subscribed: true}
+	want := &Label{ID: 5, Name: "kind/bug", Color: "#d9534f", Description: "Bug reported by user", OpenIssuesCount: 1, ClosedIssuesCount: 0, OpenMergeRequestsCount: 1, Subscribed: true}
 	if !reflect.DeepEqual(want, label) {
 		t.Errorf("Labels.GetLabel returned %+v, want %+v", label, want)
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Allows escaping special characters while operating *Labels* and *Group Labels*

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

I just changed the test scenarios to cover this special usage. 

I've been working with a pattern that prefixes a normal label with a "scope" but does not operate like a scoped label. This allows multiple labels within the same scope to be defined.

Example of MR labels:
- `domain/infra`
- `domain/backend`
- `environment::production`

This MR should fix and allow labels with slashes to work properly. 
