### PR TITLE
feat: Add any_approver project approval rule

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -1743,6 +1743,7 @@ type CreateProjectLevelRuleOptions struct {
 	GroupIDs           *[]int  `url:"group_ids,omitempty" json:"group_ids,omitempty"`
 	Name               *string `url:"name,omitempty" json:"name,omitempty"`
 	ProtectedBranchIDs *[]int  `url:"protected_branch_ids,omitempty" json:"protected_branch_ids,omitempty"`
+	RuleType           *string `url:"rule_type,omitempty" json:"rule_type,omitempty"`
 	UserIDs            *[]int  `url:"user_ids,omitempty" json:"user_ids,omitempty"`
 }
 
@@ -1781,6 +1782,7 @@ type UpdateProjectLevelRuleOptions struct {
 	GroupIDs           *[]int  `url:"group_ids,omitempty" json:"group_ids,omitempty"`
 	Name               *string `url:"name,omitempty" json:"name,omitempty"`
 	ProtectedBranchIDs *[]int  `url:"protected_branch_ids,omitempty" json:"protected_branch_ids,omitempty"`
+	RuleType           *string `url:"rule_type,omitempty" json:"rule_type,omitempty"`
 	UserIDs            *[]int  `url:"user_ids,omitempty" json:"user_ids,omitempty"`
 }
 

--- a/projects.go
+++ b/projects.go
@@ -1739,12 +1739,12 @@ func (s *ProjectsService) GetProjectApprovalRules(pid interface{}, options ...Re
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/merge_request_approvals.html#create-project-level-rules
 type CreateProjectLevelRuleOptions struct {
-	ApprovalsRequired  *int    `url:"approvals_required,omitempty" json:"approvals_required,omitempty"`
-	GroupIDs           *[]int  `url:"group_ids,omitempty" json:"group_ids,omitempty"`
 	Name               *string `url:"name,omitempty" json:"name,omitempty"`
-	ProtectedBranchIDs *[]int  `url:"protected_branch_ids,omitempty" json:"protected_branch_ids,omitempty"`
+	ApprovalsRequired  *int    `url:"approvals_required,omitempty" json:"approvals_required,omitempty"`
 	RuleType           *string `url:"rule_type,omitempty" json:"rule_type,omitempty"`
 	UserIDs            *[]int  `url:"user_ids,omitempty" json:"user_ids,omitempty"`
+	GroupIDs           *[]int  `url:"group_ids,omitempty" json:"group_ids,omitempty"`
+	ProtectedBranchIDs *[]int  `url:"protected_branch_ids,omitempty" json:"protected_branch_ids,omitempty"`
 }
 
 // CreateProjectApprovalRule creates a new project-level approval rule.
@@ -1778,12 +1778,11 @@ func (s *ProjectsService) CreateProjectApprovalRule(pid interface{}, opt *Create
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/merge_request_approvals.html#update-project-level-rules
 type UpdateProjectLevelRuleOptions struct {
-	ApprovalsRequired  *int    `url:"approvals_required,omitempty" json:"approvals_required,omitempty"`
-	GroupIDs           *[]int  `url:"group_ids,omitempty" json:"group_ids,omitempty"`
 	Name               *string `url:"name,omitempty" json:"name,omitempty"`
-	ProtectedBranchIDs *[]int  `url:"protected_branch_ids,omitempty" json:"protected_branch_ids,omitempty"`
-	RuleType           *string `url:"rule_type,omitempty" json:"rule_type,omitempty"`
+	ApprovalsRequired  *int    `url:"approvals_required,omitempty" json:"approvals_required,omitempty"`
 	UserIDs            *[]int  `url:"user_ids,omitempty" json:"user_ids,omitempty"`
+	GroupIDs           *[]int  `url:"group_ids,omitempty" json:"group_ids,omitempty"`
+	ProtectedBranchIDs *[]int  `url:"protected_branch_ids,omitempty" json:"protected_branch_ids,omitempty"`
 }
 
 // UpdateProjectApprovalRule updates an existing approval rule with new options.

--- a/projects_test.go
+++ b/projects_test.go
@@ -1130,3 +1130,48 @@ func TestCreateProjectApprovalRule(t *testing.T) {
 		t.Errorf("Projects.CreateProjectApprovalRule returned %+v, want %+v", rule, want)
 	}
 }
+
+func TestCreateProjectApprovalRuleEligibleApprovers(t *testing.T) {
+	mux, server, client := setup(t)
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v4/projects/1/approval_rules", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		fmt.Fprint(w, `{
+			"id": 1,
+			"name": "Any name",
+			"rule_type": "any_approver",
+			"eligible_approvers": [],
+			"approvals_required": 1,
+			"users": [],
+			"groups": [],
+			"contains_hidden_groups": false,
+			"protected_branches": []
+		}`)
+	})
+
+	opt := &CreateProjectLevelRuleOptions{
+		Name:              String("Any name"),
+		ApprovalsRequired: Int(1),
+	}
+
+	rule, _, err := client.Projects.CreateProjectApprovalRule(1, opt)
+	if err != nil {
+		t.Errorf("Projects.CreateProjectApprovalRule returned error: %v", err)
+	}
+
+	want := &ProjectApprovalRule{
+		ID:       1,
+		Name:     "Any name",
+		RuleType: "any_approver",
+		EligibleApprovers: []*BasicUser{},
+		ApprovalsRequired: 1,
+		Users: []*BasicUser{},
+		Groups: []*Group{},
+		ProtectedBranches: []*ProtectedBranch{},
+	}
+
+	if !reflect.DeepEqual(want, rule) {
+		t.Errorf("Projects.CreateProjectApprovalRule returned %+v, want %+v", rule, want)
+	}
+}


### PR DESCRIPTION
This rule is used in GitLab to set up Eligible Approvers,
which is currently not possible.