### PR TITLE
Implement topic delete API

### DIFF
--- a/topics.go
+++ b/topics.go
@@ -155,7 +155,7 @@ func (s *TopicsService) UpdateTopic(topic int, opt *UpdateTopicOptions, options 
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/topics.html#delete-a-project-topic
-func (s *TopicsService) DeleteTopic(topic int, ...RequestOptionFunc) (*Response, error) {
+func (s *TopicsService) DeleteTopic(topic int, options ...RequestOptionFunc) (*Response, error) {
 	u := fmt.Sprintf("topics/%d", topic)
 
 	req, err := s.client.NewRequest(http.MethodDelete, u, nil, options)

--- a/topics.go
+++ b/topics.go
@@ -150,3 +150,18 @@ func (s *TopicsService) UpdateTopic(topic int, opt *UpdateTopicOptions, options 
 
 	return t, resp, err
 }
+
+// DeleteTopic deletes a project topic. Only available to administrators.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/topics.html#delete-a-project-topic
+func (s *TopicsService) DeleteTopic(topic int, ...RequestOptionFunc) (*Response, error) {
+	u := fmt.Sprintf("topics/%d", topic)
+
+	req, err := s.client.NewRequest(http.MethodDelete, u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}


### PR DESCRIPTION
I have recently implemented this in GitLab:
https://gitlab.com/gitlab-org/gitlab/-/merge_requests/80725
https://docs.gitlab.com/ee/api/topics.html#delete-a-project-topic

Would be nice to have this in the client here so that eventually we can have in
the terraform provider :)