### PR TITLE
feat(project): Add missing 'container_registry_image_prefix' field

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -64,6 +64,7 @@ type Project struct {
 	ContainerExpirationPolicy                 *ContainerExpirationPolicy `json:"container_expiration_policy,omitempty"`
 	ContainerRegistryEnabled                  bool                       `json:"container_registry_enabled"`
 	ContainerRegistryAccessLevel              AccessControlValue         `json:"container_registry_access_level"`
+	ContainerRegistryImagePrefix              string                     `json:"container_registry_image_prefix,omitempty"`
 	CreatedAt                                 *time.Time                 `json:"created_at,omitempty"`
 	LastActivityAt                            *time.Time                 `json:"last_activity_at,omitempty"`
 	CreatorID                                 int                        `json:"creator_id"`


### PR DESCRIPTION
On the 13.10 Gitlab release, this `container_registry_image_prefix` field was exposed on Project API. 

[Gitlab 13.10 Changelog](https://gitlab.com/gitlab-org/gitlab/-/blob/master/CHANGELOG.md#13100-2021-03-22)

[Gitlab Merge Request](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/54090)

We will support this missing field on the `Project` golang struct in this merge request. I defined this field as `omitempty` because some people might be using older GitLab versions.