### PR TITLE
Support `namespace_id` for `GET /users/...` as admin

### DIFF
--- a/testdata/get_user_admin.json
+++ b/testdata/get_user_admin.json
@@ -38,5 +38,6 @@
   "last_sign_in_ip": "2001:db8::68",
   "plan": "gold",
   "trial": true,
-  "sign_in_count": 1337
+  "sign_in_count": 1337,
+  "namespace_id": 42
 }

--- a/users.go
+++ b/users.go
@@ -99,6 +99,7 @@ type User struct {
 	ExtraSharedRunnersMinutesLimit int                `json:"extra_shared_runners_minutes_limit"`
 	UsingLicenseSeat               bool               `json:"using_license_seat"`
 	CustomAttributes               []*CustomAttribute `json:"custom_attributes"`
+	NamespaceID                    int                `json:"namespace_id"`
 }
 
 // UserIdentity represents a user identity.

--- a/users_test.go
+++ b/users_test.go
@@ -115,6 +115,7 @@ func TestGetUserAdmin(t *testing.T) {
 		TwoFactorEnabled: true,
 		Note:             "DMCA Request: 2018-11-05 | DMCA Violation | Abuse | https://gitlab.zendesk.com/agent/tickets/123",
 		Identities:       []*UserIdentity{{Provider: "github", ExternUID: "2435223452345"}},
+		NamespaceID:      42,
 	}
 	require.Equal(t, want, user)
 }


### PR DESCRIPTION
See the [docs](https://docs.gitlab.com/ee/api/users.html#:~:text=For%20admins-,The%20namespace_id%20field%20in%20the%20response%20was%20introduced%20in%20GitLab%2014.10.,-GET%20/users)

I've introduced this field for GitLab 14.10 and require it in the provider :)