### PR TITLE
Expose project public_jobs field

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -83,6 +83,7 @@ type Project struct {
 	StarCount                                 int                        `json:"star_count"`
 	RunnersToken                              string                     `json:"runners_token"`
 	PublicBuilds                              bool                       `json:"public_builds"`
+	PublicJobs                                bool                       `json:"public_jobs"`
 	AllowMergeOnSkippedPipeline               bool                       `json:"allow_merge_on_skipped_pipeline"`
 	OnlyAllowMergeIfPipelineSucceeds          bool                       `json:"only_allow_merge_if_pipeline_succeeds"`
 	OnlyAllowMergeIfAllDiscussionsAreResolved bool                       `json:"only_allow_merge_if_all_discussions_are_resolved"`

--- a/projects.go
+++ b/projects.go
@@ -82,7 +82,6 @@ type Project struct {
 	ForksCount                                int                        `json:"forks_count"`
 	StarCount                                 int                        `json:"star_count"`
 	RunnersToken                              string                     `json:"runners_token"`
-	PublicBuilds                              bool                       `json:"public_builds"`
 	PublicJobs                                bool                       `json:"public_jobs"`
 	AllowMergeOnSkippedPipeline               bool                       `json:"allow_merge_on_skipped_pipeline"`
 	OnlyAllowMergeIfPipelineSucceeds          bool                       `json:"only_allow_merge_if_pipeline_succeeds"`
@@ -145,6 +144,9 @@ type Project struct {
 	ExternalAuthorizationClassificationLabel string             `json:"external_authorization_classification_label"`
 	RequirementsAccessLevel                  AccessControlValue `json:"requirements_access_level"`
 	SecurityAndComplianceAccessLevel         AccessControlValue `json:"security_and_compliance_access_level"`
+
+	// Deprecated members
+	PublicBuilds bool `json:"public_builds"`
 }
 
 // BasicProject included in other service responses (such as todos).


### PR DESCRIPTION
This MR fixes https://github.com/xanzy/go-gitlab/issues/1538, at least temporary, until https://gitlab.com/gitlab-org/gitlab/-/issues/329725 is fixed. Nothing more is actually needed since this field will be populated as expected now in [GetProject](https://github.com/xanzy/go-gitlab/blob/4256ad62c1044a01b0eab2fd863f53807d562876/projects.go#L521), but the field `public_builds` is still the one being used for [updates](https://github.com/xanzy/go-gitlab/blob/4256ad62c1044a01b0eab2fd863f53807d562876/projects.go#L843) and [creations](https://github.com/xanzy/go-gitlab/blob/4256ad62c1044a01b0eab2fd863f53807d562876/projects.go#L647).

We can fix those when GitLab fixes their API.

refs https://github.com/xanzy/go-gitlab/issues/1538