### PR TITLE
Adding tokens LastUsedAt field

### DIFF
--- a/group_access_tokens.go
+++ b/group_access_tokens.go
@@ -40,6 +40,7 @@ type GroupAccessToken struct {
 	Scopes      []string         `json:"scopes"`
 	CreatedAt   *time.Time       `json:"created_at"`
 	ExpiresAt   *ISOTime         `json:"expires_at"`
+	LastUsedAt  *time.Time       `json:"last_used_at"`
 	Active      bool             `json:"active"`
 	Revoked     bool             `json:"revoked"`
 	Token       string           `json:"token"`

--- a/group_access_tokens_test.go
+++ b/group_access_tokens_test.go
@@ -45,6 +45,10 @@ func TestListGroupAccessTokens(t *testing.T) {
 	if err != nil {
 		t.Errorf("GroupAccessTokens.ListGroupAccessTokens returned error: %v", err)
 	}
+	time3, err := time.Parse(time.RFC3339, "2021-03-10T21:11:47.271Z")
+	if err != nil {
+		t.Errorf("GroupAccessTokens.ListGroupAccessTokens returned error: %v", err)
+	}
 
 	want := []*GroupAccessToken{
 		{
@@ -53,6 +57,7 @@ func TestListGroupAccessTokens(t *testing.T) {
 			Name:        "token 10",
 			Scopes:      []string{"api", "read_api", "read_repository", "write_repository"},
 			CreatedAt:   &time1,
+			LastUsedAt:  &time3,
 			Active:      true,
 			Revoked:     false,
 			AccessLevel: AccessLevelValue(40),

--- a/project_access_tokens.go
+++ b/project_access_tokens.go
@@ -39,6 +39,7 @@ type ProjectAccessToken struct {
 	Name        string           `json:"name"`
 	Scopes      []string         `json:"scopes"`
 	CreatedAt   *time.Time       `json:"created_at"`
+	LastUsedAt  *time.Time       `json:"last_used_at"`
 	ExpiresAt   *ISOTime         `json:"expires_at"`
 	Active      bool             `json:"active"`
 	Revoked     bool             `json:"revoked"`

--- a/project_access_tokens_test.go
+++ b/project_access_tokens_test.go
@@ -45,6 +45,10 @@ func TestListProjectAccessTokens(t *testing.T) {
 	if err != nil {
 		t.Errorf("ProjectAccessTokens.ListProjectAccessTokens returned error: %v", err)
 	}
+	time3, err := time.Parse(time.RFC3339, "2021-03-10T21:11:47.271Z")
+	if err != nil {
+		t.Errorf("GroupAccessTokens.ListGroupAccessTokens returned error: %v", err)
+	}
 
 	want := []*ProjectAccessToken{
 		{
@@ -53,6 +57,7 @@ func TestListProjectAccessTokens(t *testing.T) {
 			Name:        "token 10",
 			Scopes:      []string{"api", "read_api", "read_repository", "write_repository"},
 			CreatedAt:   &time1,
+			LastUsedAt:  &time3,
 			Active:      true,
 			Revoked:     false,
 			AccessLevel: AccessLevelValue(40),

--- a/testdata/list_group_access_tokens.json
+++ b/testdata/list_group_access_tokens.json
@@ -4,6 +4,7 @@
     "name": "token 10",
     "revoked": false,
     "created_at": "2021-03-09T21:11:47.271Z",
+    "last_used_at": "2021-03-10T21:11:47.271Z",
     "scopes": ["api", "read_api", "read_repository", "write_repository"],
     "user_id": 2453,
     "active": true,

--- a/testdata/list_project_access_tokens.json
+++ b/testdata/list_project_access_tokens.json
@@ -4,6 +4,7 @@
     "name": "token 10",
     "revoked": false,
     "created_at": "2021-03-09T21:11:47.271Z",
+    "last_used_at": "2021-03-10T21:11:47.271Z",
     "scopes": ["api", "read_api", "read_repository", "write_repository"],
     "user_id": 2453,
     "active": true,


### PR DESCRIPTION
* The field isn't documented in the official documentation, but found in both project and group access tokens responses.
* `last_used_at: null` is returned in case the token was never used.
* Personal access token doesn't have this field.