### PR TITLE
Add missing mr_default_target_self edit project attribute

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -843,6 +843,7 @@ type EditProjectOptions struct {
 	KeepLatestArtifact                        *bool                                `url:"keep_latest_artifact,omitempty" json:"keep_latest_artifact,omitempty"`
 	LFSEnabled                                *bool                                `url:"lfs_enabled,omitempty" json:"lfs_enabled,omitempty"`
 	MergeCommitTemplate                       *string                              `url:"merge_commit_template,omitempty" json:"merge_commit_template,omitempty"`
+	MergeRequestDefaultTargetSelf             *bool                                `url:"mr_default_target_self,omitempty" json:"mr_default_target_self,omitempty"`
 	MergeMethod                               *MergeMethodValue                    `url:"merge_method,omitempty" json:"merge_method,omitempty"`
 	MergePipelinesEnabled                     *bool                                `url:"merge_pipelines_enabled,omitempty" json:"merge_pipelines_enabled,omitempty"`
 	MergeRequestsAccessLevel                  *AccessControlValue                  `url:"merge_requests_access_level,omitempty" json:"merge_requests_access_level,omitempty"`

--- a/projects.go
+++ b/projects.go
@@ -148,6 +148,7 @@ type Project struct {
 	ExternalAuthorizationClassificationLabel string             `json:"external_authorization_classification_label"`
 	RequirementsAccessLevel                  AccessControlValue `json:"requirements_access_level"`
 	SecurityAndComplianceAccessLevel         AccessControlValue `json:"security_and_compliance_access_level"`
+	MergeRequestDefaultTargetSelf            bool               `json:"mr_default_target_self"`
 
 	// Deprecated members
 	PublicBuilds bool `json:"public_builds"`


### PR DESCRIPTION
It's an option for forks, see [the docs](https://docs.gitlab.com/ee/api/projects.html#edit-project:~:text=in%20a%20project.-,mr_default_target_self,project.%20If%20false%2C%20the%20target%20will%20be%20the%20upstream%20project.,-name)