### PR TITLE
Support endpoint to get and delete project mirror

### DIFF
--- a/project_mirror.go
+++ b/project_mirror.go
@@ -74,6 +74,31 @@ func (s *ProjectMirrorService) ListProjectMirror(pid interface{}, opt *ListProje
 	return pm, resp, err
 }
 
+// GetProjectMirror gets a single mirrors configured on the project.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/remote_mirrors.html#get-a-single-projects-remote-mirror
+func (s *ProjectMirrorService) GetProjectMirror(pid interface{}, mirror int, options ...RequestOptionFunc) (*ProjectMirror, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/remote_mirrors/%d", PathEscape(project), mirror)
+
+	req, err := s.client.NewRequest(http.MethodGet, u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pm := new(ProjectMirror)
+	resp, err := s.client.Do(req, &pm)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return pm, resp, err
+}
+
 // AddProjectMirrorOptions contains the properties requires to create
 // a new project mirror.
 //
@@ -145,4 +170,23 @@ func (s *ProjectMirrorService) EditProjectMirror(pid interface{}, mirror int, op
 	}
 
 	return pm, resp, err
+}
+
+// DeleteProjectMirror deletes a project mirror.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/remote_mirrors.html#delete-a-remote-mirror
+func (s *ProjectMirrorService) DeleteProjectMirror(pid interface{}, mirror int, options ...RequestOptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/remote_mirrors/%d", PathEscape(project), mirror)
+
+	req, err := s.client.NewRequest(http.MethodDelete, u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
 }

--- a/project_mirror.go
+++ b/project_mirror.go
@@ -74,7 +74,7 @@ func (s *ProjectMirrorService) ListProjectMirror(pid interface{}, opt *ListProje
 	return pm, resp, err
 }
 
-// GetProjectMirror gets a single mirrors configured on the project.
+// GetProjectMirror gets a single mirror configured on the project.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/remote_mirrors.html#get-a-single-projects-remote-mirror

--- a/project_mirror_test.go
+++ b/project_mirror_test.go
@@ -60,6 +60,41 @@ func TestProjectMirrorService_ListProjectMirror(t *testing.T) {
 	require.Equal(t, http.StatusNotFound, resp.StatusCode)
 }
 
+func TestProjectMirrorService_GetProjectMirror(t *testing.T) {
+	mux, server, client := setup(t)
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v4/projects/42/remote_mirrors/1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprintf(w, `
+			{
+				"enabled": true,
+				"id": 101486,
+				"last_error": null,
+				"only_protected_branches": true,
+				"keep_divergent_refs": true,
+				"update_status": "finished",
+				"url": "https://*****:*****@gitlab.com/gitlab-org/security/gitlab.git"
+			}
+		`)
+	})
+
+	want := &ProjectMirror{
+		Enabled:               true,
+		ID:                    101486,
+		LastError:             "",
+		OnlyProtectedBranches: true,
+		KeepDivergentRefs:     true,
+		UpdateStatus:          "finished",
+		URL:                   "https://*****:*****@gitlab.com/gitlab-org/security/gitlab.git",
+	}
+
+	pm, resp, err := client.ProjectMirrors.GetProjectMirror(42, 1, nil)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, want, pm)
+}
+
 func TestProjectMirrorService_AddProjectMirror(t *testing.T) {
 	mux, server, client := setup(t)
 	defer teardown(server)


### PR DESCRIPTION
I have recently introduced this in GitLab 14.10:

* https://docs.gitlab.com/ee/api/remote_mirrors.html#get-a-single-projects-remote-mirror
* https://docs.gitlab.com/ee/api/remote_mirrors.html#delete-a-remote-mirror