### PR TITLE
Add project member and group member user_ids option

### DIFF
--- a/group_members.go
+++ b/group_members.go
@@ -64,7 +64,8 @@ type GroupMember struct {
 // https://docs.gitlab.com/ce/api/members.html#list-all-members-of-a-group-or-project
 type ListGroupMembersOptions struct {
 	ListOptions
-	Query *string `url:"query,omitempty" json:"query,omitempty"`
+	Query   *string `url:"query,omitempty" json:"query,omitempty"`
+	UserIDs *[]int  `url:"user_ids[],omitempty" json:"user_ids,omitempty"`
 }
 
 // ListGroupMembers get a list of group members viewable by the authenticated

--- a/project_members.go
+++ b/project_members.go
@@ -36,7 +36,8 @@ type ProjectMembersService struct {
 // https://docs.gitlab.com/ce/api/members.html#list-all-members-of-a-group-or-project
 type ListProjectMembersOptions struct {
 	ListOptions
-	Query *string `url:"query,omitempty" json:"query,omitempty"`
+	Query   *string `url:"query,omitempty" json:"query,omitempty"`
+	UserIDs *[]int  `url:"user_ids[],omitempty" json:"user_ids,omitempty"`
 }
 
 // ListProjectMembers gets a list of a project's team members viewable by the


### PR DESCRIPTION
Closes #1490 

For both:
* `groups/:id/members`
* `projects/:id/members`

https://docs.gitlab.com/ee/api/members.html#list-all-members-of-a-group-or-project

 and:
 * `groups/:id/members/all` 
* `projects/:id/members/all` 

https://docs.gitlab.com/ee/api/members.html#list-all-members-of-a-group-or-project-including-inherited-and-invited-members