### PR TITLE
Implement first draft of Acceptance Tests

### DIFF
--- a/.github/workflows/acceptance-tests-ce.yml
+++ b/.github/workflows/acceptance-tests-ce.yml
@@ -1,0 +1,50 @@
+# This workflow runs acceptance tests on pull requests (CE)
+
+name: acceptance-tests-ce
+
+on:
+  push: {}
+  pull_request:
+    # Acceptance tests are unnecessary to run on some types of PRs.
+    paths-ignore:
+      - 'examples/**'
+      - '*.md'
+  # The workflow_dispatch event type is for manual workflow execution.
+  workflow_dispatch: {}
+  # In addition to pushes, run the workflow weekly to detect issues with the latest GitLab version.
+  schedule:
+    #         ┌───────────── minute (0 - 59)
+    #         │ ┌───────────── hour (0 - 23)
+    #         │ │ ┌───────────── day of the month (1 - 31)
+    #         │ │ │ ┌───────────── month (1 - 12 or JAN-DEC)
+    #         │ │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
+    #         * * * * *
+    - cron:  '0 0 * * 3'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  acceptance-ce:
+    name: Acceptance Tests
+    strategy:
+      matrix:
+        go-version: [1.x]
+        platform: [ubuntu-latest]
+    runs-on: ${{ matrix.platform }}
+    timeout-minutes: 60
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Start GitLab CE instance
+        run: make testacc-up
+
+      - name: Run Acceptance Tests
+        run: make testacc

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -27,5 +27,5 @@ jobs:
         with:
           version: latest
 
