### PR TITLE
Added attribute BuildEvent.BuildCreatedAt on webhook model

### DIFF
--- a/event_parsing_webhook_test.go
+++ b/event_parsing_webhook_test.go
@@ -65,6 +65,10 @@ func TestParseBuildHook(t *testing.T) {
 	if event.Commit.SHA != "2293ada6b400935a1378653304eaf6221e0fdb8f" {
 		t.Errorf("Commit SHA is %v, want %v", event.Commit.SHA, "2293ada6b400935a1378653304eaf6221e0fdb8f")
 	}
+
+	if event.BuildCreatedAt != "2021-02-23T02:41:37.886Z" {
+		t.Errorf("BuildCreatedAt is %s, want %s", event.User.Name, expectedName)
+	}
 }
 
 func TestParseCommitCommentHook(t *testing.T) {

--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -37,6 +37,7 @@ type BuildEvent struct {
 	BuildName         string     `json:"build_name"`
 	BuildStage        string     `json:"build_stage"`
 	BuildStatus       string     `json:"build_status"`
+	BuildCreatedAt    string     `json:"build_created_at"`
 	BuildStartedAt    string     `json:"build_started_at"`
 	BuildFinishedAt   string     `json:"build_finished_at"`
 	BuildDuration     float64    `json:"build_duration"`

--- a/event_webhook_types_test.go
+++ b/event_webhook_types_test.go
@@ -55,6 +55,10 @@ func TestBuildEventUnmarshal(t *testing.T) {
 	if event.User.Name != expectedName {
 		t.Errorf("Username is %s, want %s", event.User.Name, expectedName)
 	}
+
+	if event.BuildCreatedAt != "2021-02-23T02:41:37.886Z" {
+		t.Errorf("BuildCreatedAt is %s, want %s", event.User.Name, expectedName)
+	}
 }
 
 func TestDeploymentEventUnmarshal(t *testing.T) {

--- a/testdata/webhooks/build.json
+++ b/testdata/webhooks/build.json
@@ -8,6 +8,7 @@
   "build_name": "test",
   "build_stage": "test",
   "build_status": "created",
+  "build_created_at": "2021-02-23T02:41:37.886Z",
   "build_started_at": null,
   "build_finished_at": null,
   "build_duration": null,
@@ -44,8 +45,14 @@
   },
   "runner": {
     "active": true,
+    "runner_type": "project_type",
     "is_shared": false,
     "id": 380987,
-    "description": "shared-runners-manager-6.gitlab.com"
-  }
+    "description": "shared-runners-manager-6.gitlab.com",
+    "tags": [
+      "linux",
+      "docker"
+    ]
+  },
+  "environment": null
 }


### PR DESCRIPTION
This PR adds the missing attribute BuildCreatedAt (mapped from build_created_at) on BuildEvent of the webhook model.