### PR TITLE
Introduce new EventLabel type for webhook events

### DIFF
--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -203,30 +203,30 @@ type IssueCommentEvent struct {
 		URL          string  `json:"url"`
 	} `json:"object_attributes"`
 	Issue struct {
-		ID                  int      `json:"id"`
-		IID                 int      `json:"iid"`
-		ProjectID           int      `json:"project_id"`
-		MilestoneID         int      `json:"milestone_id"`
-		AuthorID            int      `json:"author_id"`
-		Description         string   `json:"description"`
-		State               string   `json:"state"`
-		Title               string   `json:"title"`
-		Labels              []Label  `json:"labels"`
-		LastEditedAt        string   `json:"last_edit_at"`
-		LastEditedByID      int      `json:"last_edited_by_id"`
-		UpdatedAt           string   `json:"updated_at"`
-		UpdatedByID         int      `json:"updated_by_id"`
-		CreatedAt           string   `json:"created_at"`
-		ClosedAt            string   `json:"closed_at"`
-		DueDate             *ISOTime `json:"due_date"`
-		URL                 string   `json:"url"`
-		TimeEstimate        int      `json:"time_estimate"`
-		Confidential        bool     `json:"confidential"`
-		TotalTimeSpent      int      `json:"total_time_spent"`
-		HumanTotalTimeSpent string   `json:"human_total_time_spent"`
-		HumanTimeEstimate   string   `json:"human_time_estimate"`
-		AssigneeIDs         []int    `json:"assignee_ids"`
-		AssigneeID          int      `json:"assignee_id"`
+		ID                  int           `json:"id"`
+		IID                 int           `json:"iid"`
+		ProjectID           int           `json:"project_id"`
+		MilestoneID         int           `json:"milestone_id"`
+		AuthorID            int           `json:"author_id"`
+		Description         string        `json:"description"`
+		State               string        `json:"state"`
+		Title               string        `json:"title"`
+		Labels              []*EventLabel `json:"labels"`
+		LastEditedAt        string        `json:"last_edit_at"`
+		LastEditedByID      int           `json:"last_edited_by_id"`
+		UpdatedAt           string        `json:"updated_at"`
+		UpdatedByID         int           `json:"updated_by_id"`
+		CreatedAt           string        `json:"created_at"`
+		ClosedAt            string        `json:"closed_at"`
+		DueDate             *ISOTime      `json:"due_date"`
+		URL                 string        `json:"url"`
+		TimeEstimate        int           `json:"time_estimate"`
+		Confidential        bool          `json:"confidential"`
+		TotalTimeSpent      int           `json:"total_time_spent"`
+		HumanTotalTimeSpent string        `json:"human_total_time_spent"`
+		HumanTimeEstimate   string        `json:"human_time_estimate"`
+		AssigneeIDs         []int         `json:"assignee_ids"`
+		AssigneeID          int           `json:"assignee_id"`
 	} `json:"issue"`
 }
 
@@ -272,9 +272,9 @@ type IssueEvent struct {
 		URL         string `json:"url"`
 		Action      string `json:"action"`
 	} `json:"object_attributes"`
