### PR TITLE
expose retryablehttp Response/Request Hooks

### DIFF
--- a/client_options.go
+++ b/client_options.go
@@ -90,3 +90,19 @@ func WithoutRetries() ClientOptionFunc {
 		return nil
 	}
 }
+
+// WithRequestLogHook uses the specified RequestLogHook on all requests
+func WithRequestLogHook(hook retryablehttp.RequestLogHook) ClientOptionFunc {
+	return func(c *Client) error {
+		c.client.RequestLogHook = hook
+		return nil
+	}
+}
+
+// WithResponseLogHook uses the specified ResponseLogHook on all responses
+func WithResponseLogHook(hook retryablehttp.ResponseLogHook) ClientOptionFunc {
+	return func(c *Client) error {
+		c.client.ResponseLogHook = hook
+		return nil
+	}
+}


### PR DESCRIPTION
This exposes the `retryablehttp` Response and Request Log hooks. It allows a consumer to use these hooks to pull loggers out of context and log contextual information.

closes https://github.com/xanzy/go-gitlab/issues/1362