### PR TITLE
Setting AssigneeID type on listing options to AssigneeIDValue

### DIFF
--- a/issues.go
+++ b/issues.go
@@ -206,31 +206,31 @@ type LabelDetails struct {
 // GitLab API docs: https://docs.gitlab.com/ce/api/issues.html#list-issues
 type ListIssuesOptions struct {
 	ListOptions
-	State              *string			`url:"state,omitempty" json:"state,omitempty"`
-	Labels             *Labels			`url:"labels,comma,omitempty" json:"labels,omitempty"`
-	NotLabels          *Labels			`url:"not[labels],comma,omitempty" json:"not[labels],omitempty"`
-	WithLabelDetails   *bool			`url:"with_labels_details,omitempty" json:"with_labels_details,omitempty"`
-	Milestone          *string			`url:"milestone,omitempty" json:"milestone,omitempty"`
-	NotMilestone       *string			`url:"not[milestone],omitempty" json:"not[milestone],omitempty"`
-	Scope              *string			`url:"scope,omitempty" json:"scope,omitempty"`
-	AuthorID           *int				`url:"author_id,omitempty" json:"author_id,omitempty"`
-	NotAuthorID        *[]int			`url:"not[author_id],omitempty" json:"not[author_id],omitempty"`
+	State              *string		`url:"state,omitempty" json:"state,omitempty"`
+	Labels             *Labels		`url:"labels,comma,omitempty" json:"labels,omitempty"`
+	NotLabels          *Labels		`url:"not[labels],comma,omitempty" json:"not[labels],omitempty"`
+	WithLabelDetails   *bool		`url:"with_labels_details,omitempty" json:"with_labels_details,omitempty"`
+	Milestone          *string		`url:"milestone,omitempty" json:"milestone,omitempty"`
+	NotMilestone       *string		`url:"not[milestone],omitempty" json:"not[milestone],omitempty"`
+	Scope              *string		`url:"scope,omitempty" json:"scope,omitempty"`
+	AuthorID           *int			`url:"author_id,omitempty" json:"author_id,omitempty"`
+	NotAuthorID        *[]int		`url:"not[author_id],omitempty" json:"not[author_id],omitempty"`
 	AssigneeID         *AssigneeIDValue	`url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
-	NotAssigneeID      *[]int			`url:"not[assignee_id],omitempty" json:"not[assignee_id],omitempty"`
-	AssigneeUsername   *string			`url:"assignee_username,omitempty" json:"assignee_username,omitempty"`
-	MyReactionEmoji    *string			`url:"my_reaction_emoji,omitempty" json:"my_reaction_emoji,omitempty"`
+	NotAssigneeID      *[]int		`url:"not[assignee_id],omitempty" json:"not[assignee_id],omitempty"`
+	AssigneeUsername   *string		`url:"assignee_username,omitempty" json:"assignee_username,omitempty"`
+	MyReactionEmoji    *string		`url:"my_reaction_emoji,omitempty" json:"my_reaction_emoji,omitempty"`
 	NotMyReactionEmoji *[]string		`url:"not[my_reaction_emoji],omitempty" json:"not[my_reaction_emoji],omitempty"`
-	IIDs               *[]int			`url:"iids[],omitempty" json:"iids,omitempty"`
-	In                 *string			`url:"in,omitempty" json:"in,omitempty"`
-	OrderBy            *string			`url:"order_by,omitempty" json:"order_by,omitempty"`
-	Sort               *string			`url:"sort,omitempty" json:"sort,omitempty"`
-	Search             *string			`url:"search,omitempty" json:"search,omitempty"`
+	IIDs               *[]int		`url:"iids[],omitempty" json:"iids,omitempty"`
+	In                 *string		`url:"in,omitempty" json:"in,omitempty"`
+	OrderBy            *string		`url:"order_by,omitempty" json:"order_by,omitempty"`
+	Sort               *string		`url:"sort,omitempty" json:"sort,omitempty"`
+	Search             *string		`url:"search,omitempty" json:"search,omitempty"`
 	CreatedAfter       *time.Time		`url:"created_after,omitempty" json:"created_after,omitempty"`
 	CreatedBefore      *time.Time		`url:"created_before,omitempty" json:"created_before,omitempty"`
 	UpdatedAfter       *time.Time		`url:"updated_after,omitempty" json:"updated_after,omitempty"`
 	UpdatedBefore      *time.Time		`url:"updated_before,omitempty" json:"updated_before,omitempty"`
-	Confidential       *bool			`url:"confidential,omitempty" json:"confidential,omitempty"`
-	IssueType          *string			`url:"issue_type,omitempty" json:"issue_type,omitempty"`
+	Confidential       *bool		`url:"confidential,omitempty" json:"confidential,omitempty"`
+	IssueType          *string		`url:"issue_type,omitempty" json:"issue_type,omitempty"`
 }
 
 // ListIssues gets all issues created by authenticated user. This function

--- a/issues.go
+++ b/issues.go
@@ -257,31 +257,32 @@ func (s *IssuesService) ListIssues(opt *ListIssuesOptions, options ...RequestOpt
 // GitLab API docs: https://docs.gitlab.com/ce/api/issues.html#list-group-issues
 type ListGroupIssuesOptions struct {
 	ListOptions
-	State              *string    `url:"state,omitempty" json:"state,omitempty"`
-	Labels             *Labels    `url:"labels,comma,omitempty" json:"labels,omitempty"`
-	NotLabels          *Labels    `url:"not[labels],comma,omitempty" json:"not[labels],omitempty"`
-	WithLabelDetails   *bool      `url:"with_labels_details,omitempty" json:"with_labels_details,omitempty"`
-	IIDs               *[]int     `url:"iids[],omitempty" json:"iids,omitempty"`
-	Milestone          *string    `url:"milestone,omitempty" json:"milestone,omitempty"`
-	NotMilestone       *string    `url:"not[milestone],omitempty" json:"not[milestone],omitempty"`
-	Scope              *string    `url:"scope,omitempty" json:"scope,omitempty"`
-	AuthorID           *int       `url:"author_id,omitempty" json:"author_id,omitempty"`
-	NotAuthorID        *[]int     `url:"not[author_id],omitempty" json:"not[author_id],omitempty"`
-	AuthorUsername     *string    `url:"author_username,omitempty" json:"author_username,omitempty"`
-	AssigneeID         *int       `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
-	NotAssigneeID      *[]int     `url:"not[assignee_id],omitempty" json:"not[assignee_id],omitempty"`
-	AssigneeUsername   *string    `url:"assignee_username,omitempty" json:"assignee_username,omitempty"`
-	MyReactionEmoji    *string    `url:"my_reaction_emoji,omitempty" json:"my_reaction_emoji,omitempty"`
-	NotMyReactionEmoji *[]string  `url:"not[my_reaction_emoji],omitempty" json:"not[my_reaction_emoji],omitempty"`
-	OrderBy            *string    `url:"order_by,omitempty" json:"order_by,omitempty"`
-	Sort               *string    `url:"sort,omitempty" json:"sort,omitempty"`
-	Search             *string    `url:"search,omitempty" json:"search,omitempty"`
-	In                 *string    `url:"in,omitempty" json:"in,omitempty"`
-	CreatedAfter       *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
-	CreatedBefore      *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
-	UpdatedAfter       *time.Time `url:"updated_after,omitempty" json:"updated_after,omitempty"`
-	UpdatedBefore      *time.Time `url:"updated_before,omitempty" json:"updated_before,omitempty"`
-	IssueType          *string    `url:"issue_type,omitempty" json:"issue_type,omitempty"`
+	State              *string	    `url:"state,omitempty" json:"state,omitempty"`
+	Labels             *Labels	    `url:"labels,comma,omitempty" json:"labels,omitempty"`
+	NotLabels          *Labels	    `url:"not[labels],comma,omitempty" json:"not[labels],omitempty"`
+	WithLabelDetails   *bool	    `url:"with_labels_details,omitempty" json:"with_labels_details,omitempty"`
+	IIDs               *[]int	    `url:"iids[],omitempty" json:"iids,omitempty"`
+	Milestone          *string	    `url:"milestone,omitempty" json:"milestone,omitempty"`
+	NotMilestone       *string	    `url:"not[milestone],omitempty" json:"not[milestone],omitempty"`
+	Scope              *string	    `url:"scope,omitempty" json:"scope,omitempty"`
+	AuthorID           *int		    `url:"author_id,omitempty" json:"author_id,omitempty"`
+	NotAuthorID        *[]int	    `url:"not[author_id],omitempty" json:"not[author_id],omitempty"`
+	AuthorUsername     *string	    `url:"author_username,omitempty" json:"author_username,omitempty"`
+
+	AssigneeID         *AssigneeIDValue `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
+	NotAssigneeID      *[]int	    `url:"not[assignee_id],omitempty" json:"not[assignee_id],omitempty"`
+	AssigneeUsername   *string	    `url:"assignee_username,omitempty" json:"assignee_username,omitempty"`
+	MyReactionEmoji    *string	    `url:"my_reaction_emoji,omitempty" json:"my_reaction_emoji,omitempty"`
+	NotMyReactionEmoji *[]string	    `url:"not[my_reaction_emoji],omitempty" json:"not[my_reaction_emoji],omitempty"`
+	OrderBy            *string	    `url:"order_by,omitempty" json:"order_by,omitempty"`
+	Sort               *string	    `url:"sort,omitempty" json:"sort,omitempty"`
+	Search             *string	    `url:"search,omitempty" json:"search,omitempty"`
+	In                 *string	    `url:"in,omitempty" json:"in,omitempty"`
+	CreatedAfter       *time.Time	    `url:"created_after,omitempty" json:"created_after,omitempty"`
+	CreatedBefore      *time.Time	    `url:"created_before,omitempty" json:"created_before,omitempty"`
+	UpdatedAfter       *time.Time	    `url:"updated_after,omitempty" json:"updated_after,omitempty"`
+	UpdatedBefore      *time.Time	    `url:"updated_before,omitempty" json:"updated_before,omitempty"`
+	IssueType          *string	    `url:"issue_type,omitempty" json:"issue_type,omitempty"`
 }
 
 // ListGroupIssues gets a list of group issues. This function accepts
@@ -314,32 +315,32 @@ func (s *IssuesService) ListGroupIssues(pid interface{}, opt *ListGroupIssuesOpt
 // GitLab API docs: https://docs.gitlab.com/ce/api/issues.html#list-project-issues
 type ListProjectIssuesOptions struct {
 	ListOptions
-	IIDs               *[]int     `url:"iids[],omitempty" json:"iids,omitempty"`
-	State              *string    `url:"state,omitempty" json:"state,omitempty"`
-	Labels             *Labels    `url:"labels,comma,omitempty" json:"labels,omitempty"`
-	NotLabels          *Labels    `url:"not[labels],comma,omitempty" json:"not[labels],omitempty"`
-	WithLabelDetails   *bool      `url:"with_labels_details,omitempty" json:"with_labels_details,omitempty"`
-	Milestone          *string    `url:"milestone,omitempty" json:"milestone,omitempty"`
-	NotMilestone       *[]string  `url:"not[milestone],omitempty" json:"not[milestone],omitempty"`
-	Scope              *string    `url:"scope,omitempty" json:"scope,omitempty"`
-	AuthorID           *int       `url:"author_id,omitempty" json:"author_id,omitempty"`
-	NotAuthorID        *[]int     `url:"not[author_id],omitempty" json:"not[author_id],omitempty"`
-	AssigneeID         *int       `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
-	NotAssigneeID      *[]int     `url:"not[assignee_id],omitempty" json:"not[assignee_id],omitempty"`
-	AssigneeUsername   *string    `url:"assignee_username,omitempty" json:"assignee_username,omitempty"`
-	MyReactionEmoji    *string    `url:"my_reaction_emoji,omitempty" json:"my_reaction_emoji,omitempty"`
-	NotMyReactionEmoji *[]string  `url:"not[my_reaction_emoji],omitempty" json:"not[my_reaction_emoji],omitempty"`
-	OrderBy            *string    `url:"order_by,omitempty" json:"order_by,omitempty"`
-	Sort               *string    `url:"sort,omitempty" json:"sort,omitempty"`
-	Search             *string    `url:"search,omitempty" json:"search,omitempty"`
-	In                 *string    `url:"in,omitempty" json:"in,omitempty"`
-	CreatedAfter       *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
-	CreatedBefore      *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
-	DueDate            *string    `url:"due_date,omitempty" json:"due_date,omitempty"`
-	UpdatedAfter       *time.Time `url:"updated_after,omitempty" json:"updated_after,omitempty"`
-	UpdatedBefore      *time.Time `url:"updated_before,omitempty" json:"updated_before,omitempty"`
-	Confidential       *bool      `url:"confidential,omitempty" json:"confidential,omitempty"`
-	IssueType          *string    `url:"issue_type,omitempty" json:"issue_type,omitempty"`
+	IIDs               *[]int	    `url:"iids[],omitempty" json:"iids,omitempty"`
+	State              *string	    `url:"state,omitempty" json:"state,omitempty"`
+	Labels             *Labels	    `url:"labels,comma,omitempty" json:"labels,omitempty"`
+	NotLabels          *Labels	    `url:"not[labels],comma,omitempty" json:"not[labels],omitempty"`
+	WithLabelDetails   *bool	    `url:"with_labels_details,omitempty" json:"with_labels_details,omitempty"`
+	Milestone          *string	    `url:"milestone,omitempty" json:"milestone,omitempty"`
+	NotMilestone       *[]string	    `url:"not[milestone],omitempty" json:"not[milestone],omitempty"`
+	Scope              *string	    `url:"scope,omitempty" json:"scope,omitempty"`
+	AuthorID           *int		    `url:"author_id,omitempty" json:"author_id,omitempty"`
+	NotAuthorID        *[]int	    `url:"not[author_id],omitempty" json:"not[author_id],omitempty"`
+	AssigneeID         *AssigneeIDValue `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
+	NotAssigneeID      *[]int	    `url:"not[assignee_id],omitempty" json:"not[assignee_id],omitempty"`
+	AssigneeUsername   *string	    `url:"assignee_username,omitempty" json:"assignee_username,omitempty"`
+	MyReactionEmoji    *string	    `url:"my_reaction_emoji,omitempty" json:"my_reaction_emoji,omitempty"`
+	NotMyReactionEmoji *[]string	    `url:"not[my_reaction_emoji],omitempty" json:"not[my_reaction_emoji],omitempty"`
+	OrderBy            *string	    `url:"order_by,omitempty" json:"order_by,omitempty"`
+	Sort               *string	    `url:"sort,omitempty" json:"sort,omitempty"`
+	Search             *string	    `url:"search,omitempty" json:"search,omitempty"`
+	In                 *string	    `url:"in,omitempty" json:"in,omitempty"`
+	CreatedAfter       *time.Time	    `url:"created_after,omitempty" json:"created_after,omitempty"`
+	CreatedBefore      *time.Time	    `url:"created_before,omitempty" json:"created_before,omitempty"`
+	DueDate            *string	    `url:"due_date,omitempty" json:"due_date,omitempty"`
+	UpdatedAfter       *time.Time	    `url:"updated_after,omitempty" json:"updated_after,omitempty"`
+	UpdatedBefore      *time.Time	    `url:"updated_before,omitempty" json:"updated_before,omitempty"`
+	Confidential       *bool	    `url:"confidential,omitempty" json:"confidential,omitempty"`
+	IssueType          *string	    `url:"issue_type,omitempty" json:"issue_type,omitempty"`
 }
 
 // ListProjectIssues gets a list of project issues. This function accepts

--- a/issues.go
+++ b/issues.go
@@ -206,31 +206,31 @@ type LabelDetails struct {
 // GitLab API docs: https://docs.gitlab.com/ce/api/issues.html#list-issues
 type ListIssuesOptions struct {
 	ListOptions
-	State              *string    `url:"state,omitempty" json:"state,omitempty"`
-	Labels             *Labels    `url:"labels,comma,omitempty" json:"labels,omitempty"`
-	NotLabels          *Labels    `url:"not[labels],comma,omitempty" json:"not[labels],omitempty"`
-	WithLabelDetails   *bool      `url:"with_labels_details,omitempty" json:"with_labels_details,omitempty"`
-	Milestone          *string    `url:"milestone,omitempty" json:"milestone,omitempty"`
-	NotMilestone       *string    `url:"not[milestone],omitempty" json:"not[milestone],omitempty"`
-	Scope              *string    `url:"scope,omitempty" json:"scope,omitempty"`
-	AuthorID           *int       `url:"author_id,omitempty" json:"author_id,omitempty"`
-	NotAuthorID        *[]int     `url:"not[author_id],omitempty" json:"not[author_id],omitempty"`
-	AssigneeID         *int       `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
-	NotAssigneeID      *[]int     `url:"not[assignee_id],omitempty" json:"not[assignee_id],omitempty"`
-	AssigneeUsername   *string    `url:"assignee_username,omitempty" json:"assignee_username,omitempty"`
-	MyReactionEmoji    *string    `url:"my_reaction_emoji,omitempty" json:"my_reaction_emoji,omitempty"`
-	NotMyReactionEmoji *[]string  `url:"not[my_reaction_emoji],omitempty" json:"not[my_reaction_emoji],omitempty"`
-	IIDs               *[]int     `url:"iids[],omitempty" json:"iids,omitempty"`
-	In                 *string    `url:"in,omitempty" json:"in,omitempty"`
-	OrderBy            *string    `url:"order_by,omitempty" json:"order_by,omitempty"`
-	Sort               *string    `url:"sort,omitempty" json:"sort,omitempty"`
-	Search             *string    `url:"search,omitempty" json:"search,omitempty"`
-	CreatedAfter       *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
-	CreatedBefore      *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
-	UpdatedAfter       *time.Time `url:"updated_after,omitempty" json:"updated_after,omitempty"`
-	UpdatedBefore      *time.Time `url:"updated_before,omitempty" json:"updated_before,omitempty"`
-	Confidential       *bool      `url:"confidential,omitempty" json:"confidential,omitempty"`
-	IssueType          *string    `url:"issue_type,omitempty" json:"issue_type,omitempty"`
+	State              *string			`url:"state,omitempty" json:"state,omitempty"`
+	Labels             *Labels			`url:"labels,comma,omitempty" json:"labels,omitempty"`
+	NotLabels          *Labels			`url:"not[labels],comma,omitempty" json:"not[labels],omitempty"`
+	WithLabelDetails   *bool			`url:"with_labels_details,omitempty" json:"with_labels_details,omitempty"`
+	Milestone          *string			`url:"milestone,omitempty" json:"milestone,omitempty"`
+	NotMilestone       *string			`url:"not[milestone],omitempty" json:"not[milestone],omitempty"`
+	Scope              *string			`url:"scope,omitempty" json:"scope,omitempty"`
+	AuthorID           *int				`url:"author_id,omitempty" json:"author_id,omitempty"`
+	NotAuthorID        *[]int			`url:"not[author_id],omitempty" json:"not[author_id],omitempty"`
+	AssigneeID         *AssigneeIDValue	`url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
+	NotAssigneeID      *[]int			`url:"not[assignee_id],omitempty" json:"not[assignee_id],omitempty"`
+	AssigneeUsername   *string			`url:"assignee_username,omitempty" json:"assignee_username,omitempty"`
+	MyReactionEmoji    *string			`url:"my_reaction_emoji,omitempty" json:"my_reaction_emoji,omitempty"`
+	NotMyReactionEmoji *[]string		`url:"not[my_reaction_emoji],omitempty" json:"not[my_reaction_emoji],omitempty"`
+	IIDs               *[]int			`url:"iids[],omitempty" json:"iids,omitempty"`
+	In                 *string			`url:"in,omitempty" json:"in,omitempty"`
+	OrderBy            *string			`url:"order_by,omitempty" json:"order_by,omitempty"`
+	Sort               *string			`url:"sort,omitempty" json:"sort,omitempty"`
+	Search             *string			`url:"search,omitempty" json:"search,omitempty"`
+	CreatedAfter       *time.Time		`url:"created_after,omitempty" json:"created_after,omitempty"`
+	CreatedBefore      *time.Time		`url:"created_before,omitempty" json:"created_before,omitempty"`
+	UpdatedAfter       *time.Time		`url:"updated_after,omitempty" json:"updated_after,omitempty"`
+	UpdatedBefore      *time.Time		`url:"updated_before,omitempty" json:"updated_before,omitempty"`
+	Confidential       *bool			`url:"confidential,omitempty" json:"confidential,omitempty"`
+	IssueType          *string			`url:"issue_type,omitempty" json:"issue_type,omitempty"`
 }
 
 // ListIssues gets all issues created by authenticated user. This function

--- a/issues_test.go
+++ b/issues_test.go
@@ -152,7 +152,7 @@ func TestListIssues(t *testing.T) {
 
 	listProjectIssue := &ListIssuesOptions{
 		AuthorID:   Int(01),
-		AssigneeID: Int(02),
+		AssigneeID: AssigneeID(02),
 	}
 
 	issues, _, err := client.Issues.ListIssues(listProjectIssue)
@@ -220,7 +220,7 @@ func TestListIssuesWithLabelDetails(t *testing.T) {
 
 	listProjectIssue := &ListIssuesOptions{
 		AuthorID:   Int(01),
-		AssigneeID: Int(02),
+		AssigneeID: AssigneeID(02),
 	}
 
 	issues, _, err := client.Issues.ListIssues(listProjectIssue)

--- a/issues_test.go
+++ b/issues_test.go
@@ -336,7 +336,7 @@ func TestListProjectIssues(t *testing.T) {
 
 	listProjectIssue := &ListProjectIssuesOptions{
 		AuthorID:   Int(01),
-		AssigneeID: Int(02),
+		AssigneeID: AssigneeID(02),
 	}
 	issues, _, err := client.Issues.ListProjectIssues("1", listProjectIssue)
 	if err != nil {
@@ -368,7 +368,7 @@ func TestListGroupIssues(t *testing.T) {
 	listGroupIssue := &ListGroupIssuesOptions{
 		State:      String("Open"),
 		AuthorID:   Int(01),
-		AssigneeID: Int(02),
+		AssigneeID: AssigneeID(02),
 	}
 
 	issues, _, err := client.Issues.ListGroupIssues("1", listGroupIssue)


### PR DESCRIPTION
This allows users to use the 'none' and 'any' AssigneeIDs, as allowed by the GitLab API docs. Naturally, this is likely to generate error on existing dependent code that passes AssigneeID as an integer.

All local tests were successful.

Closes #1408 