### PR TITLE
Creation of match between tags.go and Gitlab API

### DIFF
--- a/tags.go
+++ b/tags.go
@@ -17,9 +17,9 @@
 package gitlab
 
 import (
-	"fmt"
-	"net/http"
-	"net/url"
+    "fmt"
+    "net/http"
+    "net/url"
 )
 
 // TagsService handles communication with the tags related methods
@@ -27,29 +27,31 @@ import (
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/tags.html
 type TagsService struct {
-	client *Client
+    client *Client
 }
 
 // Tag represents a GitLab tag.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/tags.html
 type Tag struct {
-	Commit  *Commit      `json:"commit"`
-	Release *ReleaseNote `json:"release"`
-	Name    string       `json:"name"`
-	Message string       `json:"message"`
+    Commit    *Commit      `json:"commit"`
+    Release   *ReleaseNote `json:"release"`
+    Name      string       `json:"name"`
+    Message   string       `json:"message"`
+    Protected bool         `json:"protected"`
+    Target    string       `json:"target"`
 }
 
 // ReleaseNote represents a GitLab version release.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/tags.html
 type ReleaseNote struct {
-	TagName     string `json:"tag_name"`
-	Description string `json:"description"`
+    TagName     string `json:"tag_name"`
+    Description string `json:"description"`
 }
 
 func (t Tag) String() string {
-	return Stringify(t)
+    return Stringify(t)
 }
 
 // ListTagsOptions represents the available ListTags() options.
@@ -57,10 +59,10 @@ func (t Tag) String() string {
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/tags.html#list-project-repository-tags
 type ListTagsOptions struct {
-	ListOptions
-	OrderBy *string `url:"order_by,omitempty" json:"order_by,omitempty"`
-	Search  *string `url:"search,omitempty" json:"search,omitempty"`
-	Sort    *string `url:"sort,omitempty" json:"sort,omitempty"`
+    ListOptions
+    OrderBy *string `url:"order_by,omitempty" json:"order_by,omitempty"`
+    Search  *string `url:"search,omitempty" json:"search,omitempty"`
+    Sort    *string `url:"sort,omitempty" json:"sort,omitempty"`
 }
 
 // ListTags gets a list of tags from a project, sorted by name in reverse
@@ -69,24 +71,24 @@ type ListTagsOptions struct {
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/tags.html#list-project-repository-tags
 func (s *TagsService) ListTags(pid interface{}, opt *ListTagsOptions, options ...RequestOptionFunc) ([]*Tag, *Response, error) {
-	project, err := parseID(pid)
-	if err != nil {
-		return nil, nil, err
-	}
-	u := fmt.Sprintf("projects/%s/repository/tags", PathEscape(project))
+    project, err := parseID(pid)
+    if err != nil {
+        return nil, nil, err
+    }
+    u := fmt.Sprintf("projects/%s/repository/tags", PathEscape(project))
 
-	req, err := s.client.NewRequest(http.MethodGet, u, opt, options)
-	if err != nil {
-		return nil, nil, err
-	}
+    req, err := s.client.NewRequest(http.MethodGet, u, opt, options)
+    if err != nil {
+        return nil, nil, err
+    }
 
-	var t []*Tag
-	resp, err := s.client.Do(req, &t)
-	if err != nil {
-		return nil, resp, err
-	}
+    var t []*Tag
+    resp, err := s.client.Do(req, &t)
+    if err != nil {
+        return nil, resp, err
+    }
 
-	return t, resp, err
+    return t, resp, err
 }
 
 // GetTag a specific repository tag determined by its name. It returns 200 together
@@ -95,24 +97,24 @@ func (s *TagsService) ListTags(pid interface{}, opt *ListTagsOptions, options ..
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/tags.html#get-a-single-repository-tag
 func (s *TagsService) GetTag(pid interface{}, tag string, options ...RequestOptionFunc) (*Tag, *Response, error) {
-	project, err := parseID(pid)
-	if err != nil {
-		return nil, nil, err
-	}
-	u := fmt.Sprintf("projects/%s/repository/tags/%s", PathEscape(project), url.PathEscape(tag))
+    project, err := parseID(pid)
+    if err != nil {
+        return nil, nil, err
+    }
+    u := fmt.Sprintf("projects/%s/repository/tags/%s", PathEscape(project), url.PathEscape(tag))
 
-	req, err := s.client.NewRequest(http.MethodGet, u, nil, options)
-	if err != nil {
-		return nil, nil, err
-	}
+    req, err := s.client.NewRequest(http.MethodGet, u, nil, options)
+    if err != nil {
+        return nil, nil, err
+    }
 
-	var t *Tag
-	resp, err := s.client.Do(req, &t)
-	if err != nil {
-		return nil, resp, err
-	}
+    var t *Tag
+    resp, err := s.client.Do(req, &t)
+    if err != nil {
+        return nil, resp, err
+    }
 
-	return t, resp, err
+    return t, resp, err
 }
 
 // CreateTagOptions represents the available CreateTag() options.
@@ -120,11 +122,11 @@ func (s *TagsService) GetTag(pid interface{}, tag string, options ...RequestOpti
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/tags.html#create-a-new-tag
 type CreateTagOptions struct {
-	TagName *string `url:"tag_name,omitempty" json:"tag_name,omitempty"`
-	Ref     *string `url:"ref,omitempty" json:"ref,omitempty"`
-	Message *string `url:"message,omitempty" json:"message,omitempty"`
-	// ReleaseDescription parameter was deprecated in GitLab 11.7
-	ReleaseDescription *string `url:"release_description:omitempty" json:"release_description,omitempty"`
+    TagName *string `url:"tag_name,omitempty" json:"tag_name,omitempty"`
+    Ref     *string `url:"ref,omitempty" json:"ref,omitempty"`
+    Message *string `url:"message,omitempty" json:"message,omitempty"`
+    // ReleaseDescription parameter was deprecated in GitLab 11.7
+    ReleaseDescription *string `url:"release_description:omitempty" json:"release_description,omitempty"`
 }
 
 // CreateTag creates a new tag in the repository that points to the supplied ref.
@@ -132,24 +134,24 @@ type CreateTagOptions struct {
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/tags.html#create-a-new-tag
 func (s *TagsService) CreateTag(pid interface{}, opt *CreateTagOptions, options ...RequestOptionFunc) (*Tag, *Response, error) {
-	project, err := parseID(pid)
-	if err != nil {
-		return nil, nil, err
-	}
-	u := fmt.Sprintf("projects/%s/repository/tags", PathEscape(project))
+    project, err := parseID(pid)
+    if err != nil {
+        return nil, nil, err
+    }
+    u := fmt.Sprintf("projects/%s/repository/tags", PathEscape(project))
 
-	req, err := s.client.NewRequest(http.MethodPost, u, opt, options)
-	if err != nil {
-		return nil, nil, err
-	}
+    req, err := s.client.NewRequest(http.MethodPost, u, opt, options)
+    if err != nil {
+        return nil, nil, err
+    }
 
-	t := new(Tag)
-	resp, err := s.client.Do(req, t)
-	if err != nil {
-		return nil, resp, err
-	}
+    t := new(Tag)
+    resp, err := s.client.Do(req, t)
+    if err != nil {
+        return nil, resp, err
+    }
 
-	return t, resp, err
+    return t, resp, err
 }
 
 // DeleteTag deletes a tag of a repository with given name.
@@ -157,18 +159,18 @@ func (s *TagsService) CreateTag(pid interface{}, opt *CreateTagOptions, options 
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/tags.html#delete-a-tag
 func (s *TagsService) DeleteTag(pid interface{}, tag string, options ...RequestOptionFunc) (*Response, error) {
-	project, err := parseID(pid)
-	if err != nil {
-		return nil, err
-	}
-	u := fmt.Sprintf("projects/%s/repository/tags/%s", PathEscape(project), url.PathEscape(tag))
+    project, err := parseID(pid)
+    if err != nil {
+        return nil, err
+    }
+    u := fmt.Sprintf("projects/%s/repository/tags/%s", PathEscape(project), url.PathEscape(tag))
 
-	req, err := s.client.NewRequest(http.MethodDelete, u, nil, options)
-	if err != nil {
-		return nil, err
-	}
+    req, err := s.client.NewRequest(http.MethodDelete, u, nil, options)
+    if err != nil {
+        return nil, err
+    }
 
-	return s.client.Do(req, nil)
+    return s.client.Do(req, nil)
 }
 
 // CreateReleaseNoteOptions represents the available CreateReleaseNote() options.
@@ -178,7 +180,7 @@ func (s *TagsService) DeleteTag(pid interface{}, tag string, options ...RequestO
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/tags.html#create-a-new-release
 type CreateReleaseNoteOptions struct {
-	Description *string `url:"description:omitempty" json:"description,omitempty"`
+    Description *string `url:"description:omitempty" json:"description,omitempty"`
 }
 
 // CreateReleaseNote Add release notes to the existing git tag.
@@ -189,24 +191,24 @@ type CreateReleaseNoteOptions struct {
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/tags.html#create-a-new-release
 func (s *TagsService) CreateReleaseNote(pid interface{}, tag string, opt *CreateReleaseNoteOptions, options ...RequestOptionFunc) (*ReleaseNote, *Response, error) {
-	project, err := parseID(pid)
-	if err != nil {
-		return nil, nil, err
-	}
-	u := fmt.Sprintf("projects/%s/repository/tags/%s/release", PathEscape(project), url.PathEscape(tag))
+    project, err := parseID(pid)
+    if err != nil {
+        return nil, nil, err
+    }
+    u := fmt.Sprintf("projects/%s/repository/tags/%s/release", PathEscape(project), url.PathEscape(tag))
 
-	req, err := s.client.NewRequest(http.MethodPost, u, opt, options)
-	if err != nil {
-		return nil, nil, err
-	}
+    req, err := s.client.NewRequest(http.MethodPost, u, opt, options)
+    if err != nil {
+        return nil, nil, err
+    }
 
-	r := new(ReleaseNote)
-	resp, err := s.client.Do(req, r)
-	if err != nil {
-		return nil, resp, err
-	}
+    r := new(ReleaseNote)
+    resp, err := s.client.Do(req, r)
+    if err != nil {
+        return nil, resp, err
+    }
 
-	return r, resp, err
+    return r, resp, err
 }
 
 // UpdateReleaseNoteOptions represents the available UpdateReleaseNote() options.
@@ -214,7 +216,7 @@ func (s *TagsService) CreateReleaseNote(pid interface{}, tag string, opt *Create
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/tags.html#update-a-release
 type UpdateReleaseNoteOptions struct {
-	Description *string `url:"description:omitempty" json:"description,omitempty"`
+    Description *string `url:"description:omitempty" json:"description,omitempty"`
 }
 
 // UpdateReleaseNote Updates the release notes of a given release.
@@ -224,22 +226,22 @@ type UpdateReleaseNoteOptions struct {
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/tags.html#update-a-release
 func (s *TagsService) UpdateReleaseNote(pid interface{}, tag string, opt *UpdateReleaseNoteOptions, options ...RequestOptionFunc) (*ReleaseNote, *Response, error) {
-	project, err := parseID(pid)
-	if err != nil {
-		return nil, nil, err
-	}
-	u := fmt.Sprintf("projects/%s/repository/tags/%s/release", PathEscape(project), url.PathEscape(tag))
+    project, err := parseID(pid)
+    if err != nil {
+        return nil, nil, err
+    }
+    u := fmt.Sprintf("projects/%s/repository/tags/%s/release", PathEscape(project), url.PathEscape(tag))
 
-	req, err := s.client.NewRequest(http.MethodPut, u, opt, options)
-	if err != nil {
-		return nil, nil, err
-	}
+    req, err := s.client.NewRequest(http.MethodPut, u, opt, options)
+    if err != nil {
+        return nil, nil, err
+    }
 
-	r := new(ReleaseNote)
-	resp, err := s.client.Do(req, r)
-	if err != nil {
-		return nil, resp, err
-	}
+    r := new(ReleaseNote)
+    resp, err := s.client.Do(req, r)
+    if err != nil {
+        return nil, resp, err
+    }
 
-	return r, resp, err
+    return r, resp, err
 }

--- a/tags.go
+++ b/tags.go
@@ -17,9 +17,9 @@
 package gitlab
 
 import (
-    "fmt"
-    "net/http"
-    "net/url"
+	"fmt"
+	"net/http"
+	"net/url"
 )
 
 // TagsService handles communication with the tags related methods
@@ -27,31 +27,31 @@ import (
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/tags.html
 type TagsService struct {
-    client *Client
+	client *Client
 }
 
 // Tag represents a GitLab tag.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/tags.html
 type Tag struct {
-    Commit    *Commit      `json:"commit"`
-    Release   *ReleaseNote `json:"release"`
-    Name      string       `json:"name"`
-    Message   string       `json:"message"`
-    Protected bool         `json:"protected"`
-    Target    string       `json:"target"`
+	Commit    *Commit      `json:"commit"`
+	Release   *ReleaseNote `json:"release"`
+	Name      string       `json:"name"`
+	Message   string       `json:"message"`
+	Protected bool         `json:"protected"`
+	Target    string       `json:"target"`
 }
 
 // ReleaseNote represents a GitLab version release.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/tags.html
 type ReleaseNote struct {
-    TagName     string `json:"tag_name"`
-    Description string `json:"description"`
+	TagName     string `json:"tag_name"`
+	Description string `json:"description"`
 }
 
 func (t Tag) String() string {
-    return Stringify(t)
+	return Stringify(t)
 }
 
 // ListTagsOptions represents the available ListTags() options.
@@ -59,10 +59,10 @@ func (t Tag) String() string {
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/tags.html#list-project-repository-tags
 type ListTagsOptions struct {
-    ListOptions
-    OrderBy *string `url:"order_by,omitempty" json:"order_by,omitempty"`
-    Search  *string `url:"search,omitempty" json:"search,omitempty"`
-    Sort    *string `url:"sort,omitempty" json:"sort,omitempty"`
+	ListOptions
+	OrderBy *string `url:"order_by,omitempty" json:"order_by,omitempty"`
+	Search  *string `url:"search,omitempty" json:"search,omitempty"`
+	Sort    *string `url:"sort,omitempty" json:"sort,omitempty"`
 }
 
 // ListTags gets a list of tags from a project, sorted by name in reverse
@@ -71,24 +71,24 @@ type ListTagsOptions struct {
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/tags.html#list-project-repository-tags
 func (s *TagsService) ListTags(pid interface{}, opt *ListTagsOptions, options ...RequestOptionFunc) ([]*Tag, *Response, error) {
-    project, err := parseID(pid)
-    if err != nil {
-        return nil, nil, err
-    }
-    u := fmt.Sprintf("projects/%s/repository/tags", PathEscape(project))
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/repository/tags", PathEscape(project))
 
-    req, err := s.client.NewRequest(http.MethodGet, u, opt, options)
-    if err != nil {
-        return nil, nil, err
-    }
+	req, err := s.client.NewRequest(http.MethodGet, u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
 
-    var t []*Tag
-    resp, err := s.client.Do(req, &t)
-    if err != nil {
-        return nil, resp, err
-    }
+	var t []*Tag
+	resp, err := s.client.Do(req, &t)
+	if err != nil {
+		return nil, resp, err
+	}
 
-    return t, resp, err
+	return t, resp, err
 }
 
 // GetTag a specific repository tag determined by its name. It returns 200 together
@@ -97,24 +97,24 @@ func (s *TagsService) ListTags(pid interface{}, opt *ListTagsOptions, options ..
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/tags.html#get-a-single-repository-tag
 func (s *TagsService) GetTag(pid interface{}, tag string, options ...RequestOptionFunc) (*Tag, *Response, error) {
-    project, err := parseID(pid)
-    if err != nil {
-        return nil, nil, err
-    }
-    u := fmt.Sprintf("projects/%s/repository/tags/%s", PathEscape(project), url.PathEscape(tag))
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/repository/tags/%s", PathEscape(project), url.PathEscape(tag))
 
-    req, err := s.client.NewRequest(http.MethodGet, u, nil, options)
-    if err != nil {
-        return nil, nil, err
-    }
+	req, err := s.client.NewRequest(http.MethodGet, u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
 
-    var t *Tag
-    resp, err := s.client.Do(req, &t)
-    if err != nil {
-        return nil, resp, err
-    }
+	var t *Tag
+	resp, err := s.client.Do(req, &t)
+	if err != nil {
+		return nil, resp, err
+	}
 
-    return t, resp, err
+	return t, resp, err
 }
 
 // CreateTagOptions represents the available CreateTag() options.
@@ -122,11 +122,11 @@ func (s *TagsService) GetTag(pid interface{}, tag string, options ...RequestOpti
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/tags.html#create-a-new-tag
 type CreateTagOptions struct {
-    TagName *string `url:"tag_name,omitempty" json:"tag_name,omitempty"`
-    Ref     *string `url:"ref,omitempty" json:"ref,omitempty"`
-    Message *string `url:"message,omitempty" json:"message,omitempty"`
-    // ReleaseDescription parameter was deprecated in GitLab 11.7
-    ReleaseDescription *string `url:"release_description:omitempty" json:"release_description,omitempty"`
+	TagName *string `url:"tag_name,omitempty" json:"tag_name,omitempty"`
+	Ref     *string `url:"ref,omitempty" json:"ref,omitempty"`
+	Message *string `url:"message,omitempty" json:"message,omitempty"`
+	// ReleaseDescription parameter was deprecated in GitLab 11.7
+	ReleaseDescription *string `url:"release_description:omitempty" json:"release_description,omitempty"`
 }
 
 // CreateTag creates a new tag in the repository that points to the supplied ref.
@@ -134,24 +134,24 @@ type CreateTagOptions struct {
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/tags.html#create-a-new-tag
 func (s *TagsService) CreateTag(pid interface{}, opt *CreateTagOptions, options ...RequestOptionFunc) (*Tag, *Response, error) {
-    project, err := parseID(pid)
-    if err != nil {
-        return nil, nil, err
-    }
-    u := fmt.Sprintf("projects/%s/repository/tags", PathEscape(project))
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/repository/tags", PathEscape(project))
 
-    req, err := s.client.NewRequest(http.MethodPost, u, opt, options)
-    if err != nil {
-        return nil, nil, err
-    }
+	req, err := s.client.NewRequest(http.MethodPost, u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
 
-    t := new(Tag)
-    resp, err := s.client.Do(req, t)
-    if err != nil {
-        return nil, resp, err
-    }
+	t := new(Tag)
+	resp, err := s.client.Do(req, t)
+	if err != nil {
+		return nil, resp, err
+	}
 
-    return t, resp, err
+	return t, resp, err
 }
 
 // DeleteTag deletes a tag of a repository with given name.
@@ -159,18 +159,18 @@ func (s *TagsService) CreateTag(pid interface{}, opt *CreateTagOptions, options 
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/tags.html#delete-a-tag
 func (s *TagsService) DeleteTag(pid interface{}, tag string, options ...RequestOptionFunc) (*Response, error) {
-    project, err := parseID(pid)
-    if err != nil {
-        return nil, err
-    }
-    u := fmt.Sprintf("projects/%s/repository/tags/%s", PathEscape(project), url.PathEscape(tag))
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/repository/tags/%s", PathEscape(project), url.PathEscape(tag))
 
-    req, err := s.client.NewRequest(http.MethodDelete, u, nil, options)
-    if err != nil {
-        return nil, err
-    }
+	req, err := s.client.NewRequest(http.MethodDelete, u, nil, options)
+	if err != nil {
+		return nil, err
+	}
 
-    return s.client.Do(req, nil)
+	return s.client.Do(req, nil)
 }
 
 // CreateReleaseNoteOptions represents the available CreateReleaseNote() options.
@@ -180,7 +180,7 @@ func (s *TagsService) DeleteTag(pid interface{}, tag string, options ...RequestO
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/tags.html#create-a-new-release
 type CreateReleaseNoteOptions struct {
-    Description *string `url:"description:omitempty" json:"description,omitempty"`
+	Description *string `url:"description:omitempty" json:"description,omitempty"`
 }
 
 // CreateReleaseNote Add release notes to the existing git tag.
@@ -191,24 +191,24 @@ type CreateReleaseNoteOptions struct {
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/tags.html#create-a-new-release
 func (s *TagsService) CreateReleaseNote(pid interface{}, tag string, opt *CreateReleaseNoteOptions, options ...RequestOptionFunc) (*ReleaseNote, *Response, error) {
-    project, err := parseID(pid)
-    if err != nil {
-        return nil, nil, err
-    }
-    u := fmt.Sprintf("projects/%s/repository/tags/%s/release", PathEscape(project), url.PathEscape(tag))
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/repository/tags/%s/release", PathEscape(project), url.PathEscape(tag))
 
-    req, err := s.client.NewRequest(http.MethodPost, u, opt, options)
-    if err != nil {
-        return nil, nil, err
-    }
+	req, err := s.client.NewRequest(http.MethodPost, u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
 
-    r := new(ReleaseNote)
-    resp, err := s.client.Do(req, r)
-    if err != nil {
-        return nil, resp, err
-    }
+	r := new(ReleaseNote)
+	resp, err := s.client.Do(req, r)
+	if err != nil {
+		return nil, resp, err
+	}
 
-    return r, resp, err
+	return r, resp, err
 }
 
 // UpdateReleaseNoteOptions represents the available UpdateReleaseNote() options.
@@ -216,7 +216,7 @@ func (s *TagsService) CreateReleaseNote(pid interface{}, tag string, opt *Create
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/tags.html#update-a-release
 type UpdateReleaseNoteOptions struct {
-    Description *string `url:"description:omitempty" json:"description,omitempty"`
+	Description *string `url:"description:omitempty" json:"description,omitempty"`
 }
 
 // UpdateReleaseNote Updates the release notes of a given release.
@@ -226,22 +226,22 @@ type UpdateReleaseNoteOptions struct {
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/tags.html#update-a-release
 func (s *TagsService) UpdateReleaseNote(pid interface{}, tag string, opt *UpdateReleaseNoteOptions, options ...RequestOptionFunc) (*ReleaseNote, *Response, error) {
-    project, err := parseID(pid)
-    if err != nil {
-        return nil, nil, err
-    }
-    u := fmt.Sprintf("projects/%s/repository/tags/%s/release", PathEscape(project), url.PathEscape(tag))
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/repository/tags/%s/release", PathEscape(project), url.PathEscape(tag))
 
-    req, err := s.client.NewRequest(http.MethodPut, u, opt, options)
-    if err != nil {
-        return nil, nil, err
-    }
+	req, err := s.client.NewRequest(http.MethodPut, u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
 
-    r := new(ReleaseNote)
-    resp, err := s.client.Do(req, r)
-    if err != nil {
-        return nil, resp, err
-    }
+	r := new(ReleaseNote)
+	resp, err := s.client.Do(req, r)
+	if err != nil {
+		return nil, resp, err
+	}
 
-    return r, resp, err
+	return r, resp, err
 }

--- a/tags_test.go
+++ b/tags_test.go
@@ -18,6 +18,7 @@ package gitlab
 
 import (
 	"fmt"
+	"encoding/json"
 	"net/http"
 	"reflect"
 	"testing"
@@ -27,9 +28,16 @@ func TestTagsService_ListTags(t *testing.T) {
 	mux, server, client := setup(t)
 	defer teardown(server)
 
+	tagsJson := `[{"name": "1.0.0", "message": "test", "target": "fffff", "protected": false},{"name": "1.0.1"}]`
+	var want []*Tag
+	err := json.Unmarshal([]byte(tagsJson), &want)
+	if err != nil {
+		t.Errorf("Error occured during unmarshaling: %v", err)
+	}
+
 	mux.HandleFunc("/api/v4/projects/1/repository/tags", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
-		fmt.Fprint(w, `[{"name": "1.0.0"},{"name": "1.0.1"}]`)
+		fmt.Fprint(w, tagsJson)
 	})
 
 	opt := &ListTagsOptions{ListOptions: ListOptions{Page: 2, PerPage: 3}}
@@ -39,7 +47,6 @@ func TestTagsService_ListTags(t *testing.T) {
 		t.Errorf("Tags.ListTags returned error: %v", err)
 	}
 
-	want := []*Tag{{Name: "1.0.0"}, {Name: "1.0.1"}}
 	if !reflect.DeepEqual(want, tags) {
 		t.Errorf("Tags.ListTags returned %+v, want %+v", tags, want)
 	}


### PR DESCRIPTION
At present time tags structure doesn't match Gitlab API. For this reason, I add fields `target` and `protected` ([link to Gitlab API](https://docs.gitlab.com/ee/api/tags.html)).