### PR TITLE
Add specific type for issue relations

### DIFF
--- a/issue_links.go
+++ b/issue_links.go
@@ -60,6 +60,7 @@ type IssueRelation struct {
 	Labels         Labels           `json:"labels"`
 	DueDate        *ISOTime         `json:"due_date"`
 	WebURL         string           `json:"web_url"`
+	References     *IssueReferences `json:"references"`
 	Weight         int              `json:"weight"`
 	UserNotesCount int              `json:"user_notes_count"`
 	IssueLinkID    int              `json:"issue_link_id"`

--- a/issue_links.go
+++ b/issue_links.go
@@ -19,6 +19,7 @@ package gitlab
 import (
 	"fmt"
 	"net/http"
+	"time"
 )
 
 // IssueLinksService handles communication with the issue relations related methods
@@ -38,6 +39,35 @@ type IssueLink struct {
 	LinkType    string `json:"link_type"`
 }
 
+// IssueRelation gets a relation between two issues.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/issue_links.html#list-issue-relations
+type IssueRelation struct {
+	ID             int              `json:"id"`
+	IID            int              `json:"iid"`
+	State          string           `json:"state"`
+	Description    string           `json:"description"`
+	Confidential   bool             `json:"confidential"`
+	Author         *IssueAuthor     `json:"author"`
+	Milestone      *Milestone       `json:"milestone"`
+	ProjectID      int              `json:"project_id"`
+	Assignees      []*IssueAssignee `json:"assignees"`
+	Assignee       *IssueAssignee   `json:"assignee"`
+	UpdatedAt      *time.Time       `json:"updated_at"`
+	Title          string           `json:"title"`
+	CreatedAt      *time.Time       `json:"created_at"`
+	Labels         Labels           `json:"labels"`
+	DueDate        *ISOTime         `json:"due_date"`
+	WebURL         string           `json:"web_url"`
+	Weight         int              `json:"weight"`
+	UserNotesCount int              `json:"user_notes_count"`
+	IssueLinkID    int              `json:"issue_link_id"`
+	LinkType       string           `json:"link_type"`
+	LinkCreatedAt  *time.Time       `json:"link_created_at"`
+	LinkUpdatedAt  *time.Time       `json:"link_updated_at"`
+}
+
 // ListIssueRelations gets a list of related issues of a given issue,
 // sorted by the relationship creation datetime (ascending).
 //
@@ -45,7 +75,7 @@ type IssueLink struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/issue_links.html#list-issue-relations
-func (s *IssueLinksService) ListIssueRelations(pid interface{}, issue int, options ...RequestOptionFunc) ([]*Issue, *Response, error) {
+func (s *IssueLinksService) ListIssueRelations(pid interface{}, issue int, options ...RequestOptionFunc) ([]*IssueRelation, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
@@ -57,7 +87,7 @@ func (s *IssueLinksService) ListIssueRelations(pid interface{}, issue int, optio
 		return nil, nil, err
 	}
 
-	var is []*Issue
+	var is []*IssueRelation
 	resp, err := s.client.Do(req, &is)
 	if err != nil {
 		return nil, resp, err

--- a/issue_links_test.go
+++ b/issue_links_test.go
@@ -19,6 +19,7 @@ func TestIssueLinksService_ListIssueRelations(t *testing.T) {
 			  {
 				"id" : 84,
 				"iid" : 14,
+				"confidential": false,
 				"issue_link_id": 1,
 				"project_id" : 4,
 				"title" : "Issues with auth",
@@ -49,35 +50,30 @@ func TestIssueLinksService_ListIssueRelations(t *testing.T) {
 		`)
 	})
 
-	want := []*Issue{{
-		ID:          84,
-		IID:         14,
-		ExternalID:  "",
-		State:       "opened",
-		Description: "",
+	want := []*IssueRelation{{
+		ID:           84,
+		IID:          14,
+		State:        "opened",
+		Description:  "",
+		Confidential: false,
 		Author: &IssueAuthor{
 			ID:        18,
 			State:     "active",
 			WebURL:    "https://gitlab.example.com/eileen.lowe",
 			Name:      "Venkatesh Thalluri",
 			AvatarURL: "",
-			Username:  "venkatesh.thalluri"},
-		ProjectID:         4,
-		Assignees:         []*IssueAssignee{},
-		Title:             "Issues with auth",
-		MovedToID:         0,
-		Labels:            []string{"bug"},
-		Upvotes:           0,
-		Downvotes:         0,
-		WebURL:            "http://example.com/example/example/issues/14",
-		Confidential:      false,
-		Weight:            0,
-		DiscussionLocked:  false,
-		Subscribed:        false,
-		UserNotesCount:    0,
-		IssueLinkID:       1,
-		MergeRequestCount: 0,
-		EpicIssueID:       0,
+			Username:  "venkatesh.thalluri",
+		},
+		Milestone:   nil,
+		ProjectID:   4,
+		Assignees:   []*IssueAssignee{},
+		Assignee:    nil,
+		Title:       "Issues with auth",
+		Labels:      []string{"bug"},
+		WebURL:      "http://example.com/example/example/issues/14",
+		Weight:      0,
+		IssueLinkID: 1,
+		LinkType:    "relates_to",
 	}}
 
 	is, resp, err := client.IssueLinks.ListIssueRelations(4, 14, nil)


### PR DESCRIPTION
Fields selected based on described fields/examples from docs

Added `references` even though it is not in the docs, as gitlab does return that field

This picks up where #1386 previously left off