### PR TITLE
Support `shared_runners_enabled` field in group response

### DIFF
--- a/groups.go
+++ b/groups.go
@@ -62,6 +62,7 @@ type Group struct {
 	MentionsDisabled        bool                       `json:"mentions_disabled"`
 	RunnersToken            string                     `json:"runners_token"`
 	SharedProjects          []*Project                 `json:"shared_projects"`
+	SharedRunnersEnabled    bool                       `json:"shared_runners_enabled"`
 	SharedWithGroups        []struct {
 		GroupID          int      `json:"group_id"`
 		GroupName        string   `json:"group_name"`


### PR DESCRIPTION
See [docs](https://docs.gitlab.com/ee/api/groups.html#:~:text=17T07%3A47%3A25.881Z%22%2C-,%22shared_runners_enabled%22%3A%20true%2C,-%22creator_id%22%3A%201%2C%0A%20%20%20%20%20%20%22namespace)