### PR TITLE
Add support for provisioned users API endpoint

### DIFF
--- a/groups.go
+++ b/groups.go
@@ -803,3 +803,39 @@ func (s *GroupsService) DeleteGroupPushRule(gid interface{}, options ...RequestO
 
 	return s.client.Do(req, nil)
 }
+
+type ListProvisionedUsersOptions struct {
+	ListOptions
+	Username             *string    `url:"username,omitempty" json:"username,omitempty"`
+	Search               *string    `url:"search,omitempty" json:"search,omitempty"`
+	Active               *bool `url:"active,omitempty" json:"active,omitempty"`
+	Blocked              *bool `url:"blocked,omitempty" json:"blocked,omitempty"`
+	CreatedAfter         *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
+	CreatedBefore        *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
+}
+
+// ListProvisionedUsers gets a list of users provisioned by the given group.
+// Requires at least the Maintainer role on the group.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/groups.html#provisioned-users-api
+func (s *GroupsService) ListProvisionedUsers(gid interface{}, opt *ListProvisionedUsersOptions, options ...RequestOptionFunc) ([]*User, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/provisioned_users", PathEscape(group))
+
+	req, err := s.client.NewRequest("GET", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var usr []*User
+	resp, err := s.client.Do(req, &usr)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return usr, resp, err
+}

--- a/groups.go
+++ b/groups.go
@@ -806,12 +806,12 @@ func (s *GroupsService) DeleteGroupPushRule(gid interface{}, options ...RequestO
 
 type ListProvisionedUsersOptions struct {
 	ListOptions
-	Username             *string    `url:"username,omitempty" json:"username,omitempty"`
-	Search               *string    `url:"search,omitempty" json:"search,omitempty"`
-	Active               *bool `url:"active,omitempty" json:"active,omitempty"`
-	Blocked              *bool `url:"blocked,omitempty" json:"blocked,omitempty"`
-	CreatedAfter         *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
-	CreatedBefore        *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
+	Username      *string    `url:"username,omitempty" json:"username,omitempty"`
+	Search        *string    `url:"search,omitempty" json:"search,omitempty"`
+	Active        *bool      `url:"active,omitempty" json:"active,omitempty"`
+	Blocked       *bool      `url:"blocked,omitempty" json:"blocked,omitempty"`
+	CreatedAfter  *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
+	CreatedBefore *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
 }
 
 // ListProvisionedUsers gets a list of users provisioned by the given group.
@@ -826,7 +826,7 @@ func (s *GroupsService) ListProvisionedUsers(gid interface{}, opt *ListProvision
 	}
 	u := fmt.Sprintf("groups/%s/provisioned_users", PathEscape(group))
 
-	req, err := s.client.NewRequest("GET", u, opt, options)
+	req, err := s.client.NewRequest(http.MethodGet, u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/groups.go
+++ b/groups.go
@@ -114,13 +114,124 @@ func (s *GroupsService) ListGroups(opt *ListGroupsOptions, options ...RequestOpt
 		return nil, nil, err
 	}
 
-	var g []*Group
-	resp, err := s.client.Do(req, &g)
+	var gs []*Group
+	resp, err := s.client.Do(req, &gs)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return g, resp, err
+	return gs, resp, err
+}
+
+// ListSubgroupsOptions represents the available ListSubgroups() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/groups.html#list-a-groups-s-subgroups
+type ListSubgroupsOptions ListGroupsOptions
+
+// ListSubgroups gets a list of subgroups for a given group.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/groups.html#list-a-groups-s-subgroups
+func (s *GroupsService) ListSubgroups(gid interface{}, opt *ListSubgroupsOptions, options ...RequestOptionFunc) ([]*Group, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/subgroups", PathEscape(group))
+
+	req, err := s.client.NewRequest(http.MethodGet, u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var gs []*Group
+	resp, err := s.client.Do(req, &gs)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return gs, resp, err
+}
+
+// ListDescendantGroupsOptions represents the available ListDescendantGroups()
+// options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/groups.html#list-a-groups-descendant-groups
+type ListDescendantGroupsOptions ListGroupsOptions
+
+// ListDescendantGroups gets a list of subgroups for a given project.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/groups.html#list-a-groups-descendant-groups
+func (s *GroupsService) ListDescendantGroups(gid interface{}, opt *ListDescendantGroupsOptions, options ...RequestOptionFunc) ([]*Group, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/descendant_groups", PathEscape(group))
+
+	req, err := s.client.NewRequest(http.MethodGet, u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var gs []*Group
+	resp, err := s.client.Do(req, &gs)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return gs, resp, err
+}
+
+// ListGroupProjectsOptions represents the available ListGroup() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/groups.html#list-a-group-39-s-projects
+type ListGroupProjectsOptions struct {
+	ListOptions
+	Archived                 *bool             `url:"archived,omitempty" json:"archived,omitempty"`
+	IncludeSubgroups         *bool             `url:"include_subgroups,omitempty" json:"include_subgroups,omitempty"`
+	MinAccessLevel           *AccessLevelValue `url:"min_access_level,omitempty" json:"min_access_level,omitempty"`
+	OrderBy                  *string           `url:"order_by,omitempty" json:"order_by,omitempty"`
+	Owned                    *bool             `url:"owned,omitempty" json:"owned,omitempty"`
+	Search                   *string           `url:"search,omitempty" json:"search,omitempty"`
+	Simple                   *bool             `url:"simple,omitempty" json:"simple,omitempty"`
+	Sort                     *string           `url:"sort,omitempty" json:"sort,omitempty"`
+	Starred                  *bool             `url:"starred,omitempty" json:"starred,omitempty"`
+	Visibility               *VisibilityValue  `url:"visibility,omitempty" json:"visibility,omitempty"`
+	WithCustomAttributes     *bool             `url:"with_custom_attributes,omitempty" json:"with_custom_attributes,omitempty"`
+	WithIssuesEnabled        *bool             `url:"with_issues_enabled,omitempty" json:"with_issues_enabled,omitempty"`
+	WithMergeRequestsEnabled *bool             `url:"with_merge_requests_enabled,omitempty" json:"with_merge_requests_enabled,omitempty"`
+	WithSecurityReports      *bool             `url:"with_security_reports,omitempty" json:"with_security_reports,omitempty"`
+	WithShared               *bool             `url:"with_shared,omitempty" json:"with_shared,omitempty"`
+}
+
+// ListGroupProjects get a list of group projects
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/groups.html#list-a-group-39-s-projects
+func (s *GroupsService) ListGroupProjects(gid interface{}, opt *ListGroupProjectsOptions, options ...RequestOptionFunc) ([]*Project, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/projects", PathEscape(group))
+
+	req, err := s.client.NewRequest(http.MethodGet, u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var ps []*Project
+	resp, err := s.client.Do(req, &ps)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return ps, resp, err
 }
 
 // GetGroupOptions represents the available GetGroup() options.
@@ -340,124 +451,53 @@ func (s *GroupsService) SearchGroup(query string, options ...RequestOptionFunc) 
 		return nil, nil, err
 	}
 
-	var g []*Group
-	resp, err := s.client.Do(req, &g)
+	var gs []*Group
+	resp, err := s.client.Do(req, &gs)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return g, resp, err
+	return gs, resp, err
 }
 
-// ListGroupProjectsOptions represents the available ListGroup() options.
-//
-// GitLab API docs:
-// https://docs.gitlab.com/ce/api/groups.html#list-a-group-39-s-projects
-type ListGroupProjectsOptions struct {
-	ListOptions
-	Archived                 *bool             `url:"archived,omitempty" json:"archived,omitempty"`
-	IncludeSubgroups         *bool             `url:"include_subgroups,omitempty" json:"include_subgroups,omitempty"`
-	MinAccessLevel           *AccessLevelValue `url:"min_access_level,omitempty" json:"min_access_level,omitempty"`
-	OrderBy                  *string           `url:"order_by,omitempty" json:"order_by,omitempty"`
-	Owned                    *bool             `url:"owned,omitempty" json:"owned,omitempty"`
-	Search                   *string           `url:"search,omitempty" json:"search,omitempty"`
-	Simple                   *bool             `url:"simple,omitempty" json:"simple,omitempty"`
-	Sort                     *string           `url:"sort,omitempty" json:"sort,omitempty"`
-	Starred                  *bool             `url:"starred,omitempty" json:"starred,omitempty"`
-	Visibility               *VisibilityValue  `url:"visibility,omitempty" json:"visibility,omitempty"`
-	WithCustomAttributes     *bool             `url:"with_custom_attributes,omitempty" json:"with_custom_attributes,omitempty"`
-	WithIssuesEnabled        *bool             `url:"with_issues_enabled,omitempty" json:"with_issues_enabled,omitempty"`
-	WithMergeRequestsEnabled *bool             `url:"with_merge_requests_enabled,omitempty" json:"with_merge_requests_enabled,omitempty"`
-	WithSecurityReports      *bool             `url:"with_security_reports,omitempty" json:"with_security_reports,omitempty"`
-	WithShared               *bool             `url:"with_shared,omitempty" json:"with_shared,omitempty"`
-}
-
-// ListGroupProjects get a list of group projects
-//
-// GitLab API docs:
-// https://docs.gitlab.com/ce/api/groups.html#list-a-group-39-s-projects
-func (s *GroupsService) ListGroupProjects(gid interface{}, opt *ListGroupProjectsOptions, options ...RequestOptionFunc) ([]*Project, *Response, error) {
-	group, err := parseID(gid)
-	if err != nil {
-		return nil, nil, err
-	}
-	u := fmt.Sprintf("groups/%s/projects", PathEscape(group))
-
-	req, err := s.client.NewRequest(http.MethodGet, u, opt, options)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	var p []*Project
-	resp, err := s.client.Do(req, &p)
-	if err != nil {
-		return nil, resp, err
-	}
-
-	return p, resp, err
-}
-
-// ListSubgroupsOptions represents the available ListSubgroups() options.
-//
-// GitLab API docs:
-// https://docs.gitlab.com/ce/api/groups.html#list-a-groups-s-subgroups
-type ListSubgroupsOptions ListGroupsOptions
-
-// ListSubgroups gets a list of subgroups for a given group.
-//
-// GitLab API docs:
-// https://docs.gitlab.com/ce/api/groups.html#list-a-groups-s-subgroups
-func (s *GroupsService) ListSubgroups(gid interface{}, opt *ListSubgroupsOptions, options ...RequestOptionFunc) ([]*Group, *Response, error) {
-	group, err := parseID(gid)
-	if err != nil {
-		return nil, nil, err
-	}
-	u := fmt.Sprintf("groups/%s/subgroups", PathEscape(group))
-
-	req, err := s.client.NewRequest(http.MethodGet, u, opt, options)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	var g []*Group
-	resp, err := s.client.Do(req, &g)
-	if err != nil {
-		return nil, resp, err
-	}
-
-	return g, resp, err
-}
-
-// ListDescendantGroupsOptions represents the available ListDescendantGroups()
+// ListProvisionedUsersOptions represents the available ListProvisionedUsers()
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/groups.html#list-a-groups-descendant-groups
-type ListDescendantGroupsOptions ListGroupsOptions
+// https://docs.gitlab.com/ee/api/groups.html#provisioned-users-api
+type ListProvisionedUsersOptions struct {
+	ListOptions
+	Username      *string    `url:"username,omitempty" json:"username,omitempty"`
+	Search        *string    `url:"search,omitempty" json:"search,omitempty"`
+	Active        *bool      `url:"active,omitempty" json:"active,omitempty"`
+	Blocked       *bool      `url:"blocked,omitempty" json:"blocked,omitempty"`
+	CreatedAfter  *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
+	CreatedBefore *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
+}
 
-// ListDescendantGroups gets a list of subgroups for a given project.
+// ListProvisionedUsers gets a list of users provisioned by the given group.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/groups.html#list-a-groups-descendant-groups
-func (s *GroupsService) ListDescendantGroups(gid interface{}, opt *ListDescendantGroupsOptions, options ...RequestOptionFunc) ([]*Group, *Response, error) {
+// https://docs.gitlab.com/ee/api/groups.html#provisioned-users-api
+func (s *GroupsService) ListProvisionedUsers(gid interface{}, opt *ListProvisionedUsersOptions, options ...RequestOptionFunc) ([]*User, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("groups/%s/descendant_groups", PathEscape(group))
+	u := fmt.Sprintf("groups/%s/provisioned_users", PathEscape(group))
 
 	req, err := s.client.NewRequest(http.MethodGet, u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	var g []*Group
-	resp, err := s.client.Do(req, &g)
+	var us []*User
+	resp, err := s.client.Do(req, &us)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return g, resp, err
+	return us, resp, err
 }
 
 // ListGroupLDAPLinks lists the group's LDAP links. Available only for users who
@@ -477,13 +517,13 @@ func (s *GroupsService) ListGroupLDAPLinks(gid interface{}, options ...RequestOp
 		return nil, nil, err
 	}
 
-	var gl []*LDAPGroupLink
-	resp, err := s.client.Do(req, &gl)
+	var gls []*LDAPGroupLink
+	resp, err := s.client.Do(req, &gls)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return gl, resp, nil
+	return gls, resp, nil
 }
 
 // AddGroupLDAPLinkOptions represents the available AddGroupLDAPLink() options.
@@ -802,40 +842,4 @@ func (s *GroupsService) DeleteGroupPushRule(gid interface{}, options ...RequestO
 	}
 
 	return s.client.Do(req, nil)
-}
-
-type ListProvisionedUsersOptions struct {
-	ListOptions
-	Username      *string    `url:"username,omitempty" json:"username,omitempty"`
-	Search        *string    `url:"search,omitempty" json:"search,omitempty"`
-	Active        *bool      `url:"active,omitempty" json:"active,omitempty"`
-	Blocked       *bool      `url:"blocked,omitempty" json:"blocked,omitempty"`
-	CreatedAfter  *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
-	CreatedBefore *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
-}
-
-// ListProvisionedUsers gets a list of users provisioned by the given group.
-// Requires at least the Maintainer role on the group.
-//
-// GitLab API docs:
-// https://docs.gitlab.com/ee/api/groups.html#provisioned-users-api
-func (s *GroupsService) ListProvisionedUsers(gid interface{}, opt *ListProvisionedUsersOptions, options ...RequestOptionFunc) ([]*User, *Response, error) {
-	group, err := parseID(gid)
-	if err != nil {
-		return nil, nil, err
-	}
-	u := fmt.Sprintf("groups/%s/provisioned_users", PathEscape(group))
-
-	req, err := s.client.NewRequest(http.MethodGet, u, opt, options)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	var usr []*User
-	resp, err := s.client.Do(req, &usr)
-	if err != nil {
-		return nil, resp, err
-	}
-
-	return usr, resp, err
 }


### PR DESCRIPTION
[In 14.8, GitLab added](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/79600/) a new provisioned users API endpoint. The new endpoint allows group maintainers to list [users provisioned by a group](https://docs.gitlab.com/ee/user/group/saml_sso/scim_setup.html). 

[Provisioned users API documentation](https://docs.gitlab.com/ee/api/groups.html#provisioned-users-api)