-	Assignee  *EventUser   `json:"assignee"`
-	Assignees *[]EventUser `json:"assignees"`
-	Labels    []Label      `json:"labels"`
+	Assignee  *EventUser    `json:"assignee"`
+	Assignees *[]EventUser  `json:"assignees"`
+	Labels    []*EventLabel `json:"labels"`
 	Changes   struct {
 		Assignees struct {
 			Previous []*EventUser `json:"previous"`
@@ -285,8 +285,8 @@ type IssueEvent struct {
 			Current  string `json:"current"`
 		} `json:"description"`
 		Labels struct {
-			Previous []Label `json:"previous"`
-			Current  []Label `json:"current"`
+			Previous []*EventLabel `json:"previous"`
+			Current  []*EventLabel `json:"current"`
 		} `json:"labels"`
 		Title struct {
 			Previous string `json:"previous"`
@@ -549,11 +549,11 @@ type MergeEvent struct {
 		OldRev                      string     `json:"oldrev"`
 		Assignee                    *EventUser `json:"assignee"`
 	} `json:"object_attributes"`
-	Repository *Repository  `json:"repository"`
-	Assignee   *EventUser   `json:"assignee"`
-	Assignees  []*EventUser `json:"assignees"`
-	Reviewers  []*EventUser `json:"reviewers"`
-	Labels     []*Label     `json:"labels"`
+	Repository *Repository   `json:"repository"`
+	Assignee   *EventUser    `json:"assignee"`
+	Assignees  []*EventUser  `json:"assignees"`
+	Reviewers  []*EventUser  `json:"reviewers"`
+	Labels     []*EventLabel `json:"labels"`
 	Changes    struct {
 		Assignees struct {
 			Previous []*EventUser `json:"previous"`
@@ -568,8 +568,8 @@ type MergeEvent struct {
 			Current  string `json:"current"`
 		} `json:"description"`
 		Labels struct {
-			Previous []*Label `json:"previous"`
-			Current  []*Label `json:"current"`
+			Previous []*EventLabel `json:"previous"`
+			Current  []*EventLabel `json:"current"`
 		} `json:"labels"`
 		SourceBranch struct {
 			Previous string `json:"previous"`
@@ -1030,4 +1030,21 @@ type WikiPageEvent struct {
 		URL     string `json:"url"`
 		Action  string `json:"action"`
 	} `json:"object_attributes"`
+}
+
+// EventLabel represents a label inside a webhook event.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#issue-events
+type EventLabel struct {
+	ID          int    `json:"id"`
+	Title       string `json:"title"`
+	Color       string `json:"color"`
+	ProjectID   int    `json:"project_id"`
+	CreatedAt   string `json:"created_at"`
+	UpdatedAt   string `json:"updated_at"`
+	Template    bool   `json:"template"`
+	Description string `json:"description"`
+	Type        string `json:"type"`
+	GroupID     int    `json:"group_id"`
 }

--- a/event_webhook_types_test.go
+++ b/event_webhook_types_test.go
@@ -20,6 +20,8 @@ import (
 	"encoding/json"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const (
@@ -131,6 +133,33 @@ func TestIssueCommentEventUnmarshal(t *testing.T) {
 	if len(event.Issue.Labels) == 0 || event.Issue.Labels[0].ID != 25 {
 		t.Errorf("Label id is null")
 	}
+
+	assert.Equal(t, []*EventLabel{
+		{
+			ID:          25,
+			Title:       "Afterpod",
+			Color:       "#3e8068",
+			ProjectID:   0,
+			CreatedAt:   "2019-06-05T14:32:20.211Z",
+			UpdatedAt:   "2019-06-05T14:32:20.211Z",
+			Template:    false,
+			Description: "",
+			Type:        "GroupLabel",
+			GroupID:     4,
+		},
+		{
+			ID:          86,
+			Title:       "Element",
+			Color:       "#231afe",
+			ProjectID:   4,
+			CreatedAt:   "2019-06-05T14:32:20.637Z",
+			UpdatedAt:   "2019-06-05T14:32:20.637Z",
+			Template:    false,
+			Description: "",
+			Type:        "ProjectLabel",
+			GroupID:     0,
+		},
+	}, event.Issue.Labels)
 }
 
 func TestIssueEventUnmarshal(t *testing.T) {
@@ -162,6 +191,51 @@ func TestIssueEventUnmarshal(t *testing.T) {
 	if event.Changes.TotalTimeSpent.Current != 9900 {
 		t.Errorf("Changes.TotalTimeSpent.Current is %v , want %v", event.Changes.TotalTimeSpent.Current, 8100)
 	}
+
+	assert.Equal(t, []*EventLabel{
+		{
+			ID:          206,
+			Title:       "API",
+			Color:       "#ffffff",
+			ProjectID:   14,
+			CreatedAt:   "2013-12-03T17:15:43Z",
+			UpdatedAt:   "2013-12-03T17:15:43Z",
+			Template:    false,
+			Description: "API related issues",
+			Type:        "ProjectLabel",
+			GroupID:     41,
+		},
+	}, event.Labels)
+
+	assert.Equal(t, []*EventLabel{
+		{
+			ID:          206,
+			Title:       "API",
+			Color:       "#ffffff",
+			ProjectID:   14,
+			CreatedAt:   "2013-12-03T17:15:43Z",
+			UpdatedAt:   "2013-12-03T17:15:43Z",
+			Template:    false,
+			Description: "API related issues",
+			Type:        "ProjectLabel",
+			GroupID:     41,
+		},
+	}, event.Changes.Labels.Previous)
+
+	assert.Equal(t, []*EventLabel{
+		{
+			ID:          205,
+			Title:       "Platform",
+			Color:       "#123123",
+			ProjectID:   14,
+			CreatedAt:   "2013-12-03T17:15:43Z",
+			UpdatedAt:   "2013-12-03T17:15:43Z",
+			Template:    false,
+			Description: "Platform related issues",
+			Type:        "ProjectLabel",
+			GroupID:     41,
+		},
+	}, event.Changes.Labels.Current)
 }
 
 func TestMergeEventUnmarshal(t *testing.T) {
@@ -252,6 +326,51 @@ func TestMergeEventUnmarshal(t *testing.T) {
 	if event.Reviewers[0].AvatarURL != excpectedAvatar {
 		t.Errorf("Reviewers[0].AvatarURL is %v, want %v", event.Reviewers[0].AvatarURL, excpectedAvatar)
 	}
+
+	assert.Equal(t, []*EventLabel{
+		{
+			ID:          206,
+			Title:       "API",
+			Color:       "#ffffff",
+			ProjectID:   14,
+			CreatedAt:   "2013-12-03T17:15:43Z",
+			UpdatedAt:   "2013-12-03T17:15:43Z",
+			Template:    false,
+			Description: "API related issues",
+			Type:        "ProjectLabel",
+			GroupID:     41,
+		},
+	}, event.Labels)
+
+	assert.Equal(t, []*EventLabel{
+		{
+			ID:          206,
+			Title:       "API",
+			Color:       "#ffffff",
+			ProjectID:   14,
+			CreatedAt:   "2013-12-03T17:15:43Z",
+			UpdatedAt:   "2013-12-03T17:15:43Z",
+			Template:    false,
+			Description: "API related issues",
+			Type:        "ProjectLabel",
+			GroupID:     41,
+		},
+	}, event.Changes.Labels.Previous)
+
+	assert.Equal(t, []*EventLabel{
+		{
+			ID:          205,
+			Title:       "Platform",
+			Color:       "#123123",
+			ProjectID:   14,
+			CreatedAt:   "2013-12-03T17:15:43Z",
+			UpdatedAt:   "2013-12-03T17:15:43Z",
+			Template:    false,
+			Description: "Platform related issues",
+			Type:        "ProjectLabel",
+			GroupID:     41,
+		},
+	}, event.Changes.Labels.Current)
 }
 
 func TestMemberEventUnmarshal(t *testing.T) {


### PR DESCRIPTION
### Description

I implemented option 2 from #1594, which replaces all `Label` webhook event fields with a new `EventLabel` type that contains the correct fields.

### How it was tested

I updated the unmarshal tests for all event types that contain labels, without touching the testdata. (These tests were not previously inspecting labels.)

### Notes

* This is a breaking change to the package, by changing some field types to `EventLabel`.
* In the `EventLabel` struct, I considered making `ProjectID` and `GroupID` of type `*int` because they are technically nullable. GitLab will populate whichever field matches the label `Type`. However, since this struct is never marshalled, I decided to keep them as `int`.

Closes #1594