### PR TITLE
Fix SAML Group Links Access Level type

### DIFF
--- a/groups.go
+++ b/groups.go
@@ -105,8 +105,8 @@ type LDAPGroupLink struct {
 //
 // GitLab API docs: https://docs.gitlab.com/ce/api/groups.html#saml-group-links
 type SAMLGroupLink struct {
-	Name        string `json:"name"`
-	AccessLevel string `json:"access_level"`
+	Name        string           `json:"name"`
+	AccessLevel AccessLevelValue `json:"access_level"`
 }
 
 // ListGroupsOptions represents the available ListGroups() options.
@@ -810,8 +810,8 @@ func (s *GroupsService) GetGroupSAMLLink(gid interface{}, samlGroupName string, 
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/groups.html#add-saml-group-link
 type AddGroupSAMLLinkOptions struct {
-	SAMLGroupName *string `url:"saml_group_name,omitempty" json:"saml_group_name,omitempty"`
-	AccessLevel   *string `url:"access_level,omitempty" json:"access_level,omitempty"`
+	SAMLGroupName *string           `url:"saml_group_name,omitempty" json:"saml_group_name,omitempty"`
+	AccessLevel   *AccessLevelValue `url:"access_level,omitempty" json:"access_level,omitempty"`
 }
 
 // AddGroupSAMLLink creates a new group SAML link. Available only for users who

--- a/groups_test.go
+++ b/groups_test.go
@@ -373,11 +373,11 @@ func TestListGroupSAMLLinks(t *testing.T) {
 			testMethod(t, r, http.MethodGet)
 			fmt.Fprint(w, `[
 	{
-		"access_level":"Developer",
+		"access_level":30,
 		"name":"gitlab_group_example_developer"
 	},
 	{
-		"access_level":"Maintainer",
+		"access_level":40,
 		"name":"gitlab_group_example_maintainer"
 	}
 ]`)
@@ -390,11 +390,11 @@ func TestListGroupSAMLLinks(t *testing.T) {
 
 	want := []*SAMLGroupLink{
 		{
-			AccessLevel: "Developer",
+			AccessLevel: DeveloperPermissions,
 			Name:        "gitlab_group_example_developer",
 		},
 		{
-			AccessLevel: "Maintainer",
+			AccessLevel: MaintainerPermissions,
 			Name:        "gitlab_group_example_maintainer",
 		},
 	}
@@ -412,7 +412,7 @@ func TestGetGroupSAMLLink(t *testing.T) {
 			testMethod(t, r, http.MethodGet)
 			fmt.Fprint(w, `
 {
-	"access_level":"Developer",
+	"access_level":30,
 	"name":"gitlab_group_example_developer"
 }`)
 		})
@@ -423,7 +423,7 @@ func TestGetGroupSAMLLink(t *testing.T) {
 	}
 
 	want := &SAMLGroupLink{
-		AccessLevel: "Developer",
+		AccessLevel: DeveloperPermissions,
 		Name:        "gitlab_group_example_developer",
 	}
 	if !reflect.DeepEqual(want, links) {
@@ -440,14 +440,14 @@ func TestAddGroupSAMLLink(t *testing.T) {
 			testMethod(t, r, http.MethodPost)
 			fmt.Fprint(w, `
 {
-	"access_level":"Developer",
+	"access_level":30,
 	"name":"gitlab_group_example_developer"
 }`)
 		})
 
 	opt := &AddGroupSAMLLinkOptions{
 		SAMLGroupName: String("gitlab_group_example_developer"),
-		AccessLevel:   String("Developer"),
+		AccessLevel:   AccessLevel(DeveloperPermissions),
 	}
 
 	link, _, err := client.Groups.AddGroupSAMLLink(1, opt)
@@ -456,7 +456,7 @@ func TestAddGroupSAMLLink(t *testing.T) {
 	}
 
 	want := &SAMLGroupLink{
-		AccessLevel: "Developer",
+		AccessLevel: DeveloperPermissions,
 		Name:        "gitlab_group_example_developer",
 	}
 	if !reflect.DeepEqual(want, link) {


### PR DESCRIPTION
While working on https://github.com/gitlabhq/terraform-provider-gitlab/pull/1215
I have noticed that the access level type introcued in
https://github.com/xanzy/go-gitlab/pull/1527
is wrong.

@svanharmelen Do you mind creating a bugfix release with this in it?