### PR TITLE
fix(commit discussions): Make commit ids strings (close #1546)

### DIFF
--- a/discussions.go
+++ b/discussions.go
@@ -917,12 +917,12 @@ type ListCommitDiscussionsOptions ListOptions
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/discussions.html#list-project-commit-discussion-items
-func (s *DiscussionsService) ListCommitDiscussions(pid interface{}, commit int, opt *ListCommitDiscussionsOptions, options ...RequestOptionFunc) ([]*Discussion, *Response, error) {
+func (s *DiscussionsService) ListCommitDiscussions(pid interface{}, commit string, opt *ListCommitDiscussionsOptions, options ...RequestOptionFunc) ([]*Discussion, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/repository/commits/%d/discussions",
+	u := fmt.Sprintf("projects/%s/repository/commits/%s/discussions",
 		PathEscape(project),
 		commit,
 	)
@@ -946,12 +946,12 @@ func (s *DiscussionsService) ListCommitDiscussions(pid interface{}, commit int, 
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/discussions.html#get-single-commit-discussion-item
-func (s *DiscussionsService) GetCommitDiscussion(pid interface{}, commit int, discussion string, options ...RequestOptionFunc) (*Discussion, *Response, error) {
+func (s *DiscussionsService) GetCommitDiscussion(pid interface{}, commit string, discussion string, options ...RequestOptionFunc) (*Discussion, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/repository/commits/%d/discussions/%s",
+	u := fmt.Sprintf("projects/%s/repository/commits/%s/discussions/%s",
 		PathEscape(project),
 		commit,
 		discussion,
@@ -986,12 +986,12 @@ type CreateCommitDiscussionOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/discussions.html#create-new-commit-thread
-func (s *DiscussionsService) CreateCommitDiscussion(pid interface{}, commit int, opt *CreateCommitDiscussionOptions, options ...RequestOptionFunc) (*Discussion, *Response, error) {
+func (s *DiscussionsService) CreateCommitDiscussion(pid interface{}, commit string, opt *CreateCommitDiscussionOptions, options ...RequestOptionFunc) (*Discussion, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/repository/commits/%d/discussions",
+	u := fmt.Sprintf("projects/%s/repository/commits/%s/discussions",
 		PathEscape(project),
 		commit,
 	)
@@ -1024,12 +1024,12 @@ type AddCommitDiscussionNoteOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/discussions.html#add-note-to-existing-commit-thread
-func (s *DiscussionsService) AddCommitDiscussionNote(pid interface{}, commit int, discussion string, opt *AddCommitDiscussionNoteOptions, options ...RequestOptionFunc) (*Note, *Response, error) {
+func (s *DiscussionsService) AddCommitDiscussionNote(pid interface{}, commit string, discussion string, opt *AddCommitDiscussionNoteOptions, options ...RequestOptionFunc) (*Note, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/repository/commits/%d/discussions/%s/notes",
+	u := fmt.Sprintf("projects/%s/repository/commits/%s/discussions/%s/notes",
 		PathEscape(project),
 		commit,
 		discussion,
@@ -1063,12 +1063,12 @@ type UpdateCommitDiscussionNoteOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/discussions.html#modify-an-existing-commit-thread-note
-func (s *DiscussionsService) UpdateCommitDiscussionNote(pid interface{}, commit int, discussion string, note int, opt *UpdateCommitDiscussionNoteOptions, options ...RequestOptionFunc) (*Note, *Response, error) {
+func (s *DiscussionsService) UpdateCommitDiscussionNote(pid interface{}, commit string, discussion string, note int, opt *UpdateCommitDiscussionNoteOptions, options ...RequestOptionFunc) (*Note, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/repository/commits/%d/discussions/%s/notes/%d",
+	u := fmt.Sprintf("projects/%s/repository/commits/%s/discussions/%s/notes/%d",
 		PathEscape(project),
 		commit,
 		discussion,
@@ -1093,12 +1093,12 @@ func (s *DiscussionsService) UpdateCommitDiscussionNote(pid interface{}, commit 
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/discussions.html#delete-a-commit-thread-note
-func (s *DiscussionsService) DeleteCommitDiscussionNote(pid interface{}, commit int, discussion string, note int, options ...RequestOptionFunc) (*Response, error) {
+func (s *DiscussionsService) DeleteCommitDiscussionNote(pid interface{}, commit string, discussion string, note int, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/repository/commits/%d/discussions/%s/notes/%d",
+	u := fmt.Sprintf("projects/%s/repository/commits/%s/discussions/%s/notes/%d",
 		PathEscape(project),
 		commit,
 		discussion,

--- a/discussions_test.go
+++ b/discussions_test.go
@@ -2245,7 +2245,7 @@ func TestDiscussionsService_ListCommitDiscussions(t *testing.T) {
 	mux, server, client := setup(t)
 	defer teardown(server)
 
-	mux.HandleFunc("/api/v4/projects/5/repository/commits/11/discussions", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v4/projects/5/repository/commits/abc123/discussions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
 		fmt.Fprintf(w, `
 			[
@@ -2327,22 +2327,22 @@ func TestDiscussionsService_ListCommitDiscussions(t *testing.T) {
 		}},
 	}}
 
-	ds, resp, err := client.Discussions.ListCommitDiscussions(5, 11, nil, nil)
+	ds, resp, err := client.Discussions.ListCommitDiscussions(5, "abc123", nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.Equal(t, want, ds)
 
-	ds, resp, err = client.Discussions.ListCommitDiscussions(5.01, 11, nil, nil)
+	ds, resp, err = client.Discussions.ListCommitDiscussions(5.01, "abc123", nil, nil)
 	require.EqualError(t, err, "invalid ID type 5.01, the ID must be an int or a string")
 	require.Nil(t, resp)
 	require.Nil(t, ds)
 
-	ds, resp, err = client.Discussions.ListCommitDiscussions(5, 11, nil, nil, errorOption)
+	ds, resp, err = client.Discussions.ListCommitDiscussions(5, "abc123", nil, nil, errorOption)
 	require.EqualError(t, err, "RequestOptionFunc returns an error")
 	require.Nil(t, resp)
 	require.Nil(t, ds)
 
-	ds, resp, err = client.Discussions.ListCommitDiscussions(3, 11, nil, nil)
+	ds, resp, err = client.Discussions.ListCommitDiscussions(3, "abc123", nil, nil)
 	require.Error(t, err)
 	require.Nil(t, ds)
 	require.Equal(t, http.StatusNotFound, resp.StatusCode)
@@ -2352,7 +2352,7 @@ func TestDiscussionsService_GetCommitDiscussion(t *testing.T) {
 	mux, server, client := setup(t)
 	defer teardown(server)
 
-	mux.HandleFunc("/api/v4/projects/5/repository/commits/11/discussions/6a9c1750b37d513a43987b574953fceb50b03ce7", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v4/projects/5/repository/commits/abc123/discussions/6a9c1750b37d513a43987b574953fceb50b03ce7", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
 		fmt.Fprintf(w, `
 		  {
@@ -2432,22 +2432,22 @@ func TestDiscussionsService_GetCommitDiscussion(t *testing.T) {
 		}},
 	}
 
-	d, resp, err := client.Discussions.GetCommitDiscussion(5, 11, "6a9c1750b37d513a43987b574953fceb50b03ce7", nil, nil)
+	d, resp, err := client.Discussions.GetCommitDiscussion(5, "abc123", "6a9c1750b37d513a43987b574953fceb50b03ce7", nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.Equal(t, want, d)
 
-	d, resp, err = client.Discussions.GetCommitDiscussion(5.01, 11, "6a9c1750b37d513a43987b574953fceb50b03ce7", nil, nil)
+	d, resp, err = client.Discussions.GetCommitDiscussion(5.01, "abc123", "6a9c1750b37d513a43987b574953fceb50b03ce7", nil, nil)
 	require.EqualError(t, err, "invalid ID type 5.01, the ID must be an int or a string")
 	require.Nil(t, resp)
 	require.Nil(t, d)
 
-	d, resp, err = client.Discussions.GetCommitDiscussion(5, 11, "6a9c1750b37d513a43987b574953fceb50b03ce7", nil, nil, errorOption)
+	d, resp, err = client.Discussions.GetCommitDiscussion(5, "abc123", "6a9c1750b37d513a43987b574953fceb50b03ce7", nil, nil, errorOption)
 	require.EqualError(t, err, "RequestOptionFunc returns an error")
 	require.Nil(t, resp)
 	require.Nil(t, d)
 
-	d, resp, err = client.Discussions.GetCommitDiscussion(3, 11, "6a9c1750b37d513a43987b574953fceb50b03ce7", nil, nil)
+	d, resp, err = client.Discussions.GetCommitDiscussion(3, "abc123", "6a9c1750b37d513a43987b574953fceb50b03ce7", nil, nil)
 	require.Error(t, err)
 	require.Nil(t, d)
 	require.Equal(t, http.StatusNotFound, resp.StatusCode)
@@ -2457,7 +2457,7 @@ func TestDiscussionsService_CreateCommitDiscussion(t *testing.T) {
 	mux, server, client := setup(t)
 	defer teardown(server)
 
-	mux.HandleFunc("/api/v4/projects/5/repository/commits/11/discussions", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v4/projects/5/repository/commits/abc123/discussions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
 		fmt.Fprintf(w, `
 		  {
@@ -2537,22 +2537,22 @@ func TestDiscussionsService_CreateCommitDiscussion(t *testing.T) {
 		}},
 	}
 
-	d, resp, err := client.Discussions.CreateCommitDiscussion(5, 11, nil, nil)
+	d, resp, err := client.Discussions.CreateCommitDiscussion(5, "abc123", nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.Equal(t, want, d)
 
-	d, resp, err = client.Discussions.CreateCommitDiscussion(5.01, 11, nil, nil)
+	d, resp, err = client.Discussions.CreateCommitDiscussion(5.01, "abc123", nil, nil)
 	require.EqualError(t, err, "invalid ID type 5.01, the ID must be an int or a string")
 	require.Nil(t, resp)
 	require.Nil(t, d)
 
-	d, resp, err = client.Discussions.CreateCommitDiscussion(5, 11, nil, nil, errorOption)
+	d, resp, err = client.Discussions.CreateCommitDiscussion(5, "abc123", nil, nil, errorOption)
 	require.EqualError(t, err, "RequestOptionFunc returns an error")
 	require.Nil(t, resp)
 	require.Nil(t, d)
 
-	d, resp, err = client.Discussions.CreateCommitDiscussion(3, 11, nil, nil)
+	d, resp, err = client.Discussions.CreateCommitDiscussion(3, "abc123", nil, nil)
 	require.Error(t, err)
 	require.Nil(t, d)
 	require.Equal(t, http.StatusNotFound, resp.StatusCode)
@@ -2562,7 +2562,7 @@ func TestDiscussionsService_AddCommitDiscussionNote(t *testing.T) {
 	mux, server, client := setup(t)
 	defer teardown(server)
 
-	mux.HandleFunc("/api/v4/projects/5/repository/commits/11/discussions/6a9c1750b37d513a43987b574953fceb50b03ce7/notes", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v4/projects/5/repository/commits/abc123/discussions/6a9c1750b37d513a43987b574953fceb50b03ce7/notes", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
 		fmt.Fprintf(w, `
 		  {
@@ -2632,22 +2632,22 @@ func TestDiscussionsService_AddCommitDiscussionNote(t *testing.T) {
 		NoteableIID: 377,
 	}
 
-	n, resp, err := client.Discussions.AddCommitDiscussionNote(5, 11, "6a9c1750b37d513a43987b574953fceb50b03ce7", nil, nil)
+	n, resp, err := client.Discussions.AddCommitDiscussionNote(5, "abc123", "6a9c1750b37d513a43987b574953fceb50b03ce7", nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.Equal(t, want, n)
 
-	n, resp, err = client.Discussions.AddCommitDiscussionNote(5.01, 11, "6a9c1750b37d513a43987b574953fceb50b03ce7", nil, nil)
+	n, resp, err = client.Discussions.AddCommitDiscussionNote(5.01, "abc123", "6a9c1750b37d513a43987b574953fceb50b03ce7", nil, nil)
 	require.EqualError(t, err, "invalid ID type 5.01, the ID must be an int or a string")
 	require.Nil(t, resp)
 	require.Nil(t, n)
 
-	n, resp, err = client.Discussions.AddCommitDiscussionNote(5, 11, "6a9c1750b37d513a43987b574953fceb50b03ce7", nil, nil, errorOption)
+	n, resp, err = client.Discussions.AddCommitDiscussionNote(5, "abc123", "6a9c1750b37d513a43987b574953fceb50b03ce7", nil, nil, errorOption)
 	require.EqualError(t, err, "RequestOptionFunc returns an error")
 	require.Nil(t, resp)
 	require.Nil(t, n)
 
-	n, resp, err = client.Discussions.AddCommitDiscussionNote(3, 11, "6a9c1750b37d513a43987b574953fceb50b03ce7", nil, nil)
+	n, resp, err = client.Discussions.AddCommitDiscussionNote(3, "abc123", "6a9c1750b37d513a43987b574953fceb50b03ce7", nil, nil)
 	require.Error(t, err)
 	require.Nil(t, n)
 	require.Equal(t, http.StatusNotFound, resp.StatusCode)
@@ -2657,7 +2657,7 @@ func TestDiscussionsService_UpdateCommitDiscussionNote(t *testing.T) {
 	mux, server, client := setup(t)
 	defer teardown(server)
 
-	mux.HandleFunc("/api/v4/projects/5/repository/commits/11/discussions/6a9c1750b37d513a43987b574953fceb50b03ce7/notes/302", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v4/projects/5/repository/commits/abc123/discussions/6a9c1750b37d513a43987b574953fceb50b03ce7/notes/302", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
 		fmt.Fprintf(w, `
 		  {
@@ -2727,22 +2727,22 @@ func TestDiscussionsService_UpdateCommitDiscussionNote(t *testing.T) {
 		NoteableIID: 377,
 	}
 
-	n, resp, err := client.Discussions.UpdateCommitDiscussionNote(5, 11, "6a9c1750b37d513a43987b574953fceb50b03ce7", 302, nil, nil)
+	n, resp, err := client.Discussions.UpdateCommitDiscussionNote(5, "abc123", "6a9c1750b37d513a43987b574953fceb50b03ce7", 302, nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.Equal(t, want, n)
 
-	n, resp, err = client.Discussions.UpdateCommitDiscussionNote(5.01, 11, "6a9c1750b37d513a43987b574953fceb50b03ce7", 302, nil, nil)
+	n, resp, err = client.Discussions.UpdateCommitDiscussionNote(5.01, "abc123", "6a9c1750b37d513a43987b574953fceb50b03ce7", 302, nil, nil)
 	require.EqualError(t, err, "invalid ID type 5.01, the ID must be an int or a string")
 	require.Nil(t, resp)
 	require.Nil(t, n)
 
-	n, resp, err = client.Discussions.UpdateCommitDiscussionNote(5, 11, "6a9c1750b37d513a43987b574953fceb50b03ce7", 302, nil, nil, errorOption)
+	n, resp, err = client.Discussions.UpdateCommitDiscussionNote(5, "abc123", "6a9c1750b37d513a43987b574953fceb50b03ce7", 302, nil, nil, errorOption)
 	require.EqualError(t, err, "RequestOptionFunc returns an error")
 	require.Nil(t, resp)
 	require.Nil(t, n)
 
-	n, resp, err = client.Discussions.UpdateCommitDiscussionNote(3, 11, "6a9c1750b37d513a43987b574953fceb50b03ce7", 302, nil, nil)
+	n, resp, err = client.Discussions.UpdateCommitDiscussionNote(3, "abc123", "6a9c1750b37d513a43987b574953fceb50b03ce7", 302, nil, nil)
 	require.Error(t, err)
 	require.Nil(t, n)
 	require.Equal(t, http.StatusNotFound, resp.StatusCode)
@@ -2752,23 +2752,23 @@ func TestDiscussionsService_DeleteCommitDiscussionNote(t *testing.T) {
 	mux, server, client := setup(t)
 	defer teardown(server)
 
-	mux.HandleFunc("/api/v4/projects/5/repository/commits/11/discussions/6a9c1750b37d513a43987b574953fceb50b03ce7/notes/302", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v4/projects/5/repository/commits/abc123/discussions/6a9c1750b37d513a43987b574953fceb50b03ce7/notes/302", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
 	})
 
-	resp, err := client.Discussions.DeleteCommitDiscussionNote(5, 11, "6a9c1750b37d513a43987b574953fceb50b03ce7", 302, nil, nil)
+	resp, err := client.Discussions.DeleteCommitDiscussionNote(5, "abc123", "6a9c1750b37d513a43987b574953fceb50b03ce7", 302, nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 
-	resp, err = client.Discussions.DeleteCommitDiscussionNote(5.01, 11, "6a9c1750b37d513a43987b574953fceb50b03ce7", 302, nil, nil)
+	resp, err = client.Discussions.DeleteCommitDiscussionNote(5.01, "abc123", "6a9c1750b37d513a43987b574953fceb50b03ce7", 302, nil, nil)
 	require.EqualError(t, err, "invalid ID type 5.01, the ID must be an int or a string")
 	require.Nil(t, resp)
 
-	resp, err = client.Discussions.DeleteCommitDiscussionNote(5, 11, "6a9c1750b37d513a43987b574953fceb50b03ce7", 302, nil, nil, errorOption)
+	resp, err = client.Discussions.DeleteCommitDiscussionNote(5, "abc123", "6a9c1750b37d513a43987b574953fceb50b03ce7", 302, nil, nil, errorOption)
 	require.EqualError(t, err, "RequestOptionFunc returns an error")
 	require.Nil(t, resp)
 
-	resp, err = client.Discussions.DeleteCommitDiscussionNote(3, 11, "6a9c1750b37d513a43987b574953fceb50b03ce7", 302, nil, nil)
+	resp, err = client.Discussions.DeleteCommitDiscussionNote(3, "abc123", "6a9c1750b37d513a43987b574953fceb50b03ce7", 302, nil, nil)
 	require.Error(t, err)
 	require.Equal(t, http.StatusNotFound, resp.StatusCode)
 }


### PR DESCRIPTION
Hi, this resolves my issue at #1546 by reverting some of the changes from #1260 and turning the commit id back into a string for the `*CommitDiscussion` functions. Note that -- at this time -- the API docs are still incorrectly stating that commit ids are ints, but [MR 97586](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/97586) (which corrects the docs) ~~appears to be set for merge.~~ (**Update**: that MR has been merged.) Quoting one of the reviewers on that MR: "The assertion that these IDs are in fact SHA strings is correct."

I believe that this is safe to merge now, before that MR is merged and/or released. As is, these functions appear to unusable unless you happen to be working with discussions on the small set of commits whose SHAs can be represented as ints. 😄 

Thanks for your consideration, and for this great library!