### PR TITLE
Make the label priority nullable

### DIFF
--- a/labels.go
+++ b/labels.go
@@ -43,7 +43,7 @@ type Label struct {
 	ClosedIssuesCount      int    `json:"closed_issues_count"`
 	OpenMergeRequestsCount int    `json:"open_merge_requests_count"`
 	Subscribed             bool   `json:"subscribed"`
-	Priority               int    `json:"priority"`
+	Priority               *int   `json:"priority"`
 	IsProjectLabel         bool   `json:"is_project_label"`
 }
 

--- a/labels_test.go
+++ b/labels_test.go
@@ -44,7 +44,7 @@ func TestCreateLabel(t *testing.T) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	want := &Label{ID: 1, Name: "My Label", Color: "#11FF22", Priority: 2}
+	want := &Label{ID: 1, Name: "My Label", Color: "#11FF22", Priority: Int(2)}
 	if !reflect.DeepEqual(want, label) {
 		t.Errorf("Labels.CreateLabel returned %+v, want %+v", label, want)
 	}
@@ -96,7 +96,7 @@ func TestUpdateLabel(t *testing.T) {
 		log.Fatal(err)
 	}
 
-	want := &Label{ID: 1, Name: "New Label", Color: "#11FF23", Description: "This is updated label", Priority: 42}
+	want := &Label{ID: 1, Name: "New Label", Color: "#11FF23", Description: "This is updated label", Priority: Int(42)}
 
 	if !reflect.DeepEqual(want, label) {
 		t.Errorf("Labels.UpdateLabel returned %+v, want %+v", label, want)


### PR DESCRIPTION
The label priority field can actually be `null`.

See examples here: https://docs.gitlab.com/ee/api/labels.html#list-labels

Btw. in the update method we have the same problem as here:

* https://github.com/xanzy/go-gitlab/issues/1384

... `null` is actually a valid value meaning that the priority should be removed from the label. For the `due_date` the fix in the marshaller (https://github.com/xanzy/go-gitlab/pull/1404) may work fine, because the default value isn't a sane due date. However, the integer value `0` for a label priority is a sane value.

I don't see any other option than introduce a special type to support this use case, ...

At the moment I'm trying to implement custom `RequestOptionFunc` to re-write the body which is kinda hacky ...

Actually quite some other API fields suffer from this issue, too.