-      - name: Test package
-        run: go test -v ./...
+      - name: Unit Test package
+        run: go test -v .

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contributing to go-gitlab
+
+First of all, thanks for considering to contribute to the [go-gitlab library](https://github.com/xanzy/go-gitlab) :tada:.
+
+## Repository Structure
+
+This library aims to provide a go client providing a 1:1 mapping to the [GitLab REST API](https://docs.gitlab.com/ee/api/).
+Every REST API resource has it's own Go file with an associated `_test.go` file. Acceptance Tests are located in the `acc/`
+directory. When implementing a new endpoint, please inspire yourself with an already existing one.
+
+## Unit Tests
+
+Unit Tests are implemented in the corresponding `_test.go` file located in the root of the project.
+They can be run using `go test -v .` or `make test`.
+
+## Acceptance Tests
+
+The Acceptance Tests run against a real GitLab instance. At the moment only a GitLab CE instance is supported in the pipeline,
+but given a license key you can easily run the test suite against an EE instance.
+
+To start a GitLab CE instance you can use `make testacc-up`. It requires `docker-compose`.
+Once an instance is running you can run the test suite with `make testacc`.
+The instance can be destroyed using `make testacc-down`.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+.PHONY: build test testacc-up testacc-down testacc
+
+all: build test
+
+build:
+	go mod tidy
+	go install
+
+test: ## Run unit tests.
+	go test $(TESTARGS) -v .
+
+SERVICE ?= gitlab-ce
+GITLAB_TOKEN ?= ACCTEST1234567890123
+GITLAB_BASE_URL ?= http://127.0.0.1:8080/api/v4
+ACC_TEST_DIR ?= ./acc
+
+testacc-up:
+	docker-compose up -d $(SERVICE)
+	./scripts/await-healthy.sh
+
+testacc-down:
+	docker-compose down
+
+testacc:
+	TF_ACC=1 GITLAB_TOKEN=$(GITLAB_TOKEN) GITLAB_BASE_URL=$(GITLAB_BASE_URL) go test -v $(ACC_TEST_DIR) $(TESTARGS) -timeout 40m

--- a/acc/acc.go
+++ b/acc/acc.go
@@ -1,0 +1,41 @@
+package acc
+
+import (
+	"os"
+	"testing"
+	"math/rand"
+	"time"
+
+	"github.com/xanzy/go-gitlab"
+)
+
+type Config struct {
+	BaseURL string
+	Token string
+}
+
+func setup(t *testing.T) (*gitlab.Client, Config) {
+	config := newConfig()
+	client := newTestClient(t, config)
+	return client, config
+}
+
+func newConfig() Config {
+	baseURL := os.Getenv("GITLAB_BASE_URL")
+	token := os.Getenv("GITLAB_TOKEN")
+
+	config := Config{BaseURL: baseURL, Token: token}
+	return config
+}
+
+func newTestClient(t *testing.T, config Config) *gitlab.Client {
+	client, err := gitlab.NewOAuthClient(config.Token, gitlab.WithBaseURL(config.BaseURL))
+	if err != nil {
+		t.Errorf("failed to instantiate new GitLab OAuth client: %v", err)
+	}
+	return client
+}
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}

--- a/acc/auth_test.go
+++ b/acc/auth_test.go
@@ -1,0 +1,15 @@
+package acc
+
+import (
+	"testing"
+)
+
+
+func TestGitlabAuth_withAccessToken(t *testing.T) {
+	client, _ := setup(t)
+
+	_, _, err := client.Users.CurrentUser()
+	if err != nil {
+		t.Errorf("failed to query current user, something went wrong with the client instantition: %v", err)
+	}
+}

--- a/acc/topic_test.go
+++ b/acc/topic_test.go
@@ -1,0 +1,46 @@
+package acc
+
+import (
+	"fmt"
+	"testing"
+	"math/rand"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/xanzy/go-gitlab"
+)
+
+
+func TestGitlabTopic_basic(t *testing.T) {
+	client, _ := setup(t)
+	testID := rand.Int()
+	testTopicName := fmt.Sprintf("test-topic-%d", testID)
+
+	// we can successfully get all topics
+	_, _, err := client.Topics.ListTopics(&gitlab.ListTopicsOptions{})
+	require.NoError(t, err)
+
+	// we can create a topic
+	topic, _, err := client.Topics.CreateTopic(&gitlab.CreateTopicOptions{Name: gitlab.String(testTopicName), Description: gitlab.String("Acceptance Test Topic")}, nil)
+	require.NoError(t, err)
+
+	// FIXME: topic's cannot yet be deleted, ...
+	// make sure that the topic is deleted afterwards
+	// defer func(topicID int) {
+	// 	_, err = client.Topics.DeleteTopic(topicID)
+	// 	require.NoError(t, err)
+	// }(topic.ID)
+
+	require.Equal(t, testTopicName, topic.Name)
+	require.Equal(t, "Acceptance Test Topic", topic.Description)
+
+	// we can query the topic
+	gotTopic, _ ,err := client.Topics.GetTopic(topic.ID, nil)
+	require.NoError(t, err)
+	require.Equal(t, topic, gotTopic)
+
+	// we see the topic in the list of topics
+	topics, _, err := client.Topics.ListTopics(&gitlab.ListTopicsOptions{Search: gitlab.String(testTopicName)})
+	require.NoError(t, err)
+	require.Contains(t, topics, topic)
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,52 @@
+version: '3'
+
+# Acceptance tests depend on a running GitLab instance.
+# Only one of these services should be run at a time.
+services:
+  gitlab-ce:
+    image: gitlab/gitlab-ce
+    restart: always
+    ports:
+      - 8080:80
+    environment:
+      GITLAB_ROOT_PASSWORD: adminadmin
+    labels:
+      terraform-provider-gitlab/owned: ''
+    volumes:
+      - config-ce:/etc/gitlab
+      - logs-ce:/var/log/gitlab
+      - data-ce:/var/opt/gitlab
+      - ${PWD}/scripts/healthcheck-and-setup.sh:/healthcheck-and-setup.sh
+    healthcheck:
+      test: /healthcheck-and-setup.sh
+      interval: 10s
+      timeout: 2m
+
+  gitlab-ee:
+    image: gitlab/gitlab-ee
+    restart: always
+    ports:
+      - 8080:80
+    environment:
+      GITLAB_ROOT_PASSWORD: adminadmin
+      GITLAB_LICENSE_FILE: /Gitlab-license.txt
+    labels:
+      terraform-provider-gitlab/owned: ''
+    volumes:
+      - config-ee:/etc/gitlab
+      - logs-ee:/var/log/gitlab
+      - data-ee:/var/opt/gitlab
+      - ${PWD}/scripts/healthcheck-and-setup.sh:/healthcheck-and-setup.sh
+      - ${PWD}/Gitlab-license.txt:/Gitlab-license.txt
+    healthcheck:
+      test: /healthcheck-and-setup.sh
+      interval: 10s
+      timeout: 2m
+
+volumes:
+  config-ce:
+  logs-ce:
+  data-ce:
+  config-ee:
+  logs-ee:
+  data-ee:

--- a/scripts/await-healthy.sh
+++ b/scripts/await-healthy.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+
+printf 'Waiting for GitLab container to become healthy'
+
+until test -n "$(docker ps --quiet --filter label=terraform-provider-gitlab/owned --filter health=healthy)"; do
+  printf '.'
+  sleep 5
+done
+
+echo
+echo 'GitLab is healthy'
+
+# Print the version, since it is useful debugging information.
+curl --silent --show-error --header 'Authorization: Bearer ACCTEST1234567890123' http://127.0.0.1:8080/api/v4/version
+echo

--- a/scripts/healthcheck-and-setup.sh
+++ b/scripts/healthcheck-and-setup.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env sh
+
+# This script is intended to be used as a Docker HEALTHCHECK for the GitLab container.
+# It prepares GitLab prior to running acceptance tests.
+#
+# This is a known workaround for docker-compose lacking lifecycle hooks.
+# See: https://github.com/docker/compose/issues/1809#issuecomment-657815188
+
+set -e
+
+# Check for a successful HTTP status code from GitLab.
+curl --silent --show-error --fail --output /dev/null 127.0.0.1:80
+
+# Because this script runs on a regular health check interval,
+# this file functions as a marker that tells us if initialization already finished.
+done=/var/gitlab-acctest-initialized
+
+test -f $done || {
+  echo 'Initializing GitLab for acceptance tests'
+
+  echo 'Creating access token'
+  (
+    printf 'terraform_token = PersonalAccessToken.create('
+    printf 'user_id: 1, '
+    printf 'scopes: [:api, :read_user], '
+    printf 'name: :terraform);'
+    printf "terraform_token.set_token('ACCTEST1234567890123');"
+    printf 'terraform_token.save!;'
+  ) | gitlab-rails console
+
+  # 2020-09-07: Currently Gitlab (version 13.3.6 ) doesn't allow in admin API
+  # ability to set a group as instance level templates.
+  # To test resource_gitlab_project_test template features we add
+  # group, project myrails and admin settings directly in scripts/start-gitlab.sh
+  # Once Gitlab add admin template in API we could manage group/project/settings
+  # directly in tests like TestAccGitlabProject_basic.
+  # Works on CE too
+
+  echo 'Creating an instance level template group with a simple template based on rails'
+  (
+    printf 'group_template = Group.new('
+    printf 'name: :terraform, '
+    printf 'path: :terraform);'
+    printf 'group_template.save!;'
+    printf 'application_settings = ApplicationSetting.find_by "";'
+    printf 'application_settings.custom_project_templates_group_id = group_template.id;'
+    printf 'application_settings.save!;'
+    printf 'attrs = {'
+    printf 'name: :myrails, '
+    printf 'path: :myrails, '
+    printf 'namespace_id: group_template.id, '
+    printf 'template_name: :rails, '
+    printf 'id: 999};'
+    printf 'project = ::Projects::CreateService.new(User.find_by_username("root"), attrs).execute;'
+    printf 'project.saved?;'
+  ) | gitlab-rails console
+
+  touch $done
+}
+
+echo 'GitLab is ready for acceptance tests'


### PR DESCRIPTION
I took a stab at implementing some basic form of Acceptance Tests which run against a real GitLab instance.

They are located in the `acc/` directory. They run against a GitLab CE instance, but also a GitLab EE instance can be used given that you own license. I've wrote a brief contributing file to document this.

I'm not really sure if that's the best way yet to structure this, but I think it's already a valuable start.

We are actually using a pretty similar setup in the [GitLab terraform provider](https://github.com/gitlabhq/terraform-provider-gitlab).

@svanharmelen please let me know what you think ;)