### PR TITLE
Add support for environment tiers

### DIFF
--- a/environments.go
+++ b/environments.go
@@ -38,6 +38,7 @@ type Environment struct {
 	Name           string      `json:"name"`
 	Slug           string      `json:"slug"`
 	State          string      `json:"state"`
+	Tier           string      `json:"tier"`
 	ExternalURL    string      `json:"external_url"`
 	Project        *Project    `json:"project"`
 	CreatedAt      *time.Time  `json:"created_at"`
@@ -118,6 +119,7 @@ func (s *EnvironmentsService) GetEnvironment(pid interface{}, environment int, o
 type CreateEnvironmentOptions struct {
 	Name        *string `url:"name,omitempty" json:"name,omitempty"`
 	ExternalURL *string `url:"external_url,omitempty" json:"external_url,omitempty"`
+	Tier        *string `url:"tier,omitempty" json:"tier,omitempty"`
 }
 
 // CreateEnvironment adds an environment to a project. This is an idempotent
@@ -155,6 +157,7 @@ func (s *EnvironmentsService) CreateEnvironment(pid interface{}, opt *CreateEnvi
 type EditEnvironmentOptions struct {
 	Name        *string `url:"name,omitempty" json:"name,omitempty"`
 	ExternalURL *string `url:"external_url,omitempty" json:"external_url,omitempty"`
+	Tier        *string `url:"tier,omitempty" json:"tier,omitempty"`
 }
 
 // EditEnvironment updates a project team environment to a specified access level..

--- a/environments_test.go
+++ b/environments_test.go
@@ -114,15 +114,15 @@ func TestCreateEnvironment(t *testing.T) {
 	mux.HandleFunc("/api/v4/projects/1/environments", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
 		testURL(t, r, "/api/v4/projects/1/environments")
-		fmt.Fprint(w, `{"id": 1,"name": "deploy", "slug": "deploy", "external_url": "https://deploy.example.gitlab.com"}`)
+		fmt.Fprint(w, `{"id": 1,"name": "deploy", "slug": "deploy", "external_url": "https://deploy.example.gitlab.com", "tier": "production"}`)
 	})
 
-	envs, _, err := client.Environments.CreateEnvironment(1, &CreateEnvironmentOptions{Name: String("deploy"), ExternalURL: String("https://deploy.example.gitlab.com")})
+	envs, _, err := client.Environments.CreateEnvironment(1, &CreateEnvironmentOptions{Name: String("deploy"), ExternalURL: String("https://deploy.example.gitlab.com"), Tier: String("production")})
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	want := &Environment{ID: 1, Name: "deploy", Slug: "deploy", ExternalURL: "https://deploy.example.gitlab.com"}
+	want := &Environment{ID: 1, Name: "deploy", Slug: "deploy", ExternalURL: "https://deploy.example.gitlab.com", Tier: "production"}
 	if !reflect.DeepEqual(want, envs) {
 		t.Errorf("Environments.CreateEnvironment returned %+v, want %+v", envs, want)
 	}
@@ -135,15 +135,15 @@ func TestEditEnvironment(t *testing.T) {
 	mux.HandleFunc("/api/v4/projects/1/environments/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
 		testURL(t, r, "/api/v4/projects/1/environments/1")
-		fmt.Fprint(w, `{"id": 1,"name": "staging", "slug": "staging", "external_url": "https://staging.example.gitlab.com"}`)
+		fmt.Fprint(w, `{"id": 1,"name": "staging", "slug": "staging", "external_url": "https://staging.example.gitlab.com", "tier": "staging"}`)
 	})
 
-	envs, _, err := client.Environments.EditEnvironment(1, 1, &EditEnvironmentOptions{Name: String("staging"), ExternalURL: String("https://staging.example.gitlab.com")})
+	envs, _, err := client.Environments.EditEnvironment(1, 1, &EditEnvironmentOptions{Name: String("staging"), ExternalURL: String("https://staging.example.gitlab.com"), Tier: String("staging")})
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	want := &Environment{ID: 1, Name: "staging", Slug: "staging", ExternalURL: "https://staging.example.gitlab.com"}
+	want := &Environment{ID: 1, Name: "staging", Slug: "staging", ExternalURL: "https://staging.example.gitlab.com", Tier: "staging"}
 	if !reflect.DeepEqual(want, envs) {
 		t.Errorf("Environments.EditEnvironment returned %+v, want %+v", envs, want)
 	}


### PR DESCRIPTION
This PR adds support for obtaining and specifying the deployment tier when reading/creating/updating project environments.

Support for deployment tiers was added in Gitlab 13.10.[^1][^2]

[^1]: https://docs.gitlab.com/ee/ci/environments/#deployment-tier-of-environments
[^2]: https://docs.gitlab.com/ee/api/environments.html#create-a-new-environment