### PR TITLE
Add build timeout field to project response

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -127,6 +127,7 @@ type Project struct {
 	CustomAttributes             []*CustomAttribute `json:"custom_attributes"`
 	ComplianceFrameworks         []string           `json:"compliance_frameworks"`
 	BuildCoverageRegex           string             `json:"build_coverage_regex"`
+	BuildTimeout                 int                `json:"build_timeout"`
 	IssuesTemplate               string             `json:"issues_template"`
 	MergeRequestsTemplate        string             `json:"merge_requests_template"`
 	KeepLatestArtifact           bool               `json:"keep_latest_artifact"`


### PR DESCRIPTION
Though not mentioned in the [GitLab Projects API docs](https://docs.gitlab.com/ee/api/projects.html#get-single-project), the `build_timeout` field is included in the GitLab API response (tested with GitLab Enterprise Edition 14.5.2). Would be great to have it supported here.