### PR TITLE
Add avatar upload/download function for GroupsService

### DIFF
--- a/groups.go
+++ b/groups.go
@@ -17,7 +17,9 @@
 package gitlab
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"net/http"
 	"time"
 )
@@ -880,4 +882,67 @@ func (s *GroupsService) DeleteGroupPushRule(gid interface{}, options ...RequestO
 	}
 
 	return s.client.Do(req, nil)
+}
+
+type GroupAvatar struct {
+	Filename string
+	Image    io.Reader
+}
+
+// UploadAvatar upload a group avatar.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/groups.html#upload-a-group-avatar
+func (s *GroupsService) UploadAvatar(gid interface{}, avatar io.Reader, filename string, options ...RequestOptionFunc) (*Group, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s", PathEscape(group))
+
+	req, err := s.client.UploadRequest(
+		http.MethodPut,
+		u,
+		avatar,
+		filename,
+		UploadAvatar,
+		nil,
+		options,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	g := new(Group)
+	resp, err := s.client.Do(req, g)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return g, resp, err
+}
+
+// DownloadAvatar download a group avatar.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/groups.html#download-a-group-avatar
+func (s *GroupsService) DownloadAvatar(gid interface{}, options ...RequestOptionFunc) ([]byte, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/avatar", PathEscape(group))
+
+	req, err := s.client.NewRequest(http.MethodGet, u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var b bytes.Buffer
+	resp, err := s.client.Do(req, &b)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return b.Bytes(), resp, err
 }

--- a/projects.go
+++ b/projects.go
@@ -695,6 +695,9 @@ type ContainerExpirationPolicyAttributes struct {
 	NameRegex *string `url:"name_regex,omitempty" json:"name_regex,omitempty"`
 }
 
+// ProjectAvatar represents a GitLab project avatar.
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/projects.html#create-project
 type ProjectAvatar struct {
 	Filename string
 	Image    io.Reader


### PR DESCRIPTION
I've added `Upload` and `Download` functions for GroupsService accordingly to Gitlab API:

- [upload group avatar](https://docs.gitlab.com/ee/api/groups.html#upload-a-group-avatar)
- [download group avatar](https://docs.gitlab.com/ee/api/groups.html#download-a-group-avatar)