### PR TITLE
Add support for merged YAML return from linter

### DIFF
--- a/jobs.go
+++ b/jobs.go
@@ -103,7 +103,10 @@ type Bridge struct {
 	DownstreamPipeline *PipelineInfo `json:"downstream_pipeline"`
 }
 
-// ListJobsOptions are options for two list apis
+// ListJobsOptions represents the available ListProjectJobs() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/jobs.html#list-project-jobs
 type ListJobsOptions struct {
 	ListOptions
 	Scope          *[]BuildStateValue `url:"scope[],omitempty" json:"scope,omitempty"`

--- a/validate.go
+++ b/validate.go
@@ -29,6 +29,15 @@ type ValidateService struct {
 	client *Client
 }
 
+// LintOptions represent options for the lint API
+//
+// Gitlab API docs: https://docs.gitlab.com/ee/api/lint.html#validate-the-ci-yaml-configuration
+type LintOptions struct {
+	Content           string `url:"content,omitempty" json:"content,omitempty"`
+	IncludeMergedYAML bool   `url:"include_merged_yaml,omitempty" json:"include_merged_yaml,omitempty"`
+	IncludeJobs       bool   `url:"include_jobs,omitempty" json:"include_jobs,omitempty"`
+}
+
 // LintResult represents the linting results.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/lint.html
@@ -73,17 +82,10 @@ func (s *ValidateService) Lint(content string, options ...RequestOptionFunc) (*L
 	return l, resp, nil
 }
 
-// LintWithMergedYAML validates .gitlab-ci.yml content and returns the merged YAML
+// LintWithOptions validates .gitlab-ci.yml content with API Options
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/lint.html
-func (s *ValidateService) LintWithMergedYAML(content string, options ...RequestOptionFunc) (*LintResult, *Response, error) {
-	var opts struct {
-		Content           string `url:"content,omitempty" json:"content,omitempty"`
-		IncludeMergedYAML bool   `url:"include_merged_yaml,omitempty" json:"include_merged_yaml,omitempty"`
-	}
-	opts.Content = content
-	opts.IncludeMergedYAML = true
-
+func (s *ValidateService) LintWithOptions(opts *LintOptions, options ...RequestOptionFunc) (*LintResult, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodPost, "ci/lint", &opts, options)
 	if err != nil {
 		return nil, nil, err

--- a/validate.go
+++ b/validate.go
@@ -73,6 +73,31 @@ func (s *ValidateService) Lint(content string, options ...RequestOptionFunc) (*L
 	return l, resp, nil
 }
 
+// LintWithMergedYAML validates .gitlab-ci.yml content and returns the merged YAML
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/lint.html
+func (s *ValidateService) LintWithMergedYAML(content string, options ...RequestOptionFunc) (*LintResult, *Response, error) {
+	var opts struct {
+		Content           string `url:"content,omitempty" json:"content,omitempty"`
+		IncludeMergedYAML bool   `url:"include_merged_yaml,omitempty" json:"include_merged_yaml,omitempty"`
+	}
+	opts.Content = content
+	opts.IncludeMergedYAML = true
+
+	req, err := s.client.NewRequest(http.MethodPost, "ci/lint", &opts, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	l := new(LintResult)
+	resp, err := s.client.Do(req, l)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return l, resp, nil
+}
+
 // ProjectNamespaceLintOptions represents the available ProjectNamespaceLint() options.
 //
 // GitLab API docs:

--- a/validate.go
+++ b/validate.go
@@ -29,15 +29,6 @@ type ValidateService struct {
 	client *Client
 }
 
-// LintOptions represent options for the lint API
-//
-// Gitlab API docs: https://docs.gitlab.com/ee/api/lint.html#validate-the-ci-yaml-configuration
-type LintOptions struct {
-	Content           string `url:"content,omitempty" json:"content,omitempty"`
-	IncludeMergedYAML bool   `url:"include_merged_yaml,omitempty" json:"include_merged_yaml,omitempty"`
-	IncludeJobs       bool   `url:"include_jobs,omitempty" json:"include_jobs,omitempty"`
-}
-
 // LintResult represents the linting results.
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/lint.html
@@ -59,33 +50,21 @@ type ProjectLintResult struct {
 	MergedYaml string   `json:"merged_yaml"`
 }
 
-// Lint validates .gitlab-ci.yml content.
+// LintOptions represents the available Lint() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/lint.html
-func (s *ValidateService) Lint(content string, options ...RequestOptionFunc) (*LintResult, *Response, error) {
-	var opts struct {
-		Content string `url:"content,omitempty" json:"content,omitempty"`
-	}
-	opts.Content = content
-
-	req, err := s.client.NewRequest(http.MethodPost, "ci/lint", &opts, options)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	l := new(LintResult)
-	resp, err := s.client.Do(req, l)
-	if err != nil {
-		return nil, resp, err
-	}
-
-	return l, resp, nil
+// Gitlab API docs:
+// https://docs.gitlab.com/ee/api/lint.html#validate-the-ci-yaml-configuration
+type LintOptions struct {
+	Content           string `url:"content,omitempty" json:"content,omitempty"`
+	IncludeMergedYAML bool   `url:"include_merged_yaml,omitempty" json:"include_merged_yaml,omitempty"`
+	IncludeJobs       bool   `url:"include_jobs,omitempty" json:"include_jobs,omitempty"`
 }
 
-// LintWithOptions validates .gitlab-ci.yml content with API Options
+// Lint validates .gitlab-ci.yml content.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/lint.html
-func (s *ValidateService) LintWithOptions(opts *LintOptions, options ...RequestOptionFunc) (*LintResult, *Response, error) {
+// Gitlab API docs:
+// https://docs.gitlab.com/ee/api/lint.html#validate-the-ci-yaml-configuration
+func (s *ValidateService) Lint(opts *LintOptions, options ...RequestOptionFunc) (*LintResult, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodPost, "ci/lint", &opts, options)
 	if err != nil {
 		return nil, nil, err

--- a/validate_test.go
+++ b/validate_test.go
@@ -85,20 +85,24 @@ func TestValidate(t *testing.T) {
 	}
 }
 
-func TestValidateWithMergedYAML(t *testing.T) {
+func TestValidateWithOptions(t *testing.T) {
 	testCases := []struct {
 		description string
-		content     string
+		opts        *LintOptions
 		response    string
 		want        *LintResult
 	}{
 		{
 			description: "valid",
-			content: `
+			opts: &LintOptions{
+				Content: `
 				build1:
 					stage: build
 					script:
 						- echo "Do your build here"`,
+				IncludeMergedYAML: true,
+				IncludeJobs:       false,
+			},
 			response: `{
 				"status": "valid",
 				"errors": [],
@@ -112,9 +116,11 @@ func TestValidateWithMergedYAML(t *testing.T) {
 		},
 		{
 			description: "invalid",
-			content: `
-				build1:
-					- echo "Do your build here"`,
+			opts: &LintOptions{
+				Content: `
+					build1:
+						- echo "Do your build here"`,
+			},
 			response: `{
 				"status": "invalid",
 				"errors": ["error message when content is invalid"]
@@ -136,7 +142,7 @@ func TestValidateWithMergedYAML(t *testing.T) {
 				fmt.Fprint(w, tc.response)
 			})
 
-			got, _, err := client.Validate.LintWithMergedYAML(tc.content)
+			got, _, err := client.Validate.LintWithOptions(tc.opts)
 			if err != nil {
 				t.Errorf("Validate returned error: %v", err)
 			}

--- a/validate_test.go
+++ b/validate_test.go
@@ -26,68 +26,6 @@ import (
 func TestValidate(t *testing.T) {
 	testCases := []struct {
 		description string
-		content     string
-		response    string
-		want        *LintResult
-	}{
-		{
-			description: "valid",
-			content: `
-				build1:
-					stage: build
-					script:
-						- echo "Do your build here"`,
-			response: `{
-				"status": "valid",
-				"errors": []
-			}`,
-			want: &LintResult{
-				Status: "valid",
-				Errors: []string{},
-			},
-		},
-		{
-			description: "invalid",
-			content: `
-				build1:
-					- echo "Do your build here"`,
-			response: `{
-				"status": "invalid",
-				"errors": ["error message when content is invalid"]
-			}`,
-			want: &LintResult{
-				Status: "invalid",
-				Errors: []string{"error message when content is invalid"},
-			},
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.description, func(t *testing.T) {
-			mux, server, client := setup(t)
-			defer teardown(server)
-
-			mux.HandleFunc("/api/v4/ci/lint", func(w http.ResponseWriter, r *http.Request) {
-				testMethod(t, r, http.MethodPost)
-				fmt.Fprint(w, tc.response)
-			})
-
-			got, _, err := client.Validate.Lint(tc.content)
-			if err != nil {
-				t.Errorf("Validate returned error: %v", err)
-			}
-
-			want := tc.want
-			if !reflect.DeepEqual(got, want) {
-				t.Errorf("Validate returned \ngot:\n%v\nwant:\n%v", Stringify(got), Stringify(want))
-			}
-		})
-	}
-}
-
-func TestValidateWithOptions(t *testing.T) {
-	testCases := []struct {
-		description string
 		opts        *LintOptions
 		response    string
 		want        *LintResult
@@ -142,7 +80,7 @@ func TestValidateWithOptions(t *testing.T) {
 				fmt.Fprint(w, tc.response)
 			})
 
-			got, _, err := client.Validate.LintWithOptions(tc.opts)
+			got, _, err := client.Validate.Lint(tc.opts)
 			if err != nil {
 				t.Errorf("Validate returned error: %v", err)
 			}


### PR DESCRIPTION
The lint API requires setting the `include_merged_yaml` option to true to in order for it to return the merged YAML. Since the existing `Lint` function doesn't take options as a parameter, this adds a new function that sets that option to true. https://docs.gitlab.com/ee/api/lint.html#validate-the-ci-yaml-configuration