### PR TITLE
Update runner struct and APIs based on deprecated values

### DIFF
--- a/runners.go
+++ b/runners.go
@@ -37,6 +37,7 @@ type Runner struct {
 	ID          int    `json:"id"`
 	Description string `json:"description"`
 	Active      bool   `json:"active"`
+	Paused      bool   `json:"paused"`
 	IsShared    bool   `json:"is_shared"`
 	IPAddress   string `json:"ip_address"`
 	RunnerType  string `json:"runner_type"`
@@ -47,10 +48,14 @@ type Runner struct {
 }
 
 // RunnerDetails represents the GitLab CI runner details.
+// 
+// "Active" and "Scope" have been deprecated by GitLab. Use "Paused" and "Status" respectively.
+// They will be removed in GitLab 16.0
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/runners.html
 type RunnerDetails struct {
 	Active       bool       `json:"active"`
+	Paused       bool       `json:"paused"`
 	Architecture string     `json:"architecture"`
 	Description  string     `json:"description"`
 	ID           int        `json:"id"`
@@ -93,6 +98,7 @@ type ListRunnersOptions struct {
 	Scope   *string   `url:"scope,omitempty" json:"scope,omitempty"`
 	Type    *string   `url:"type,omitempty" json:"type,omitempty"`
 	Status  *string   `url:"status,omitempty" json:"status,omitempty"`
+	Paused  *bool     `url:"paused,omitempty" json:"paused,omitempty"`
 	TagList *[]string `url:"tag_list,comma,omitempty" json:"tag_list,omitempty"`
 }
 
@@ -162,11 +168,14 @@ func (s *RunnersService) GetRunnerDetails(rid interface{}, options ...RequestOpt
 
 // UpdateRunnerDetailsOptions represents the available UpdateRunnerDetails() options.
 //
+// "Active" in deprecated, use "Paused" instead. "Active" will be removed in GitLab 16.0
+//
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/runners.html#update-runner-39-s-details
 type UpdateRunnerDetailsOptions struct {
 	Description    *string   `url:"description,omitempty" json:"description,omitempty"`
 	Active         *bool     `url:"active,omitempty" json:"active,omitempty"`
+	Paused         *bool     `url:"paused,omitempty" json:"paused,omitempty"`
 	TagList        *[]string `url:"tag_list[],omitempty" json:"tag_list,omitempty"`
 	RunUntagged    *bool     `url:"run_untagged,omitempty" json:"run_untagged,omitempty"`
 	Locked         *bool     `url:"locked,omitempty" json:"locked,omitempty"`
@@ -384,14 +393,17 @@ func (s *RunnersService) ListGroupsRunners(gid interface{}, opt *ListGroupsRunne
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/runners.html#register-a-new-runner
 type RegisterNewRunnerOptions struct {
-	Token          *string                       `url:"token" json:"token"`
-	Description    *string                       `url:"description,omitempty" json:"description,omitempty"`
-	Info           *RegisterNewRunnerInfoOptions `url:"info,omitempty" json:"info,omitempty"`
-	Active         *bool                         `url:"active,omitempty" json:"active,omitempty"`
-	Locked         *bool                         `url:"locked,omitempty" json:"locked,omitempty"`
-	RunUntagged    *bool                         `url:"run_untagged,omitempty" json:"run_untagged,omitempty"`
-	TagList        *[]string                     `url:"tag_list[],omitempty" json:"tag_list,omitempty"`
-	MaximumTimeout *int                          `url:"maximum_timeout,omitempty" json:"maximum_timeout,omitempty"`
+	Token           *string                       `url:"token" json:"token"`
+	Description     *string                       `url:"description,omitempty" json:"description,omitempty"`
+	Info            *RegisterNewRunnerInfoOptions `url:"info,omitempty" json:"info,omitempty"`
+	Active          *bool                         `url:"active,omitempty" json:"active,omitempty"`
+	Paused          *bool                         `url:"paused,omitempty" json:"paused,omitempty"`
+	Locked          *bool                         `url:"locked,omitempty" json:"locked,omitempty"`
+	RunUntagged     *bool                         `url:"run_untagged,omitempty" json:"run_untagged,omitempty"`
+	TagList         *[]string                     `url:"tag_list[],omitempty" json:"tag_list,omitempty"`
+	AccessLevel     *string                       `url:"access_level,omitempty" json:"access_level,omitempty"`
+	MaximumTimeout  *int                          `url:"maximum_timeout,omitempty" json:"maximum_timeout,omitempty"`
+	MaintenanceNote *string                       `url:"maintenance_note,omitempty" json:"maintenance_note,omitempty"`
 }
 
 // RegisterNewRunnerInfoOptions represents the info hashmap parameter in

--- a/runners.go
+++ b/runners.go
@@ -48,13 +48,9 @@ type Runner struct {
 }
 
 // RunnerDetails represents the GitLab CI runner details.
-// 
-// "Active" and "Scope" have been deprecated by GitLab. Use "Paused" and "Status" respectively.
-// They will be removed in GitLab 16.0
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/runners.html
 type RunnerDetails struct {
-	Active       bool       `json:"active"`
 	Paused       bool       `json:"paused"`
 	Architecture string     `json:"architecture"`
 	Description  string     `json:"description"`
@@ -87,6 +83,9 @@ type RunnerDetails struct {
 		Name   string `json:"name"`
 		WebURL string `json:"web_url"`
 	} `json:"groups"`
+
+	// Deprecated members
+	Active bool `json:"active"`
 }
 
 // ListRunnersOptions represents the available ListRunners() options.
@@ -95,11 +94,13 @@ type RunnerDetails struct {
 // https://docs.gitlab.com/ce/api/runners.html#list-owned-runners
 type ListRunnersOptions struct {
 	ListOptions
-	Scope   *string   `url:"scope,omitempty" json:"scope,omitempty"`
 	Type    *string   `url:"type,omitempty" json:"type,omitempty"`
 	Status  *string   `url:"status,omitempty" json:"status,omitempty"`
 	Paused  *bool     `url:"paused,omitempty" json:"paused,omitempty"`
 	TagList *[]string `url:"tag_list,comma,omitempty" json:"tag_list,omitempty"`
+
+	// Deprecated members
+	Scope *string `url:"scope,omitempty" json:"scope,omitempty"`
 }
 
 // ListRunners gets a list of runners accessible by the authenticated user.
@@ -168,19 +169,19 @@ func (s *RunnersService) GetRunnerDetails(rid interface{}, options ...RequestOpt
 
 // UpdateRunnerDetailsOptions represents the available UpdateRunnerDetails() options.
 //
-// "Active" is deprecated, use "Paused" instead. "Active" will be removed in GitLab 16.0
-//
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/runners.html#update-runner-39-s-details
 type UpdateRunnerDetailsOptions struct {
 	Description    *string   `url:"description,omitempty" json:"description,omitempty"`
-	Active         *bool     `url:"active,omitempty" json:"active,omitempty"`
 	Paused         *bool     `url:"paused,omitempty" json:"paused,omitempty"`
 	TagList        *[]string `url:"tag_list[],omitempty" json:"tag_list,omitempty"`
 	RunUntagged    *bool     `url:"run_untagged,omitempty" json:"run_untagged,omitempty"`
 	Locked         *bool     `url:"locked,omitempty" json:"locked,omitempty"`
 	AccessLevel    *string   `url:"access_level,omitempty" json:"access_level,omitempty"`
 	MaximumTimeout *int      `url:"maximum_timeout,omitempty" json:"maximum_timeout,omitempty"`
+
+	// Deprecated members
+	Active *bool `url:"active,omitempty" json:"active,omitempty"`
 }
 
 // UpdateRunnerDetails updates details for a given runner.

--- a/runners.go
+++ b/runners.go
@@ -168,7 +168,7 @@ func (s *RunnersService) GetRunnerDetails(rid interface{}, options ...RequestOpt
 
 // UpdateRunnerDetailsOptions represents the available UpdateRunnerDetails() options.
 //
-// "Active" in deprecated, use "Paused" instead. "Active" will be removed in GitLab 16.0
+// "Active" is deprecated, use "Paused" instead. "Active" will be removed in GitLab 16.0
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/runners.html#update-runner-39-s-details

--- a/tags.go
+++ b/tags.go
@@ -125,7 +125,8 @@ type CreateTagOptions struct {
 	TagName *string `url:"tag_name,omitempty" json:"tag_name,omitempty"`
 	Ref     *string `url:"ref,omitempty" json:"ref,omitempty"`
 	Message *string `url:"message,omitempty" json:"message,omitempty"`
-	// ReleaseDescription parameter was deprecated in GitLab 11.7
+
+	// Deprecated members
 	ReleaseDescription *string `url:"release_description:omitempty" json:"release_description,omitempty"`
 }
 


### PR DESCRIPTION
This PR adds the "paused" value to the runner and runner details structs. It also adds several new fields to the RegisterNewRunnerOptions struc. I added a deprecation note to the details structs around the "Active" value, but since the deprecation notice for those fields is over 1 year out, I left them in place.

This aligns the RegisterNewRunnerOptions struct to the GitLab API documentation: https://docs.gitlab.com/ee/api/runners.html#register-a-new-runner

I know there have been conversations around alphabetical vs GitLab API ordering, I maintained the GitLab API ordering for this PR.

Closes #1444

Let me know if you have any questions!