### PR TITLE
Fix slow tests caused by retry backoff

### DIFF
--- a/gitlab_test.go
+++ b/gitlab_test.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	retryablehttp "github.com/hashicorp/go-retryablehttp"
 )
@@ -44,7 +45,13 @@ func setup(t *testing.T) (*http.ServeMux, *httptest.Server, *Client) {
 	server := httptest.NewServer(mux)
 
 	// client is the Gitlab client being tested.
-	client, err := NewClient("", WithBaseURL(server.URL))
+	client, err := NewClient("",
+		WithBaseURL(server.URL),
+		// Disable backoff to speed up tests that expect errors.
+		WithCustomBackoff(func(_, _ time.Duration, _ int, _ *http.Response) time.Duration {
+			return 0
+		}),
+	)
 	if err != nil {
 		server.Close()
 		t.Fatalf("Failed to create client: %v", err)


### PR DESCRIPTION
I disabled retry backoffs in tests to reduce the overall test run time from 25 seconds to under 1 second.

Before:

```shell
% ~/go/bin/gotestsum --jsonfile out.json
✓  . (25.685s)
% ~/go/bin/gotestsum tool slowest --jsonfile out.json
github.com/xanzy/go-gitlab TestInstanceClustersService_AddCluster_StatusInternalServerError 12.08s
github.com/xanzy/go-gitlab TestInstanceVariablesService_StatusInternalServerError 11.73s
github.com/xanzy/go-gitlab TestUploadFile_Retry 710ms
github.com/xanzy/go-gitlab TestUploadAvatar_Retry 710ms
```

After:

```shell
% ~/go/bin/gotestsum --jsonfile out.json
✓  . (425ms)
% ~/go/bin/gotestsum tool slowest --jsonfile out.json
```