### PR TITLE
fix(commit status): coverage can be null

### DIFF
--- a/commits.go
+++ b/commits.go
@@ -399,7 +399,7 @@ type CommitStatus struct {
 	FinishedAt   *time.Time `json:"finished_at"`
 	Name         string     `json:"name"`
 	AllowFailure bool       `json:"allow_failure"`
-	Coverage     float64    `json:"coverage"`
+	Coverage     *float64   `json:"coverage"`
 	Author       Author     `json:"author"`
 	Description  string     `json:"description"`
 	TargetURL    string     `json:"target_url"`

--- a/types.go
+++ b/types.go
@@ -767,6 +767,14 @@ func Int(v int) *int {
 	return p
 }
 
+// Float64 is a helper routine that allocates a new float64 value
+// to store v and returns a pointer to it.
+func Float64(v float64) *float64 {
+	p := new(float64)
+	*p = v
+	return p
+}
+
 // String is a helper routine that allocates a new string value
 // to store v and returns a pointer to it.
 func String(v string) *string {


### PR DESCRIPTION
Fix coverage field introduced in #1397.

An example output for null coverage:

```json
{
  "id": 727832,
  "sha": "b0c5d0c9cb396db02fc8a0e249e4c5d113df851a",
  "ref": "ASM-6543",
  "status": "success",
  "name": "test",
  "target_url": null,
  "description": null,
  "created_at": "2022-03-02T13:23:04.500Z",
  "started_at": null,
  "finished_at": "2022-03-02T13:23:21.005Z",
  "allow_failure": false,
  "coverage": null,
  "author": {
    "id": 86,
    "name": "bot",
    "username": "bot",
    "state": "active",
    "avatar_url": "https://gitlab.example.com/uploads/-/system/user/avatar/86/avatar.png",
    "web_url": "https://gitlab.example.com/alaudabot"
  }
}
```