### PR TITLE
Add reviewer to merge request to webhook event

### DIFF
--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -537,6 +537,10 @@ type MergeEvent struct {
 			Previous []*EventUser `json:"previous"`
 			Current  []*EventUser `json:"current"`
 		} `json:"assignees"`
+		Reviewers struct {
+			Previous []*EventUser `json:"previous"`
+			Current  []*EventUser `json:"current"`
+		} `json:"reviewers"`
 		Description struct {
 			Previous string `json:"previous"`
 			Current  string `json:"current"`

--- a/event_webhook_types_test.go
+++ b/event_webhook_types_test.go
@@ -234,6 +234,18 @@ func TestMergeEventUnmarshal(t *testing.T) {
 	if event.Assignees[0].Email != expectedEmail {
 		t.Errorf("Assignees[0].Email is %v, want %v", event.Assignees[0].Email, expectedEmail)
 	}
+
+	if len(event.Changes.Reviewers.Previous) != 0 {
+		t.Errorf("Changes.Reviewer.Previeous length is %d, want %d", len(event.Changes.Reviewers.Previous), 0)
+	}
+
+	if len(event.Changes.Reviewers.Current) != 1 {
+		t.Errorf("Changes.Reviewer.Current length is %d, want %d", len(event.Changes.Reviewers.Current), 1)
+	}
+
+	if event.Changes.Reviewers.Current[0].Username != expectedUsername {
+		t.Errorf("Changes.Reviewer.Current[0].Username is %v, want %v", event.Changes.Reviewers.Current[0].Username, expectedUsername)
+	}
 }
 
 func TestMergeEventUnmarshalFromGroup(t *testing.T) {

--- a/testdata/webhooks/merge_request.json
+++ b/testdata/webhooks/merge_request.json
@@ -159,6 +159,18 @@
         "type": "ProjectLabel",
         "group_id": 41
       }]
+    },
+    "reviewers": {
+      "previous": [],
+      "current": [
+        {
+          "id": 1,
+          "name": "User1",
+          "username": "user1",
+          "avatar_url": "http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=40&d=identicon",
+          "email": "[REDACTED]"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
Gitlab support  [Add reviewer to merge request to webhook api](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/93663) in 15.3 release.

MR webhook_event:
```yaml
  "changes": {
    "reviewers": {
      "previous": [

      ],
      "current": [
        {
          "id": 1,
          "name": "User1",
          "username": "user1",
          "avatar_url": "http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=40\u0026d=identicon",
          "email": "[REDACTED]"
        }
      ]
    }
  },
```