### PR TITLE
add SharedWithGroups.GroupFullPath field to projects.go

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -120,6 +120,7 @@ type Project struct {
 	SharedWithGroups                          []struct {
 		GroupID          int    `json:"group_id"`
 		GroupName        string `json:"group_name"`
+		GroupFullPath    string `json:"group_full_path"`
 		GroupAccessLevel int    `json:"group_access_level"`
 	} `json:"shared_with_groups"`
 	Statistics                               *Statistics        `json:"statistics"`


### PR DESCRIPTION
Fixes #1569 