### PR TITLE
CheckResponse errors include any non-JSON data

### DIFF
--- a/gitlab.go
+++ b/gitlab.go
@@ -892,7 +892,7 @@ func CheckResponse(r *http.Response) error {
 
 		var raw interface{}
 		if err := json.Unmarshal(data, &raw); err != nil {
-			errorResponse.Message = "failed to parse unknown error format"
+			errorResponse.Message = fmt.Sprintf("failed to parse unknown error format: %s", data)
 		} else {
 			errorResponse.Message = parseError(raw)
 		}

--- a/gitlab_test.go
+++ b/gitlab_test.go
@@ -172,6 +172,35 @@ func TestCheckResponse(t *testing.T) {
 	}
 }
 
+func TestCheckResponseOnUnknownErrorFormat(t *testing.T) {
+	c, err := NewClient("")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	req, err := c.NewRequest(http.MethodGet, "test", nil, nil)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+
+	resp := &http.Response{
+		Request:    req.Request,
+		StatusCode: http.StatusBadRequest,
+		Body:       io.NopCloser(strings.NewReader("some error message but not JSON")),
+	}
+
+	errResp := CheckResponse(resp)
+	if errResp == nil {
+		t.Fatal("Expected error response.")
+	}
+
+	want := "GET https://gitlab.com/api/v4/test: 400 failed to parse unknown error format: some error message but not JSON"
+
+	if errResp.Error() != want {
+		t.Errorf("Expected error: %s, got %s", want, errResp.Error())
+	}
+}
+
 func TestRequestWithContext(t *testing.T) {
 	c, err := NewClient("")
 	if err != nil {


### PR DESCRIPTION
My GitLab is throwing errors where the body is not JSON, and using this library I'm finding that the error message coming back from `CheckResponse` wasn't very helpful, just `failed to parse unknown error format`.

This PR will include the original response body in the Go error, when that body cannot be parsed as JSON.

I hope you're amenable to this change.  Thanks for maintaining such a useful project!