### PR TITLE
Add Title to MergeCommentEvent.LastCommit struct

### DIFF
--- a/event_parsing_webhook_test.go
+++ b/event_parsing_webhook_test.go
@@ -207,6 +207,11 @@ func TestParseMergeRequestCommentHook(t *testing.T) {
 	if event.MergeRequest.ID != 7 {
 		t.Errorf("MergeRequest ID is %v, want %v", event.MergeRequest.ID, 7)
 	}
+
+	expectedTitle := "Merge branch 'another-branch' into 'master'"
+	if event.MergeRequest.LastCommit.Title != expectedTitle {
+		t.Errorf("MergeRequest Title is %v, want %v", event.MergeRequest.Title, expectedTitle)
+	}
 }
 
 func TestParseMergeRequestHook(t *testing.T) {

--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -430,6 +430,7 @@ type MergeCommentEvent struct {
 		Target                    *Repository  `json:"target"`
 		LastCommit                struct {
 			ID        string     `json:"id"`
+			Title     string     `json:"title"`
 			Message   string     `json:"message"`
 			Timestamp *time.Time `json:"timestamp"`
 			URL       string     `json:"url"`

--- a/testdata/webhooks/note_merge_request.json
+++ b/testdata/webhooks/note_merge_request.json
@@ -100,6 +100,7 @@
     "last_commit": {
       "id": "562e173be03b8ff2efb05345d12df18815438a4b",
       "message": "Merge branch 'another-branch' into 'master'\n\nCheck in this test\n",
+      "title": "Merge branch 'another-branch' into 'master'",
       "timestamp": "2015-04-08T21:00:25-07:00",
       "url": "http://example.com/gitlab-org/gitlab-test/commit/562e173be03b8ff2efb05345d12df18815438a4b",
       "author": {


### PR DESCRIPTION
This has been missing while it's definitively passed by gitlab to the
MergeCommentEvent

Signed-off-by: Chmouel Boudjnah <chmouel@chmouel.com>
