### PR TITLE
Add skip_confirmation option to add email API

### DIFF
--- a/users.go
+++ b/users.go
@@ -814,10 +814,10 @@ func (s *UsersService) GetEmail(email int, options ...RequestOptionFunc) (*Email
 
 // AddEmailOptions represents the available AddEmail() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#add-email
+// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#add-email
 type AddEmailOptions struct {
 	Email            *string `url:"email,omitempty" json:"email,omitempty"`
-	SkipConfirmation *bool   `url:"skiconfirmation,omitempty" json:"skiconfirmation,omitempty"`
+	SkipConfirmation *bool   `url:"skip_confirmation,omitempty" json:"skip_confirmation,omitempty"`
 }
 
 // AddEmail creates a new email owned by the currently authenticated user.

--- a/users.go
+++ b/users.go
@@ -816,7 +816,8 @@ func (s *UsersService) GetEmail(email int, options ...RequestOptionFunc) (*Email
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#add-email
 type AddEmailOptions struct {
-	Email *string `url:"email,omitempty" json:"email,omitempty"`
+	Email            *string `url:"email,omitempty" json:"email,omitempty"`
+	SkipConfirmation *bool   `url:"skiconfirmation,omitempty" json:"skiconfirmation,omitempty"`
 }
 
 // AddEmail creates a new email owned by the currently authenticated user.


### PR DESCRIPTION
According to the [Gitlab API](https://docs.gitlab.com/ee/api/users.html#add-email-for-user) I propose to add `skip_confirmation` parameter to
- AddEmail
- AddEmailForUser

`UsersService` functions.
