### PR TITLE
Add file_template_project_id attribute to Group Struct

### DIFF
--- a/groups.go
+++ b/groups.go
@@ -71,6 +71,7 @@ type Group struct {
 	LDAPCN                         string           `json:"ldap_cn"`
 	LDAPAccess                     AccessLevelValue `json:"ldap_access"`
 	LDAPGroupLinks                 []*LDAPGroupLink `json:"ldap_group_links"`
+	FileTemplateProjectId          int              `json:"file_template_project_id"`
 	SharedRunnersMinutesLimit      int              `json:"shared_runners_minutes_limit"`
 	ExtraSharedRunnersMinutesLimit int              `json:"extra_shared_runners_minutes_limit"`
 	PreventForkingOutsideGroup     bool             `json:"prevent_forking_outside_group"`

--- a/groups.go
+++ b/groups.go
@@ -47,6 +47,7 @@ type Group struct {
 	RequestAccessEnabled    bool                       `json:"request_access_enabled"`
 	FullName                string                     `json:"full_name"`
 	FullPath                string                     `json:"full_path"`
+	FileTemplateProjectID   int                        `json:"file_template_project_id"`
 	ParentID                int                        `json:"parent_id"`
 	Projects                []*Project                 `json:"projects"`
 	Statistics              *StorageStatistics         `json:"statistics"`
@@ -71,7 +72,6 @@ type Group struct {
 	LDAPCN                         string           `json:"ldap_cn"`
 	LDAPAccess                     AccessLevelValue `json:"ldap_access"`
 	LDAPGroupLinks                 []*LDAPGroupLink `json:"ldap_group_links"`
-	FileTemplateProjectId          int              `json:"file_template_project_id"`
 	SharedRunnersMinutesLimit      int              `json:"shared_runners_minutes_limit"`
 	ExtraSharedRunnersMinutesLimit int              `json:"extra_shared_runners_minutes_limit"`
 	PreventForkingOutsideGroup     bool             `json:"prevent_forking_outside_group"`

--- a/groups_test.go
+++ b/groups_test.go
@@ -68,7 +68,6 @@ func TestGetGroupWithFileTemplateId(t *testing.T) {
 	if !reflect.DeepEqual(want, group) {
 		t.Errorf("Groups.GetGroup returned %+v, want %+v", group, want)
 	}
-
 }
 
 func TestCreateGroup(t *testing.T) {

--- a/groups_test.go
+++ b/groups_test.go
@@ -64,7 +64,7 @@ func TestGetGroupWithFileTemplateId(t *testing.T) {
 		t.Errorf("Groups.GetGroup returned error: %v", err)
 	}
 
-	want := &Group{ID: 1, Name: "g", FileTemplateProjectId: 12345}
+	want := &Group{ID: 1, Name: "g", FileTemplateProjectID: 12345}
 	if !reflect.DeepEqual(want, group) {
 		t.Errorf("Groups.GetGroup returned %+v, want %+v", group, want)
 	}

--- a/groups_test.go
+++ b/groups_test.go
@@ -49,6 +49,28 @@ func TestGetGroup(t *testing.T) {
 	}
 }
 
+func TestGetGroupWithFileTemplateId(t *testing.T) {
+	mux, server, client := setup(t)
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v4/groups/g",
+		func(w http.ResponseWriter, r *http.Request) {
+			testMethod(t, r, http.MethodGet)
+			fmt.Fprint(w, `{"id": 1, "name": "g","file_template_project_id": 12345}`)
+		})
+
+	group, _, err := client.Groups.GetGroup("g", &GetGroupOptions{})
+	if err != nil {
+		t.Errorf("Groups.GetGroup returned error: %v", err)
+	}
+
+	want := &Group{ID: 1, Name: "g", FileTemplateProjectId: 12345}
+	if !reflect.DeepEqual(want, group) {
+		t.Errorf("Groups.GetGroup returned %+v, want %+v", group, want)
+	}
+
+}
+
 func TestCreateGroup(t *testing.T) {
 	mux, server, client := setup(t)
 	defer teardown(server)


### PR DESCRIPTION
This PR adds support for the `file_template_project_id` when reading a Group via the API by adding the value to the `Group` struct. In addition, it adds one test to ensure that when the value is present properly in the JSON, it unmarshals properly.

Closes #1393