### PR TITLE
Add get wiki page options

### DIFF
--- a/group_wikis.go
+++ b/group_wikis.go
@@ -33,10 +33,11 @@ type GroupWikisService struct {
 //
 // GitLab API docs: https://docs.gitlab.com/ee/api/group_wikis.html
 type GroupWiki struct {
-	Content string          `json:"content"`
-	Format  WikiFormatValue `json:"format"`
-	Slug    string          `json:"slug"`
-	Title   string          `json:"title"`
+	Content  string          `json:"content"`
+	Encoding string          `json:"encoding"`
+	Format   WikiFormatValue `json:"format"`
+	Slug     string          `json:"slug"`
+	Title    string          `json:"title"`
 }
 
 func (w GroupWiki) String() string {
@@ -77,18 +78,27 @@ func (s *GroupWikisService) ListGroupWikis(gid interface{}, opt *ListGroupWikisO
 	return gws, resp, err
 }
 
+// GetGroupWikiPageOptions represents options to GetGroupWikiPage
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/group_wikis.html#get-a-wiki-page
+type GetGroupWikiPageOptions struct {
+	RenderHTML *bool   `url:"render_html,omitempty" json:"render_html,omitempty"`
+	Version    *string `url:"version,omitempty" json:"version,omitempty"`
+}
+
 // GetGroupWikiPage gets a wiki page for a given group.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/group_wikis.html#get-a-wiki-page
-func (s *GroupWikisService) GetGroupWikiPage(gid interface{}, slug string, options ...RequestOptionFunc) (*GroupWiki, *Response, error) {
+func (s *GroupWikisService) GetGroupWikiPage(gid interface{}, slug string, opt *GetGroupWikiPageOptions, options ...RequestOptionFunc) (*GroupWiki, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("groups/%s/wikis/%s", PathEscape(group), url.PathEscape(slug))
 
-	req, err := s.client.NewRequest(http.MethodGet, u, nil, options)
+	req, err := s.client.NewRequest(http.MethodGet, u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -116,7 +126,7 @@ type CreateGroupWikiPageOptions struct {
 // the given title, slug, and content.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/13.8/ee/api/group_wikis.html#create-a-new-wiki-page
+// https://docs.gitlab.com/ee/api/group_wikis.html#create-a-new-wiki-page
 func (s *GroupWikisService) CreateGroupWikiPage(gid interface{}, opt *CreateGroupWikiPageOptions, options ...RequestOptionFunc) (*GroupWiki, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {

--- a/group_wikis_test.go
+++ b/group_wikis_test.go
@@ -14,7 +14,14 @@ func TestListGroupWikis(t *testing.T) {
 	mux.HandleFunc("/api/v4/groups/1/wikis",
 		func(w http.ResponseWriter, r *http.Request) {
 			testMethod(t, r, http.MethodGet)
-			fmt.Fprint(w, `[{"content":"content here","format":"markdown","slug":"deploy","title":"deploy title"}]`)
+			fmt.Fprint(w, `[
+				{
+					"content": "content here",
+					"format": "markdown",
+					"slug": "deploy",
+					"title": "deploy title"
+				}
+			]`)
 		})
 
 	groupwikis, _, err := client.GroupWikis.ListGroupWikis(1, &ListGroupWikisOptions{})
@@ -22,7 +29,14 @@ func TestListGroupWikis(t *testing.T) {
 		t.Errorf("GroupWikis.ListGroupWikis returned error: %v", err)
 	}
 
-	want := []*GroupWiki{{Content: "content here", Format: WikiFormatMarkdown, Slug: "deploy", Title: "deploy title"}}
+	want := []*GroupWiki{
+		{
+			Content: "content here",
+			Format:  WikiFormatMarkdown,
+			Slug:    "deploy",
+			Title:   "deploy title",
+		},
+	}
 	if !reflect.DeepEqual(want, groupwikis) {
 		t.Errorf("GroupWikis.ListGroupWikis returned %+v, want %+v", groupwikis, want)
 	}
@@ -35,15 +49,27 @@ func TestGetGroupWikiPage(t *testing.T) {
 	mux.HandleFunc("/api/v4/groups/1/wikis/deploy",
 		func(w http.ResponseWriter, r *http.Request) {
 			testMethod(t, r, http.MethodGet)
-			fmt.Fprint(w, `{"content":"content here","format":"asciidoc","slug":"deploy","title":"deploy title"}`)
+			fmt.Fprint(w, `{
+				"content": "content here",
+				"format": "asciidoc",
+				"slug": "deploy",
+				"title": "deploy title",
+				"encoding": "UTF-8"
+			}`)
 		})
 
-	groupwiki, _, err := client.GroupWikis.GetGroupWikiPage(1, "deploy")
+	groupwiki, _, err := client.GroupWikis.GetGroupWikiPage(1, "deploy", &GetGroupWikiPageOptions{})
 	if err != nil {
 		t.Errorf("GroupWikis.GetGroupWikiPage returned error: %v", err)
 	}
 
-	want := &GroupWiki{Content: "content here", Format: WikiFormatASCIIDoc, Slug: "deploy", Title: "deploy title"}
+	want := &GroupWiki{
+		Content:  "content here",
+		Encoding: "UTF-8",
+		Format:   WikiFormatASCIIDoc,
+		Slug:     "deploy",
+		Title:    "deploy title",
+	}
 	if !reflect.DeepEqual(want, groupwiki) {
 		t.Errorf("GroupWikis.GetGroupWikiPage returned %+v, want %+v", groupwiki, want)
 	}
@@ -56,7 +82,12 @@ func TestCreateGroupWikiPage(t *testing.T) {
 	mux.HandleFunc("/api/v4/groups/1/wikis",
 		func(w http.ResponseWriter, r *http.Request) {
 			testMethod(t, r, http.MethodPost)
-			fmt.Fprint(w, `{"content":"content here","format":"rdoc","slug":"deploy","title":"deploy title"}`)
+			fmt.Fprint(w, `{
+				"content": "content here",
+				"format": "rdoc",
+				"slug": "deploy",
+				"title": "deploy title"
+			}`)
 		})
 
 	groupwiki, _, err := client.GroupWikis.CreateGroupWikiPage(1, &CreateGroupWikiPageOptions{
@@ -68,7 +99,12 @@ func TestCreateGroupWikiPage(t *testing.T) {
 		t.Errorf("GroupWikis.CreateGroupWikiPage returned error: %v", err)
 	}
 
-	want := &GroupWiki{Content: "content here", Format: WikiFormatRDoc, Slug: "deploy", Title: "deploy title"}
+	want := &GroupWiki{
+		Content: "content here",
+		Format:  WikiFormatRDoc,
+		Slug:    "deploy",
+		Title:   "deploy title",
+	}
 	if !reflect.DeepEqual(want, groupwiki) {
 		t.Errorf("GroupWikis.CreateGroupWikiPage returned %+v, want %+v", groupwiki, want)
 	}
@@ -81,7 +117,12 @@ func TestEditGroupWikiPage(t *testing.T) {
 	mux.HandleFunc("/api/v4/groups/1/wikis/deploy",
 		func(w http.ResponseWriter, r *http.Request) {
 			testMethod(t, r, http.MethodPut)
-			fmt.Fprint(w, `{"content":"content here","format":"asciidoc","slug":"deploy","title":"deploy title"}`)
+			fmt.Fprint(w, `{
+				"content": "content here",
+				"format": "asciidoc",
+				"slug": "deploy",
+				"title": "deploy title"
+			}`)
 		})
 
 	groupwiki, _, err := client.GroupWikis.EditGroupWikiPage(1, "deploy", &EditGroupWikiPageOptions{
@@ -93,7 +134,12 @@ func TestEditGroupWikiPage(t *testing.T) {
 		t.Errorf("GroupWikis.EditGroupWikiPage returned error: %v", err)
 	}
 
-	want := &GroupWiki{Content: "content here", Format: WikiFormatASCIIDoc, Slug: "deploy", Title: "deploy title"}
+	want := &GroupWiki{
+		Content: "content here",
+		Format:  WikiFormatASCIIDoc,
+		Slug:    "deploy",
+		Title:   "deploy title",
+	}
 	if !reflect.DeepEqual(want, groupwiki) {
 		t.Errorf("GroupWikis.EditGroupWikiPage returned %+v, want %+v", groupwiki, want)
 	}

--- a/wikis.go
+++ b/wikis.go
@@ -33,10 +33,11 @@ type WikisService struct {
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/wikis.html
 type Wiki struct {
-	Content string          `json:"content"`
-	Format  WikiFormatValue `json:"format"`
-	Slug    string          `json:"slug"`
-	Title   string          `json:"title"`
+	Content  string          `json:"content"`
+	Encoding string          `json:"encoding"`
+	Format   WikiFormatValue `json:"format"`
+	Slug     string          `json:"slug"`
+	Title    string          `json:"title"`
 }
 
 func (w Wiki) String() string {
@@ -77,18 +78,27 @@ func (s *WikisService) ListWikis(pid interface{}, opt *ListWikisOptions, options
 	return ws, resp, err
 }
 
+// GetWikiPageOptions represents options to GetWikiPage
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/wikis.html#get-a-wiki-page
+type GetWikiPageOptions struct {
+	RenderHTML *bool   `url:"render_html,omitempty" json:"render_html,omitempty"`
+	Version    *string `url:"version,omitempty" json:"version,omitempty"`
+}
+
 // GetWikiPage gets a wiki page for a given project.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/wikis.html#get-a-wiki-page
-func (s *WikisService) GetWikiPage(pid interface{}, slug string, options ...RequestOptionFunc) (*Wiki, *Response, error) {
+func (s *WikisService) GetWikiPage(pid interface{}, slug string, opt *GetWikiPageOptions, options ...RequestOptionFunc) (*Wiki, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/wikis/%s", PathEscape(project), url.PathEscape(slug))
 
-	req, err := s.client.NewRequest(http.MethodGet, u, nil, options)
+	req, err := s.client.NewRequest(http.MethodGet, u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/wikis_test.go
+++ b/wikis_test.go
@@ -30,21 +30,22 @@ func TestListWikis(t *testing.T) {
 		testMethod(t, r, http.MethodGet)
 		fmt.Fprintf(w, `[
 			{
-			  "content" : "Here is an instruction how to deploy this project.",
-			  "format" : "markdown",
-			  "slug" : "deploy",
-			  "title" : "deploy"
+			  "content": "Here is an instruction how to deploy this project.",
+			  "format": "markdown",
+			  "slug": "deploy",
+			  "title": "deploy"
 			},
 			{
-			  "content" : "Our development process is described here.",
-			  "format" : "markdown",
-			  "slug" : "development",
-			  "title" : "development"
-			},{
-			  "content" : "*  [Deploy](deploy)\n*  [Development](development)",
-			  "format" : "markdown",
-			  "slug" : "home",
-			  "title" : "home"
+			  "content": "Our development process is described here.",
+			  "format": "markdown",
+			  "slug": "development",
+			  "title": "development"
+			},
+			{
+			  "content": "*  [Deploy](deploy)\n*  [Development](development)",
+			  "format": "markdown",
+			  "slug": "home",
+			  "title": "home"
 			}
 		  ]`)
 	})
@@ -87,23 +88,25 @@ func TestGetWikiPage(t *testing.T) {
 	mux.HandleFunc("/api/v4/projects/1/wikis/home", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
 		fmt.Fprintf(w, `{
-			"content" : "home page",
-			"format" : "markdown",
-			"slug" : "home",
-			"title" : "home"
+			"content": "home page",
+			"format": "markdown",
+			"slug": "home",
+			"title": "home",
+			"encoding": "UTF-8"
 		  }`)
 	})
 
-	wiki, _, err := client.Wikis.GetWikiPage(1, "home")
+	wiki, _, err := client.Wikis.GetWikiPage(1, "home", &GetWikiPageOptions{})
 	if err != nil {
 		t.Errorf("Wiki.GetWikiPage returned error: %v", err)
 	}
 
 	want := &Wiki{
-		Content: "home page",
-		Format:  "markdown",
-		Slug:    "home",
-		Title:   "home",
+		Content:  "home page",
+		Encoding: "UTF-8",
+		Format:   "markdown",
+		Slug:     "home",
+		Title:    "home",
 	}
 
 	if !reflect.DeepEqual(want, wiki) {
@@ -118,10 +121,10 @@ func TestCreateWikiPage(t *testing.T) {
 	mux.HandleFunc("/api/v4/projects/1/wikis", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
 		fmt.Fprintf(w, `{
-			"content" : "Hello world",
-			"format" : "markdown",
-			"slug" : "Hello",
-			"title" : "Hello"
+			"content": "Hello world",
+			"format": "markdown",
+			"slug": "Hello",
+			"title": "Hello"
 		  }`)
 	})
 
@@ -154,10 +157,10 @@ func TestEditWikiPage(t *testing.T) {
 	mux.HandleFunc("/api/v4/projects/1/wikis/foo", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
 		fmt.Fprintf(w, `{
-			"content" : "documentation",
-			"format" : "markdown",
-			"slug" : "Docs",
-			"title" : "Docs"
+			"content": "documentation",
+			"format": "markdown",
+			"slug": "Docs",
+			"title": "Docs"
 		  }`)
 	})
 


### PR DESCRIPTION
GitLab 14.9 introduced new options for retrieving Wiki pages
- `render_html` - Return `content` as HTML
- `version` - Retrieve a wiki page at a given commit SHA

The response now also includes `encoding`. 