### PR TITLE
 Add `ref` to deployment webhook 

### DIFF
--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -151,6 +151,7 @@ type DeploymentEvent struct {
 		SSHURL            string  `json:"ssh_url"`
 		HTTPURL           string  `json:"http_url"`
 	} `json:"project"`
+	Ref         string     `json:"ref"`
 	ShortSHA    string     `json:"short_sha"`
 	User        *EventUser `json:"user"`
 	UserURL     string     `json:"user_url"`

--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -306,8 +306,7 @@ type IssueEvent struct {
 // JobEvent represents a job event.
 //
 // GitLab API docs:
-// TODO: link to docs instead of src once they are published.
-// https://gitlab.com/gitlab-org/gitlab-ce/blob/master/lib/gitlab/data_builder/build.rb
+// https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#job-events
 type JobEvent struct {
 	ObjectKind         string     `json:"object_kind"`
 	Ref                string     `json:"ref"`

--- a/event_webhook_types_test.go
+++ b/event_webhook_types_test.go
@@ -92,6 +92,10 @@ func TestDeploymentEventUnmarshal(t *testing.T) {
 	if event.CommitTitle != "Add new file" {
 		t.Errorf("CommitTitle is %s, want %s", event.CommitTitle, "Add new file")
 	}
+
+	if event.Ref != "1.0.0" {
+		t.Errorf("Ref is %s, want %s", event.Ref, "1.0.0")
+	}
 }
 
 func TestIssueCommentEventUnmarshal(t *testing.T) {

--- a/testdata/webhooks/deployment.json
+++ b/testdata/webhooks/deployment.json
@@ -32,5 +32,6 @@
   },
   "user_url": "http://10.126.0.2:3000/root",
   "commit_url": "http://10.126.0.2:3000/root/test-deployment-webhooks/-/commit/279484c09fbe69ededfced8c1bb6e6d24616b468",
-  "commit_title": "Add new file"
+  "commit_title": "Add new file",
+  "ref": "1.0.0"
 }


### PR DESCRIPTION
Hey 👋,

`ref` seems to be undocumented in the [deployment webhook event docs](https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#deployment-events), but looking at the code, it's always present: https://gitlab.com/gitlab-org/gitlab/-/blob/master/lib/gitlab/data_builder/deployment.rb#L44. 

Just as another example, deploying from sth. else than a tag will contain sth. like `"ref":"refs/merge-requests/1/merge"`. I tested this with the GitLab SaaS version.

I also updated the docs URL for the job event since the TODO comment was from 2019 🙂