### PR TITLE
Add missing fork projects options

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -909,9 +909,16 @@ func (s *ProjectsService) EditProject(pid interface{}, opt *EditProjectOptions, 
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#fork-project
 type ForkProjectOptions struct {
-	Name      *string `url:"name,omitempty" json:"name,omitempty" `
+	Description                   *string          `url:"description,omitempty" json:"description,omitempty"`
+	MergeRequestDefaultTargetSelf *bool            `url:"mr_default_target_self,omitempty" json:"mr_default_target_self,omitempty"`
+	Name                          *string          `url:"name,omitempty" json:"name,omitempty"`
+	NamespaceID                   *int             `url:"namespace_id,omitempty" json:"namespace_id,omitempty"`
+	NamespacePath                 *string          `url:"namespace_path,omitempty" json:"namespace_path,omitempty"`
+	Path                          *string          `url:"path,omitempty" json:"path,omitempty"`
+	Visibility                    *VisibilityValue `url:"visibility,omitempty" json:"visibility,omitempty"`
+
+	// Deprecated members
 	Namespace *string `url:"namespace,omitempty" json:"namespace,omitempty"`
-	Path      *string `url:"path,omitempty" json:"path,omitempty"`
 }
 
 // ForkProject forks a project into the user namespace of the authenticated

--- a/projects_test.go
+++ b/projects_test.go
@@ -751,20 +751,20 @@ func TestForkProject(t *testing.T) {
 	mux, server, client := setup(t)
 	defer teardown(server)
 
-	namespace := "mynamespace"
+	namespaceID := 42
 	name := "myreponame"
 	path := "myrepopath"
 
 	mux.HandleFunc("/api/v4/projects/1/fork", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
-		testBody(t, r, fmt.Sprintf(`{"name":"%s","namespace":"%s","path":"%s"}`, name, namespace, path))
+		testBody(t, r, fmt.Sprintf(`{"name":"%s","namespace_id":%d,"path":"%s"}`, name, namespaceID, path))
 		fmt.Fprint(w, `{"id":2}`)
 	})
 
 	project, _, err := client.Projects.ForkProject(1, &ForkProjectOptions{
-		Namespace: String(namespace),
-		Name:      String(name),
-		Path:      String(path),
+		NamespaceID: Int(namespaceID),
+		Name:        String(name),
+		Path:        String(path),
 	})
 	if err != nil {
 		t.Errorf("Projects.ForkProject returned error: %v", err)


### PR DESCRIPTION
The Gitlab API offers more options when forking, see
https://docs.gitlab.com/ee/api/projects.html#fork-project

Let's add them for completeness, also deprecate `Namespace`