### PR TITLE
Idea for managed pagination into channels for resources

### DIFF
--- a/examples/projects.go
+++ b/examples/projects.go
@@ -83,7 +83,6 @@ func streamProjectExample() {
 		if err != nil {
 			log.Printf("project streaming stopped: %s", err)
 		}
-		close(projectChan)
 	}()
 
 	for p := range projectChan {

--- a/projects.go
+++ b/projects.go
@@ -335,7 +335,10 @@ func (s *ProjectsService) ListProjects(opt *ListProjectsOptions, options ...Requ
 	return p, resp, err
 }
 
+// StreamProjects is a function that manages pagination and streams back all projects accessible to the authenticated
+// user into the supplied `projectChan`. It always closes the channel given when done paginating.
 func (s *ProjectsService) StreamProjects(opt *ListProjectsOptions, projectChan chan<- *Project, options ...RequestOptionFunc) error {
+	defer close(projectChan)
 	nextPage := 1
 
 	for nextPage != 0 {


### PR DESCRIPTION
For some context I maintain a package that does this already inside of the company I work for. The semantics have proven pretty useful and seem to integrate well in this library so I thought upstreaming this could be useful to the wider community.

I have written up a sample implementation for the projects API but this can essentially be repeated for every paginated resource.
Ultimately we can also think about implementing [!815](https://github.com/xanzy/go-gitlab/issues/815) behind the scenes in this down the line :thinking: 

But before I go implement loads of endpoints I thought it's worth checking if this is desired to have this or if this should be a separate more specialised package?

Happy to have a discussion!