### PR TITLE
fix incomplete push, push_tag and repositry_update system hooks

### DIFF
--- a/event_systemhook_types.go
+++ b/event_systemhook_types.go
@@ -147,8 +147,8 @@ type PushSystemEvent struct {
 		Description       string `json:"description"`
 		WebURL            string `json:"web_url"`
 		AvatarURL         string `json:"avatar_url"`
-		GitHttpURL        string `json:"git_http_url"`
-		GitSshURL         string `json:"git_ssh_url"`
+		GitHTTPURL        string `json:"git_http_url"`
+		GitSSHURL         string `json:"git_ssh_url"`
 		Namespace         string `json:"namespace"`
 		VisibilityLevel   int    `json:"visibility_level"`
 		PathWithNamespace string `json:"path_with_namespace"`
@@ -157,10 +157,10 @@ type PushSystemEvent struct {
 		URL               string `json:"url"`
 	} `json:"project"`
 	Commits []struct {
-		ID        string `json:"id"`
-		Message   string `json:"message"`
+		ID        string    `json:"id"`
+		Message   string    `json:"message"`
 		Timestamp time.Time `json:"timestamp"`
-		URL       string `json:"url"`
+		URL       string    `json:"url"`
 		Author    struct {
 			Name  string `json:"name"`
 			Email string `json:"email"`
@@ -190,8 +190,8 @@ type TagPushSystemEvent struct {
 		Description       string `json:"description"`
 		WebURL            string `json:"web_url"`
 		AvatarURL         string `json:"avatar_url"`
-		GitHttpURL        string `json:"git_http_url"`
-		GitSshURL         string `json:"git_ssh_url"`
+		GitHTTPURL        string `json:"git_http_url"`
+		GitSSHURL         string `json:"git_ssh_url"`
 		Namespace         string `json:"namespace"`
 		VisibilityLevel   int    `json:"visibility_level"`
 		PathWithNamespace string `json:"path_with_namespace"`
@@ -200,10 +200,10 @@ type TagPushSystemEvent struct {
 		URL               string `json:"url"`
 	} `json:"project"`
 	Commits []struct {
-		ID        string `json:"id"`
-		Message   string `json:"message"`
+		ID        string    `json:"id"`
+		Message   string    `json:"message"`
 		Timestamp time.Time `json:"timestamp"`
-		URL       string `json:"url"`
+		URL       string    `json:"url"`
 		Author    struct {
 			Name  string `json:"name"`
 			Email string `json:"email"`
@@ -229,8 +229,8 @@ type RepositoryUpdateSystemEvent struct {
 		Description       string `json:"description"`
 		WebURL            string `json:"web_url"`
 		AvatarURL         string `json:"avatar_url"`
-		GitSshURL         string `json:"git_ssh_url"`
-		GitHttpURL        string `json:"git_http_url"`
+		GitHTTPURL        string `json:"git_http_url"`
+		GitSSHURL         string `json:"git_ssh_url"`
 		Namespace         string `json:"namespace"`
 		VisibilityLevel   int    `json:"visibility_level"`
 		PathWithNamespace string `json:"path_with_namespace"`

--- a/event_systemhook_types.go
+++ b/event_systemhook_types.go
@@ -16,6 +16,8 @@
 
 package gitlab
 
+import "time"
+
 // systemHookEvent is used to pre-process events to determine the
 // system hook event type.
 type systemHookEvent struct {
@@ -130,6 +132,41 @@ type UserTeamSystemEvent struct {
 // https://docs.gitlab.com/ee/system_hooks/system_hooks.html
 type PushSystemEvent struct {
 	BaseSystemEvent
+	Before       string `json:"before"`
+	After        string `json:"after"`
+	Ref          string `json:"ref"`
+	CheckoutSHA  string `json:"checkout_sha"`
+	UserID       int    `json:"user_id"`
+	UserName     string `json:"user_name"`
+	UserUsername string `json:"user_username"`
+	UserEmail    string `json:"user_email"`
+	UserAvatar   string `json:"user_avatar"`
+	ProjectID    int    `json:"project_id"`
+	Project      struct {
+		Name              string `json:"name"`
+		Description       string `json:"description"`
+		WebURL            string `json:"web_url"`
+		AvatarURL         string `json:"avatar_url"`
+		GitHttpURL        string `json:"git_http_url"`
+		GitSshURL         string `json:"git_ssh_url"`
+		Namespace         string `json:"namespace"`
+		VisibilityLevel   int    `json:"visibility_level"`
+		PathWithNamespace string `json:"path_with_namespace"`
+		DefaultBranch     string `json:"default_branch"`
+		Homepage          string `json:"homepage"`
+		URL               string `json:"url"`
+	} `json:"project"`
+	Commits []struct {
+		ID        string `json:"id"`
+		Message   string `json:"message"`
+		Timestamp time.Time `json:"timestamp"`
+		URL       string `json:"url"`
+		Author    struct {
+			Name  string `json:"name"`
+			Email string `json:"email"`
+		} `json:"author"`
+	} `json:"commits"`
+	TotalCommitsCount int `json:"total_commits_count"`
 }
 
 // TagPushSystemEvent represents a tag push system event.
@@ -138,6 +175,41 @@ type PushSystemEvent struct {
 // https://docs.gitlab.com/ee/system_hooks/system_hooks.html
 type TagPushSystemEvent struct {
 	BaseSystemEvent
+	Before       string `json:"before"`
+	After        string `json:"after"`
+	Ref          string `json:"ref"`
+	CheckoutSHA  string `json:"checkout_sha"`
+	UserID       int    `json:"user_id"`
+	UserName     string `json:"user_name"`
+	UserUsername string `json:"user_username"`
+	UserEmail    string `json:"user_email"`
+	UserAvatar   string `json:"user_avatar"`
+	ProjectID    int    `json:"project_id"`
+	Project      struct {
+		Name              string `json:"name"`
+		Description       string `json:"description"`
+		WebURL            string `json:"web_url"`
+		AvatarURL         string `json:"avatar_url"`
+		GitHttpURL        string `json:"git_http_url"`
+		GitSshURL         string `json:"git_ssh_url"`
+		Namespace         string `json:"namespace"`
+		VisibilityLevel   int    `json:"visibility_level"`
+		PathWithNamespace string `json:"path_with_namespace"`
+		DefaultBranch     string `json:"default_branch"`
+		Homepage          string `json:"homepage"`
+		URL               string `json:"url"`
+	} `json:"project"`
+	Commits []struct {
+		ID        string `json:"id"`
+		Message   string `json:"message"`
+		Timestamp time.Time `json:"timestamp"`
+		URL       string `json:"url"`
+		Author    struct {
+			Name  string `json:"name"`
+			Email string `json:"email"`
+		} `json:"author"`
+	} `json:"commits"`
+	TotalCommitsCount int `json:"total_commits_count"`
 }
 
 // RepositoryUpdateSystemEvent represents a repository updated system event.
@@ -146,4 +218,31 @@ type TagPushSystemEvent struct {
 // https://docs.gitlab.com/ee/system_hooks/system_hooks.html
 type RepositoryUpdateSystemEvent struct {
 	BaseSystemEvent
+	UserID     int    `json:"user_id"`
+	UserName   string `json:"user_name"`
+	UserEmail  string `json:"user_email"`
+	UserAvatar string `json:"user_avatar"`
+	ProjectID  int    `json:"project_id"`
+	Project    struct {
+		ID                int    `json:"id"`
+		Name              string `json:"name"`
+		Description       string `json:"description"`
+		WebURL            string `json:"web_url"`
+		AvatarURL         string `json:"avatar_url"`
+		GitSshURL         string `json:"git_ssh_url"`
+		GitHttpURL        string `json:"git_http_url"`
+		Namespace         string `json:"namespace"`
+		VisibilityLevel   int    `json:"visibility_level"`
+		PathWithNamespace string `json:"path_with_namespace"`
+		DefaultBranch     string `json:"default_branch"`
+		CiConfigPath      string `json:"ci_config_path"`
+		Homepage          string `json:"homepage"`
+		URL               string `json:"url"`
+	} `json:"project"`
+	Changes []struct {
+		Before string `json:"before"`
+		After  string `json:"after"`
+		Ref    string `json:"ref"`
+	} `json:"changes"`
+	Refs []string `json:"refs"`
 }


### PR DESCRIPTION
The structs for the system hooks `push`, `tag_push` and
`repository_update` were left empty. This commit adds all the fields
from the documentation here:
https://docs.gitlab.com/ee/system_hooks/system_hooks.html#create-a-system-hook
except for some of them that appear to be redundant (like `repostory`
that looks like it's a subset of `project`).