### PR TITLE
Add support to the field failure_reason

### DIFF
--- a/jobs.go
+++ b/jobs.go
@@ -47,7 +47,6 @@ type Job struct {
 	TagList           []string   `json:"tag_list"`
 	ID                int        `json:"id"`
 	Name              string     `json:"name"`
-	FailureReason     string     `json:"failure_reason"`
 	Pipeline          struct {
 		ID     int    `json:"id"`
 		Ref    string `json:"ref"`
@@ -72,12 +71,13 @@ type Job struct {
 		IsShared    bool   `json:"is_shared"`
 		Name        string `json:"name"`
 	} `json:"runner"`
-	Stage   string   `json:"stage"`
-	Status  string   `json:"status"`
-	Tag     bool     `json:"tag"`
-	WebURL  string   `json:"web_url"`
-	Project *Project `json:"project"`
-	User    *User    `json:"user"`
+	Stage         string   `json:"stage"`
+	Status        string   `json:"status"`
+	FailureReason string   `json:"failure_reason"`
+	Tag           bool     `json:"tag"`
+	WebURL        string   `json:"web_url"`
+	Project       *Project `json:"project"`
+	User          *User    `json:"user"`
 }
 
 // Bridge represents a pipeline bridge.

--- a/jobs.go
+++ b/jobs.go
@@ -47,6 +47,7 @@ type Job struct {
 	TagList           []string   `json:"tag_list"`
 	ID                int        `json:"id"`
 	Name              string     `json:"name"`
+	FailureReason     string     `json:"failure_reason"`
 	Pipeline          struct {
 		ID     int    `json:"id"`
 		Ref    string `json:"ref"`

--- a/jobs_test.go
+++ b/jobs_test.go
@@ -77,9 +77,9 @@ func TestJobsService_ListProjectJobs(t *testing.T) {
     "ref": "master",
     "stage": "test",
     "status": "failed",
+	  "failure_reason": "script_failure",
     "tag": false,
-    "web_url": "https://example.com/foo/bar/-/jobs/7",
-	"failure_reason": "script_failure"
+    "web_url": "https://example.com/foo/bar/-/jobs/7"
   },
   {
     "commit": {
@@ -119,36 +119,37 @@ func TestJobsService_ListProjectJobs(t *testing.T) {
 		t.Errorf("Jobs.ListProjectJobs returned error: %v", err)
 	}
 
-	want := []*Job{{
-		Commit: &Commit{
-			ID:          "0ff3ae198f8601a285adcf5c0fff204ee6fba5fd",
-			ShortID:     "0ff3ae19",
-			Title:       "Test the CI integration.",
-			AuthorName:  "Administrator",
-			AuthorEmail: "admin@example.com",
+	want := []*Job{
+		{
+			Commit: &Commit{
+				ID:          "0ff3ae198f8601a285adcf5c0fff204ee6fba5fd",
+				ShortID:     "0ff3ae19",
+				Title:       "Test the CI integration.",
+				AuthorName:  "Administrator",
+				AuthorEmail: "admin@example.com",
+			},
+			AllowFailure: false,
+			ID:           7,
+			Name:         "teaspoon",
+			TagList:      []string{"docker runner", "ubuntu18"},
+			Pipeline: struct {
+				ID     int    `json:"id"`
+				Ref    string `json:"ref"`
+				Sha    string `json:"sha"`
+				Status string `json:"status"`
+			}{
+				ID:     6,
+				Ref:    "master",
+				Sha:    "0ff3ae198f8601a285adcf5c0fff204ee6fba5fd",
+				Status: "pending",
+			},
+			Ref:           "master",
+			Stage:         "test",
+			Status:        "failed",
+			FailureReason: "script_failure",
+			Tag:           false,
+			WebURL:        "https://example.com/foo/bar/-/jobs/7",
 		},
-		AllowFailure: false,
-		ID:           7,
-		Name:         "teaspoon",
-		TagList:      []string{"docker runner", "ubuntu18"},
-		Pipeline: struct {
-			ID     int    `json:"id"`
-			Ref    string `json:"ref"`
-			Sha    string `json:"sha"`
-			Status string `json:"status"`
-		}{
-			ID:     6,
-			Ref:    "master",
-			Sha:    "0ff3ae198f8601a285adcf5c0fff204ee6fba5fd",
-			Status: "pending",
-		},
-		Ref:           "master",
-		Stage:         "test",
-		Status:        "failed",
-		Tag:           false,
-		WebURL:        "https://example.com/foo/bar/-/jobs/7",
-		FailureReason: "script_failure",
-	},
 		{
 			Commit: &Commit{
 				ID:          "0ff3ae198f8601a285adcf5c0fff204ee6fba5fd",
@@ -174,13 +175,13 @@ func TestJobsService_ListProjectJobs(t *testing.T) {
 				Sha:    "0ff3ae198f8601a285adcf5c0fff204ee6fba5fd",
 				Status: "pending",
 			},
-			Ref:           "master",
-			Stage:         "test",
-			Status:        "failed",
-			Tag:           false,
-			WebURL:        "https://example.com/foo/bar/-/jobs/6",
-			FailureReason: "",
-		}}
+			Ref:    "master",
+			Stage:  "test",
+			Status: "failed",
+			Tag:    false,
+			WebURL: "https://example.com/foo/bar/-/jobs/6",
+		},
+	}
 	assert.Equal(t, want, jobs)
 }
 

--- a/jobs_test.go
+++ b/jobs_test.go
@@ -78,7 +78,8 @@ func TestJobsService_ListProjectJobs(t *testing.T) {
     "stage": "test",
     "status": "failed",
     "tag": false,
-    "web_url": "https://example.com/foo/bar/-/jobs/7"
+    "web_url": "https://example.com/foo/bar/-/jobs/7",
+	"failure_reason": "script_failure"
   },
   {
     "commit": {
@@ -141,11 +142,12 @@ func TestJobsService_ListProjectJobs(t *testing.T) {
 			Sha:    "0ff3ae198f8601a285adcf5c0fff204ee6fba5fd",
 			Status: "pending",
 		},
-		Ref:    "master",
-		Stage:  "test",
-		Status: "failed",
-		Tag:    false,
-		WebURL: "https://example.com/foo/bar/-/jobs/7",
+		Ref:           "master",
+		Stage:         "test",
+		Status:        "failed",
+		Tag:           false,
+		WebURL:        "https://example.com/foo/bar/-/jobs/7",
+		FailureReason: "script_failure",
 	},
 		{
 			Commit: &Commit{
@@ -172,11 +174,12 @@ func TestJobsService_ListProjectJobs(t *testing.T) {
 				Sha:    "0ff3ae198f8601a285adcf5c0fff204ee6fba5fd",
 				Status: "pending",
 			},
-			Ref:    "master",
-			Stage:  "test",
-			Status: "failed",
-			Tag:    false,
-			WebURL: "https://example.com/foo/bar/-/jobs/6",
+			Ref:           "master",
+			Stage:         "test",
+			Status:        "failed",
+			Tag:           false,
+			WebURL:        "https://example.com/foo/bar/-/jobs/6",
+			FailureReason: "",
 		}}
 	assert.Equal(t, want, jobs)
 }

--- a/projects.go
+++ b/projects.go
@@ -224,8 +224,8 @@ type ProjectNamespace struct {
 	Name      string `json:"name"`
 	Path      string `json:"path"`
 	Kind      string `json:"kind"`
-	ParentID  int    `json:"parent_id"`
 	FullPath  string `json:"full_path"`
+	ParentID  int    `json:"parent_id"`
 	AvatarURL string `json:"avatar_url"`
 	WebURL    string `json:"web_url"`
 }


### PR DESCRIPTION
Following GitLab API documentation we have:
[https://docs.gitlab.com/ee/api/jobs.html](https://docs.gitlab.com/ee/api/jobs.html)

It was added a field called `failure_reason` which returns the failure reason for a given job.

Signed-off-by: Daniela Bento <danibento@overdestiny.com>