### PR TITLE
Treat ExpiresAt as optional when editing member options

### DIFF
--- a/group_members.go
+++ b/group_members.go
@@ -300,7 +300,7 @@ func (s *GroupMembersService) DeleteShareWithGroup(gid interface{}, groupID int,
 // https://docs.gitlab.com/ce/api/members.html#edit-a-member-of-a-group-or-project
 type EditGroupMemberOptions struct {
 	AccessLevel *AccessLevelValue `url:"access_level,omitempty" json:"access_level,omitempty"`
-	ExpiresAt   *string           `url:"expires_at,omitempty" json:"expires_at"`
+	ExpiresAt   *string           `url:"expires_at,omitempty" json:"expires_at,omitempty"`
 }
 
 // EditGroupMember updates a member of a group.

--- a/project_members.go
+++ b/project_members.go
@@ -188,7 +188,7 @@ func (s *ProjectMembersService) AddProjectMember(pid interface{}, opt *AddProjec
 // https://docs.gitlab.com/ce/api/members.html#edit-a-member-of-a-group-or-project
 type EditProjectMemberOptions struct {
 	AccessLevel *AccessLevelValue `url:"access_level,omitempty" json:"access_level,omitempty"`
-	ExpiresAt   *string           `url:"expires_at,omitempty" json:"expires_at"`
+	ExpiresAt   *string           `url:"expires_at,omitempty" json:"expires_at,omitempty"`
 }
 
 // EditProjectMember updates a project team member to a specified access level..


### PR DESCRIPTION
This patch allows allows changing access levels without existing knowledge of the value and inadvertently removing the account's expiry. This currently occurs as non defined ExpiresAt renders to `"expires_at": null`

`expires_at` is a non-required field https://docs.gitlab.com/ee/api/members.html#edit-a-member-of-a-group-or-project
