### PR TITLE
Add "bot" support for Users API

### DIFF
--- a/users.go
+++ b/users.go
@@ -75,6 +75,7 @@ type User struct {
 	WebsiteURL                     string             `json:"website_url"`
 	Organization                   string             `json:"organization"`
 	JobTitle                       string             `json:"job_title"`
+	Bot                            bool               `json:"bot"`
 	ExternUID                      string             `json:"extern_uid"`
 	Provider                       string             `json:"provider"`
 	ThemeID                        int                `json:"theme_id"`
@@ -131,6 +132,7 @@ type ListUsersOptions struct {
 	External             *bool      `url:"external,omitempty" json:"external,omitempty"`
 	WithoutProjects      *bool      `url:"without_projects,omitempty" json:"without_projects,omitempty"`
 	WithCustomAttributes *bool      `url:"with_custom_attributes,omitempty" json:"with_custom_attributes,omitempty"`
+	WithoutProjectBots   *bool      `url:"without_project_bots,omitempty" json:"without_project_bots,omitempty"`
 }
 
 // ListUsers gets a list of users.

--- a/users.go
+++ b/users.go
@@ -67,6 +67,7 @@ type User struct {
 	WebURL                         string             `json:"web_url"`
 	CreatedAt                      *time.Time         `json:"created_at"`
 	Bio                            string             `json:"bio"`
+	Bot                            bool               `json:"bot"`
 	Location                       string             `json:"location"`
 	PublicEmail                    string             `json:"public_email"`
 	Skype                          string             `json:"skype"`
@@ -75,7 +76,6 @@ type User struct {
 	WebsiteURL                     string             `json:"website_url"`
 	Organization                   string             `json:"organization"`
 	JobTitle                       string             `json:"job_title"`
-	Bot                            bool               `json:"bot"`
 	ExternUID                      string             `json:"extern_uid"`
 	Provider                       string             `json:"provider"`
 	ThemeID                        int                `json:"theme_id"`


### PR DESCRIPTION
Since Project Access Token and Group Access Token, there is a "bot"
field in the User json structure returned by the API.

See: https://docs.gitlab.com/ee/api/users.html#single-user

Also, from 14.10 it is possible to exclude bots from search result using
the "without_project_bots" boolean request parameter.

It has been added in the ListUsersOptions struct.