### PR TITLE
fixing invitations by user id

### DIFF
--- a/invites.go
+++ b/invites.go
@@ -111,6 +111,7 @@ func (s *InvitesService) ListPendingProjectInvitations(pid interface{}, opt *Lis
 type InvitesOptions struct {
 	ID          interface{}       `url:"id,omitempty" json:"id,omitempty"`
 	Email       *string           `url:"email,omitempty" json:"email,omitempty"`
+	UserID      interface{}       `url:"user_id,omitempty" json:"user_id,omitempty"`
 	AccessLevel *AccessLevelValue `url:"access_level,omitempty" json:"access_level,omitempty"`
 	ExpiresAt   *ISOTime          `url:"expires_at,omitempty" json:"expires_at,omitempty"`
 }


### PR DESCRIPTION
I was not being able to add users to a project by using their ID and after checking the code I noticed the body payload was not matching what's documented:

https://docs.gitlab.com/ee/api/invitations.html#add-a-member-to-a-group-or-project

Perhaps it had changed.

Can you please take a look? thanks 🙇  



