### PR TITLE
Deprecate the test teardown function

### DIFF
--- a/access_requests_test.go
+++ b/access_requests_test.go
@@ -27,8 +27,7 @@ import (
 )
 
 func TestListProjectAccessRequests(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/access_requests", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -94,8 +93,7 @@ func TestListProjectAccessRequests(t *testing.T) {
 }
 
 func TestListGroupAccessRequests(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/access_requests", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -161,8 +159,7 @@ func TestListGroupAccessRequests(t *testing.T) {
 }
 
 func TestRequestProjectAccess(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/access_requests", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -208,8 +205,7 @@ func TestRequestProjectAccess(t *testing.T) {
 }
 
 func TestRequestGroupAccess(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/access_requests", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -255,8 +251,7 @@ func TestRequestGroupAccess(t *testing.T) {
 }
 
 func TestApproveProjectAccessRequest(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/access_requests/10/approve", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -315,8 +310,7 @@ func TestApproveProjectAccessRequest(t *testing.T) {
 }
 
 func TestApproveGroupAccessRequest(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/access_requests/10/approve", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -375,8 +369,7 @@ func TestApproveGroupAccessRequest(t *testing.T) {
 }
 
 func TestDenyProjectAccessRequest(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/access_requests/10", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
@@ -400,8 +393,7 @@ func TestDenyProjectAccessRequest(t *testing.T) {
 }
 
 func TestDenyGroupAccessRequest(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/access_requests/10", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)

--- a/applications_test.go
+++ b/applications_test.go
@@ -24,8 +24,7 @@ import (
 )
 
 func TestCreateApplication(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/applications",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -56,8 +55,7 @@ func TestCreateApplication(t *testing.T) {
 }
 
 func TestListApplications(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/applications",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -84,8 +82,7 @@ func TestListApplications(t *testing.T) {
 }
 
 func TestDeleteApplication(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/applications/4",
 		func(w http.ResponseWriter, r *http.Request) {

--- a/audit_events_test.go
+++ b/audit_events_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 func TestAuditEventsService_ListInstanceAuditEvents(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/audit_events", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -63,8 +62,7 @@ func TestAuditEventsService_ListInstanceAuditEvents(t *testing.T) {
 }
 
 func TestAuditEventsService_ListInstanceAuditEvents_StatusNotFound(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/audit_events", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -78,8 +76,7 @@ func TestAuditEventsService_ListInstanceAuditEvents_StatusNotFound(t *testing.T)
 }
 
 func TestAuditEventsService_GetInstanceAuditEvent(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/audit_events/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -135,8 +132,7 @@ func TestAuditEventsService_GetInstanceAuditEvent(t *testing.T) {
 }
 
 func TestAuditEventsService_ListGroupAuditEvents(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/6/audit_events", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -199,8 +195,7 @@ func TestAuditEventsService_ListGroupAuditEvents(t *testing.T) {
 }
 
 func TestAuditEventsService_GetGroupAuditEvent(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/6/audit_events/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -261,8 +256,7 @@ func TestAuditEventsService_GetGroupAuditEvent(t *testing.T) {
 }
 
 func TestAuditEventsService_ListProjectAuditEvents(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/6/audit_events", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -325,8 +319,7 @@ func TestAuditEventsService_ListProjectAuditEvents(t *testing.T) {
 }
 
 func TestAuditEventsService_GetProjectAuditEvent(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/6/audit_events/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)

--- a/avatar_test.go
+++ b/avatar_test.go
@@ -23,8 +23,7 @@ import (
 )
 
 func TestGetAvatar(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	const url = "https://www.gravatar.com/avatar/10e6bf7bcf22c2f00a3ef684b4ada178"
 

--- a/award_emojis_test.go
+++ b/award_emojis_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 func TestAwardEmojiService_ListMergeRequestAwardEmoji(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/merge_requests/80/award_emoji", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -80,8 +79,7 @@ func TestAwardEmojiService_ListMergeRequestAwardEmoji(t *testing.T) {
 }
 
 func TestAwardEmojiService_ListIssueAwardEmoji(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/issues/80/award_emoji", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -151,8 +149,7 @@ func TestAwardEmojiService_ListIssueAwardEmoji(t *testing.T) {
 }
 
 func TestAwardEmojiService_ListSnippetAwardEmoji(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/snippets/80/award_emoji", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -222,8 +219,7 @@ func TestAwardEmojiService_ListSnippetAwardEmoji(t *testing.T) {
 }
 
 func TestAwardEmojiService_GetMergeRequestAwardEmoji(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/merge_requests/80/award_emoji/4", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -291,8 +287,7 @@ func TestAwardEmojiService_GetMergeRequestAwardEmoji(t *testing.T) {
 }
 
 func TestAwardEmojiService_GetIssueAwardEmoji(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/issues/80/award_emoji/4", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -360,8 +355,7 @@ func TestAwardEmojiService_GetIssueAwardEmoji(t *testing.T) {
 }
 
 func TestAwardEmojiService_GetSnippetAwardEmoji(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/snippets/80/award_emoji/4", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -429,8 +423,7 @@ func TestAwardEmojiService_GetSnippetAwardEmoji(t *testing.T) {
 }
 
 func TestAwardEmojiService_CreateMergeRequestAwardEmoji(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/merge_requests/80/award_emoji", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -498,8 +491,7 @@ func TestAwardEmojiService_CreateMergeRequestAwardEmoji(t *testing.T) {
 }
 
 func TestAwardEmojiService_CreateIssueAwardEmoji(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/issues/80/award_emoji", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -567,8 +559,7 @@ func TestAwardEmojiService_CreateIssueAwardEmoji(t *testing.T) {
 }
 
 func TestAwardEmojiService_CreateSnippetAwardEmoji(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/snippets/80/award_emoji", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -636,8 +627,7 @@ func TestAwardEmojiService_CreateSnippetAwardEmoji(t *testing.T) {
 }
 
 func TestAwardEmojiService_DeleteMergeRequestAwardEmoji(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/merge_requests/80/award_emoji/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
@@ -661,8 +651,7 @@ func TestAwardEmojiService_DeleteMergeRequestAwardEmoji(t *testing.T) {
 }
 
 func TestAwardEmojiService_DeleteIssueAwardEmoji(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/issues/80/award_emoji/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
@@ -686,8 +675,7 @@ func TestAwardEmojiService_DeleteIssueAwardEmoji(t *testing.T) {
 }
 
 func TestAwardEmojiService_DeleteSnippetAwardEmoji(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/snippets/80/award_emoji/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
@@ -711,8 +699,7 @@ func TestAwardEmojiService_DeleteSnippetAwardEmoji(t *testing.T) {
 }
 
 func TestAwardEmojiService_ListMergeRequestAwardEmojiOnNote(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/merge_requests/80/notes/1/award_emoji", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -782,8 +769,7 @@ func TestAwardEmojiService_ListMergeRequestAwardEmojiOnNote(t *testing.T) {
 }
 
 func TestAwardEmojiService_ListIssuesAwardEmojiOnNote(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/issues/80/notes/1/award_emoji", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -853,8 +839,7 @@ func TestAwardEmojiService_ListIssuesAwardEmojiOnNote(t *testing.T) {
 }
 
 func TestAwardEmojiService_ListSnippetAwardEmojiOnNote(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/snippets/80/notes/1/award_emoji", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -924,8 +909,7 @@ func TestAwardEmojiService_ListSnippetAwardEmojiOnNote(t *testing.T) {
 }
 
 func TestAwardEmojiService_GetMergeRequestAwardEmojiOnNote(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/merge_requests/80/notes/1/award_emoji/4", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -993,8 +977,7 @@ func TestAwardEmojiService_GetMergeRequestAwardEmojiOnNote(t *testing.T) {
 }
 
 func TestAwardEmojiService_GetIssuesAwardEmojiOnNote(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/issues/80/notes/1/award_emoji/4", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -1062,8 +1045,7 @@ func TestAwardEmojiService_GetIssuesAwardEmojiOnNote(t *testing.T) {
 }
 
 func TestAwardEmojiService_GetSnippetAwardEmojiOnNote(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/snippets/80/notes/1/award_emoji/4", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -1131,8 +1113,7 @@ func TestAwardEmojiService_GetSnippetAwardEmojiOnNote(t *testing.T) {
 }
 
 func TestAwardEmojiService_CCreateMergeRequestAwardEmojiOnNote(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/merge_requests/80/notes/1/award_emoji", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -1200,8 +1181,7 @@ func TestAwardEmojiService_CCreateMergeRequestAwardEmojiOnNote(t *testing.T) {
 }
 
 func TestAwardEmojiService_CreateIssuesAwardEmojiOnNote(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/issues/80/notes/1/award_emoji", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -1269,8 +1249,7 @@ func TestAwardEmojiService_CreateIssuesAwardEmojiOnNote(t *testing.T) {
 }
 
 func TestAwardEmojiService_CreateSnippetAwardEmojiOnNote(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/snippets/80/notes/1/award_emoji", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -1338,8 +1317,7 @@ func TestAwardEmojiService_CreateSnippetAwardEmojiOnNote(t *testing.T) {
 }
 
 func TestAwardEmojiService_DeleteMergeRequestAwardEmojiOnNote(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/merge_requests/80/notes/1/award_emoji/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
@@ -1363,8 +1341,7 @@ func TestAwardEmojiService_DeleteMergeRequestAwardEmojiOnNote(t *testing.T) {
 }
 
 func TestAwardEmojiService_DeleteIssuesAwardEmojiOnNote(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/issues/80/notes/1/award_emoji/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
@@ -1388,8 +1365,7 @@ func TestAwardEmojiService_DeleteIssuesAwardEmojiOnNote(t *testing.T) {
 }
 
 func TestAwardEmojiService_DeleteSnippetAwardEmojiOnNote(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/snippets/80/notes/1/award_emoji/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)

--- a/boards_test.go
+++ b/boards_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 func TestIssueBoardsService_CreateIssueBoard(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/boards", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -75,8 +74,7 @@ func TestIssueBoardsService_CreateIssueBoard(t *testing.T) {
 }
 
 func TestIssueBoardsService_UpdateIssueBoard(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/boards/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -141,8 +139,7 @@ func TestIssueBoardsService_UpdateIssueBoard(t *testing.T) {
 }
 
 func TestIssueBoardsService_DeleteIssueBoard(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/boards/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
@@ -166,8 +163,7 @@ func TestIssueBoardsService_DeleteIssueBoard(t *testing.T) {
 }
 
 func TestIssueBoardsService_ListIssueBoards(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/boards", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -297,8 +293,7 @@ func TestIssueBoardsService_ListIssueBoards(t *testing.T) {
 }
 
 func TestIssueBoardsService_GetIssueBoard(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/boards/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -427,8 +422,7 @@ func TestIssueBoardsService_GetIssueBoard(t *testing.T) {
 }
 
 func TestIssueBoardsService_GetIssueBoardLists(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/boards/1/lists", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -523,8 +517,7 @@ func TestIssueBoardsService_GetIssueBoardLists(t *testing.T) {
 }
 
 func TestIssueBoardsService_GetIssueBoardList(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/boards/1/lists/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -575,8 +568,7 @@ func TestIssueBoardsService_GetIssueBoardList(t *testing.T) {
 }
 
 func TestIssueBoardsService_CreateIssueBoardList(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/boards/1/lists", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -627,8 +619,7 @@ func TestIssueBoardsService_CreateIssueBoardList(t *testing.T) {
 }
 
 func TestIssueBoardsService_UpdateIssueBoardList(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/boards/1/lists/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -679,8 +670,7 @@ func TestIssueBoardsService_UpdateIssueBoardList(t *testing.T) {
 }
 
 func TestIssueBoardsService_DeleteIssueBoardList(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/boards/1/lists/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)

--- a/branches_test.go
+++ b/branches_test.go
@@ -26,8 +26,7 @@ import (
 )
 
 func TestGetBranch(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/repository/branches/master", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -68,8 +67,7 @@ func TestGetBranch(t *testing.T) {
 }
 
 func TestBranchesService_ListBranches(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/repository/branches", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -124,8 +122,7 @@ func TestBranchesService_ListBranches(t *testing.T) {
 }
 
 func TestBranchesService_ProtectBranch(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/repository/branches/master/protect", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -179,8 +176,7 @@ func TestBranchesService_ProtectBranch(t *testing.T) {
 }
 
 func TestBranchesService_UnprotectBranch(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/repository/branches/master/unprotect", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -234,8 +230,7 @@ func TestBranchesService_UnprotectBranch(t *testing.T) {
 }
 
 func TestBranchesService_CreateBranch(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/repository/branches", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -289,8 +284,7 @@ func TestBranchesService_CreateBranch(t *testing.T) {
 }
 
 func TestBranchesService_DeleteBranch(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/repository/branches/master", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
@@ -314,8 +308,7 @@ func TestBranchesService_DeleteBranch(t *testing.T) {
 }
 
 func TestBranchesService_DeleteMergedBranches(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/repository/merged_branches", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)

--- a/broadcast_messages_test.go
+++ b/broadcast_messages_test.go
@@ -25,8 +25,7 @@ import (
 )
 
 func TestListBroadcastMessages(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/broadcast_messages", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -84,8 +83,7 @@ func TestListBroadcastMessages(t *testing.T) {
 }
 
 func TestGetBroadcastMessages(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/broadcast_messages/1/", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -123,8 +121,7 @@ func TestGetBroadcastMessages(t *testing.T) {
 }
 
 func TestCreateBroadcastMessages(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	wantedStartsAt := time.Date(2017, time.June, 26, 6, 0, 0, 0, time.UTC)
 	wantedEndsAt := time.Date(2017, time.June, 27, 12, 59, 0, 0, time.UTC)
@@ -171,8 +168,7 @@ func TestCreateBroadcastMessages(t *testing.T) {
 }
 
 func TestUpdateBroadcastMessages(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	wantedStartsAt := time.Date(2017, time.June, 26, 6, 0, 0, 0, time.UTC)
 	wantedEndsAt := time.Date(2017, time.June, 27, 12, 59, 0, 0, time.UTC)
@@ -219,8 +215,7 @@ func TestUpdateBroadcastMessages(t *testing.T) {
 }
 
 func TestDeleteBroadcastMessages(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/broadcast_messages/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)

--- a/ci_yml_templates_test.go
+++ b/ci_yml_templates_test.go
@@ -24,8 +24,7 @@ import (
 )
 
 func TestListAllTemplates(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/templates/gitlab_ci_ymls", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -76,8 +75,7 @@ func TestListAllTemplates(t *testing.T) {
 }
 
 func TestGetTemplate(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/templates/gitlab_ci_ymls/Ruby", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)

--- a/cluster_agents_test.go
+++ b/cluster_agents_test.go
@@ -25,8 +25,7 @@ import (
 )
 
 func ListClusterAgents(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/20/cluster_agents", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -111,8 +110,7 @@ func ListClusterAgents(t *testing.T) {
 }
 
 func GetClusterAgent(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/20/cluster_agents/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -161,8 +159,7 @@ func GetClusterAgent(t *testing.T) {
 }
 
 func RegisterClusterAgent(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/20/cluster_agents", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -212,8 +209,7 @@ func RegisterClusterAgent(t *testing.T) {
 }
 
 func ListAgentTokens(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/20/cluster_agents/5/tokens", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -274,8 +270,7 @@ func ListAgentTokens(t *testing.T) {
 }
 
 func GetAgentToken(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/20/cluster_agents/5/tokens/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -314,8 +309,7 @@ func GetAgentToken(t *testing.T) {
 }
 
 func RegisterAgentToken(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/20/cluster_agents/5/tokens", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)

--- a/commits_test.go
+++ b/commits_test.go
@@ -33,8 +33,7 @@ import (
 var testRevertCommitTargetBranch = "release"
 
 func TestGetCommit(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/repository/commits/b0b3a907f41409829b307a28b82fdbd552ee5a27", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -76,8 +75,7 @@ func TestGetCommit(t *testing.T) {
 }
 
 func TestGetCommitStatuses(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/repository/commits/b0b3a907f41409829b307a28b82fdbd552ee5a27/statuses", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -103,8 +101,7 @@ func TestGetCommitStatuses(t *testing.T) {
 }
 
 func TestSetCommitStatus(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/statuses/b0b3a907f41409829b307a28b82fdbd552ee5a27", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -143,8 +140,7 @@ func TestSetCommitStatus(t *testing.T) {
 }
 
 func TestRevertCommit_NoOptions(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/repository/commits/b0b3a907f41409829b307a28b82fdbd552ee5a27/revert", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -186,8 +182,7 @@ func TestRevertCommit_NoOptions(t *testing.T) {
 }
 
 func TestRevertCommit_WithOptions(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/repository/commits/b0b3a907f41409829b307a28b82fdbd552ee5a27/revert", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -232,8 +227,7 @@ func TestRevertCommit_WithOptions(t *testing.T) {
 }
 
 func TestGetGPGSignature(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/repository/commits/b0b3a907f41409829b307a28b82fdbd552ee5a27/signature", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -258,8 +252,7 @@ func TestGetGPGSignature(t *testing.T) {
 }
 
 func TestCommitsService_ListCommits(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/repository/commits", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -346,8 +339,7 @@ func TestCommitsService_ListCommits(t *testing.T) {
 }
 
 func TestCommitsService_GetCommitRefs(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/repository/commits/5937ac0a7beb003549fc5fd26fc247adbce4a52e/refs", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -402,8 +394,7 @@ func TestCommitsService_GetCommitRefs(t *testing.T) {
 }
 
 func TestCommitsService_CreateCommit(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/repository/commits", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -488,8 +479,7 @@ func TestCommitsService_CreateCommit(t *testing.T) {
 }
 
 func TestCommitsService_GetCommitDiff(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/repository/commits/master/diff", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -538,8 +528,7 @@ func TestCommitsService_GetCommitDiff(t *testing.T) {
 }
 
 func TestCommitsService_GetCommitComments(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/repository/commits/master/comments", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -592,8 +581,7 @@ func TestCommitsService_GetCommitComments(t *testing.T) {
 }
 
 func TestCommitsService_PostCommitComment(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/repository/commits/master/comments", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -644,8 +632,7 @@ func TestCommitsService_PostCommitComment(t *testing.T) {
 }
 
 func TestCommitsService_ListMergeRequestsByCommit(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/repository/commits/master/merge_requests", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -859,8 +846,7 @@ func TestCommitsService_ListMergeRequestsByCommit(t *testing.T) {
 }
 
 func TestCommitsService_CherryPickCommit(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/repository/commits/master/cherry_pick", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)

--- a/container_registry_test.go
+++ b/container_registry_test.go
@@ -25,8 +25,7 @@ import (
 )
 
 func TestListProjectRegistryRepositories(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/registry/repositories", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -101,8 +100,7 @@ func TestListProjectRegistryRepositories(t *testing.T) {
 }
 
 func TestListGroupRegistryRepositories(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/5/registry/repositories", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -177,8 +175,7 @@ func TestListGroupRegistryRepositories(t *testing.T) {
 }
 
 func TestGetSingleRegistryRepository(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/registry/repositories/5", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -221,8 +218,7 @@ func TestGetSingleRegistryRepository(t *testing.T) {
 }
 
 func TestDeleteRegistryRepository(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/registry/repositories/2", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
@@ -235,8 +231,7 @@ func TestDeleteRegistryRepository(t *testing.T) {
 }
 
 func TestListRegistryRepositoryTags(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/registry/repositories/2/tags", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -278,8 +273,7 @@ func TestListRegistryRepositoryTags(t *testing.T) {
 }
 
 func TestGetRegistryRepositoryTagDetail(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/registry/repositories/2/tags/v10.0.0", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -321,8 +315,7 @@ func TestGetRegistryRepositoryTagDetail(t *testing.T) {
 }
 
 func TestDeleteRegistryRepositoryTag(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/registry/repositories/2/tags/v10.0.0", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
@@ -335,8 +328,7 @@ func TestDeleteRegistryRepositoryTag(t *testing.T) {
 }
 
 func TestDeleteRegistryRepositoryTags(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/registry/repositories/2/tags", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)

--- a/custom_attributes_test.go
+++ b/custom_attributes_test.go
@@ -24,8 +24,7 @@ import (
 )
 
 func TestListCustomUserAttributes(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/users/2/custom_attributes", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -45,8 +44,7 @@ func TestListCustomUserAttributes(t *testing.T) {
 }
 
 func TestListCustomGroupAttributes(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/2/custom_attributes", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -66,8 +64,7 @@ func TestListCustomGroupAttributes(t *testing.T) {
 }
 
 func TestListCustomProjectAttributes(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/2/custom_attributes", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -87,8 +84,7 @@ func TestListCustomProjectAttributes(t *testing.T) {
 }
 
 func TestGetCustomUserAttribute(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/users/2/custom_attributes/testkey1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -108,8 +104,7 @@ func TestGetCustomUserAttribute(t *testing.T) {
 }
 
 func TestGetCustomGropupAttribute(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/2/custom_attributes/testkey1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -129,8 +124,7 @@ func TestGetCustomGropupAttribute(t *testing.T) {
 }
 
 func TestGetCustomProjectAttribute(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/2/custom_attributes/testkey1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -150,8 +144,7 @@ func TestGetCustomProjectAttribute(t *testing.T) {
 }
 
 func TestSetCustomUserAttribute(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/users/2/custom_attributes/testkey1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -174,8 +167,7 @@ func TestSetCustomUserAttribute(t *testing.T) {
 }
 
 func TestSetCustomGroupAttribute(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/2/custom_attributes/testkey1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -198,8 +190,7 @@ func TestSetCustomGroupAttribute(t *testing.T) {
 }
 
 func TestDeleteCustomUserAttribute(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/users/2/custom_attributes/testkey1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
@@ -219,8 +210,7 @@ func TestDeleteCustomUserAttribute(t *testing.T) {
 }
 
 func TestDeleteCustomGroupAttribute(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/2/custom_attributes/testkey1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
@@ -240,8 +230,7 @@ func TestDeleteCustomGroupAttribute(t *testing.T) {
 }
 
 func TestDeleteCustomProjectAttribute(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/2/custom_attributes/testkey1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)

--- a/deploy_keys_test.go
+++ b/deploy_keys_test.go
@@ -25,8 +25,7 @@ import (
 )
 
 func TestListAllDeployKeys(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/deploy_keys", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -122,8 +121,7 @@ func TestListAllDeployKeys(t *testing.T) {
 }
 
 func TestListProjectDeployKeys(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/deploy_keys", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -182,8 +180,7 @@ func TestListProjectDeployKeys(t *testing.T) {
 }
 
 func TestGetDeployKey(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/deploy_keys/11", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -219,8 +216,7 @@ func TestGetDeployKey(t *testing.T) {
 }
 
 func TestAddDeployKey(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/deploy_keys", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -261,8 +257,7 @@ func TestAddDeployKey(t *testing.T) {
 }
 
 func TestDeleteDeployKey(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/deploy_keys/13", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
@@ -275,8 +270,7 @@ func TestDeleteDeployKey(t *testing.T) {
 }
 
 func TestEnableDeployKey(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/deploy_keys/13/enable", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -310,8 +304,7 @@ func TestEnableDeployKey(t *testing.T) {
 }
 
 func TestUpdateDeployKey(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/deploy_keys/11", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)

--- a/deploy_tokens_test.go
+++ b/deploy_tokens_test.go
@@ -25,8 +25,7 @@ import (
 )
 
 func TestListAllDeployTokens(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/deploy_tokens", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -72,8 +71,7 @@ func TestListAllDeployTokens(t *testing.T) {
 }
 
 func TestListProjectDeployTokens(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/deploy_tokens", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -119,8 +117,7 @@ func TestListProjectDeployTokens(t *testing.T) {
 }
 
 func TestGetProjectDeployTokens(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/deploy_tokens/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -162,8 +159,7 @@ func TestGetProjectDeployTokens(t *testing.T) {
 }
 
 func TestCreateProjectDeployToken(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/deploy_tokens", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -212,8 +208,7 @@ func TestCreateProjectDeployToken(t *testing.T) {
 }
 
 func TestDeleteProjectDeployToken(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/deploy_tokens/13", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
@@ -234,8 +229,7 @@ func TestDeleteProjectDeployToken(t *testing.T) {
 }
 
 func TestListGroupDeployTokens(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/deploy_tokens", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -281,8 +275,7 @@ func TestListGroupDeployTokens(t *testing.T) {
 }
 
 func TestGetGroupDeployTokens(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/deploy_tokens/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -324,8 +317,7 @@ func TestGetGroupDeployTokens(t *testing.T) {
 }
 
 func TestCreateGroupDeployToken(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/5/deploy_tokens", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -374,8 +366,7 @@ func TestCreateGroupDeployToken(t *testing.T) {
 }
 
 func TestDeleteGroupDeployToken(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/5/deploy_tokens/13", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)

--- a/deployments_merge_requests_test.go
+++ b/deployments_merge_requests_test.go
@@ -10,8 +10,7 @@ import (
 )
 
 func TestDeploymentMergeRequestsService_ListDeploymentMergeRequests(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/278964/deployments/2/merge_requests", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)

--- a/deployments_test.go
+++ b/deployments_test.go
@@ -10,8 +10,7 @@ import (
 )
 
 func TestDeploymentsService_ListProjectDeployments(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/deployments", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -208,8 +207,7 @@ func TestDeploymentsService_ListProjectDeployments(t *testing.T) {
 }
 
 func TestDeploymentsService_GetProjectDeployment(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/deployments/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -404,8 +402,7 @@ func TestDeploymentsService_GetProjectDeployment(t *testing.T) {
 }
 
 func TestDeploymentsService_CreateProjectDeployment(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/deployments", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -600,8 +597,7 @@ func TestDeploymentsService_CreateProjectDeployment(t *testing.T) {
 }
 
 func TestDeploymentsService_UpdateProjectDeployment(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/deployments/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)

--- a/discussions_test.go
+++ b/discussions_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 func TestDiscussionsService_ListIssueDiscussions(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/issues/11/discussions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -116,8 +115,7 @@ func TestDiscussionsService_ListIssueDiscussions(t *testing.T) {
 }
 
 func TestDiscussionsService_GetIssueDiscussion(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/issues/11/discussions/6a9c1750b37d513a43987b574953fceb50b03ce7", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -221,8 +219,7 @@ func TestDiscussionsService_GetIssueDiscussion(t *testing.T) {
 }
 
 func TestDiscussionsService_CreateIssueDiscussion(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/issues/11/discussions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -326,8 +323,7 @@ func TestDiscussionsService_CreateIssueDiscussion(t *testing.T) {
 }
 
 func TestDiscussionsService_AddIssueDiscussionNote(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/issues/11/discussions/6a9c1750b37d513a43987b574953fceb50b03ce7/notes", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -421,8 +417,7 @@ func TestDiscussionsService_AddIssueDiscussionNote(t *testing.T) {
 }
 
 func TestDiscussionsService_UpdateIssueDiscussionNote(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/issues/11/discussions/6a9c1750b37d513a43987b574953fceb50b03ce7/notes/302", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -516,8 +511,7 @@ func TestDiscussionsService_UpdateIssueDiscussionNote(t *testing.T) {
 }
 
 func TestDiscussionsService_DeleteIssueDiscussionNote(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/issues/11/discussions/6a9c1750b37d513a43987b574953fceb50b03ce7/notes/302", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
@@ -541,8 +535,7 @@ func TestDiscussionsService_DeleteIssueDiscussionNote(t *testing.T) {
 }
 
 func TestDiscussionsService_ListSnippetDiscussions(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/snippets/11/discussions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -648,8 +641,7 @@ func TestDiscussionsService_ListSnippetDiscussions(t *testing.T) {
 }
 
 func TestDiscussionsService_GetSnippetDiscussion(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/snippets/11/discussions/6a9c1750b37d513a43987b574953fceb50b03ce7", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -753,8 +745,7 @@ func TestDiscussionsService_GetSnippetDiscussion(t *testing.T) {
 }
 
 func TestDiscussionsService_CreateSnippetDiscussion(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/snippets/11/discussions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -858,8 +849,7 @@ func TestDiscussionsService_CreateSnippetDiscussion(t *testing.T) {
 }
 
 func TestDiscussionsService_AddSnippetDiscussionNote(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/snippets/11/discussions/6a9c1750b37d513a43987b574953fceb50b03ce7/notes", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -953,8 +943,7 @@ func TestDiscussionsService_AddSnippetDiscussionNote(t *testing.T) {
 }
 
 func TestDiscussionsService_UpdateSnippetDiscussionNote(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/snippets/11/discussions/6a9c1750b37d513a43987b574953fceb50b03ce7/notes/302", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -1048,8 +1037,7 @@ func TestDiscussionsService_UpdateSnippetDiscussionNote(t *testing.T) {
 }
 
 func TestDiscussionsService_DeleteSnippetDiscussionNote(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/snippets/11/discussions/6a9c1750b37d513a43987b574953fceb50b03ce7/notes/302", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
@@ -1073,8 +1061,7 @@ func TestDiscussionsService_DeleteSnippetDiscussionNote(t *testing.T) {
 }
 
 func TestDiscussionsService_ListGroupEpicDiscussions(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/5/epics/11/discussions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -1180,8 +1167,7 @@ func TestDiscussionsService_ListGroupEpicDiscussions(t *testing.T) {
 }
 
 func TestDiscussionsService_GetEpicDiscussion(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/5/epics/11/discussions/6a9c1750b37d513a43987b574953fceb50b03ce7", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -1285,8 +1271,7 @@ func TestDiscussionsService_GetEpicDiscussion(t *testing.T) {
 }
 
 func TestDiscussionsService_CreateEpicDiscussion(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/5/epics/11/discussions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -1390,8 +1375,7 @@ func TestDiscussionsService_CreateEpicDiscussion(t *testing.T) {
 }
 
 func TestDiscussionsService_AddEpicDiscussionNote(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/5/epics/11/discussions/6a9c1750b37d513a43987b574953fceb50b03ce7/notes", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -1485,8 +1469,7 @@ func TestDiscussionsService_AddEpicDiscussionNote(t *testing.T) {
 }
 
 func TestDiscussionsService_UpdateEpicDiscussionNote(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/5/epics/11/discussions/6a9c1750b37d513a43987b574953fceb50b03ce7/notes/302", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -1580,8 +1563,7 @@ func TestDiscussionsService_UpdateEpicDiscussionNote(t *testing.T) {
 }
 
 func TestDiscussionsService_DeleteEpicDiscussionNote(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/5/epics/11/discussions/6a9c1750b37d513a43987b574953fceb50b03ce7/notes/302", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
@@ -1605,8 +1587,7 @@ func TestDiscussionsService_DeleteEpicDiscussionNote(t *testing.T) {
 }
 
 func TestDiscussionsService_ListMergeRequestDiscussions(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/merge_requests/11/discussions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -1712,8 +1693,7 @@ func TestDiscussionsService_ListMergeRequestDiscussions(t *testing.T) {
 }
 
 func TestDiscussionsService_GetMergeRequestDiscussion(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/merge_requests/11/discussions/6a9c1750b37d513a43987b574953fceb50b03ce7", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -1817,8 +1797,7 @@ func TestDiscussionsService_GetMergeRequestDiscussion(t *testing.T) {
 }
 
 func TestDiscussionsService_CreateMergeRequestDiscussion(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/merge_requests/11/discussions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -1922,8 +1901,7 @@ func TestDiscussionsService_CreateMergeRequestDiscussion(t *testing.T) {
 }
 
 func TestDiscussionsService_ResolveMergeRequestDiscussion(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/merge_requests/11/discussions/6a9c1750b37d513a43987b574953fceb50b03ce7", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -2027,8 +2005,7 @@ func TestDiscussionsService_ResolveMergeRequestDiscussion(t *testing.T) {
 }
 
 func TestDiscussionsService_AddMergeRequestDiscussionNote(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/merge_requests/11/discussions/6a9c1750b37d513a43987b574953fceb50b03ce7/notes", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -2122,8 +2099,7 @@ func TestDiscussionsService_AddMergeRequestDiscussionNote(t *testing.T) {
 }
 
 func TestDiscussionsService_UpdateMergeRequestDiscussionNote(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/merge_requests/11/discussions/6a9c1750b37d513a43987b574953fceb50b03ce7/notes/302", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -2217,8 +2193,7 @@ func TestDiscussionsService_UpdateMergeRequestDiscussionNote(t *testing.T) {
 }
 
 func TestDiscussionsService_DeleteMergeRequestDiscussionNote(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/merge_requests/11/discussions/6a9c1750b37d513a43987b574953fceb50b03ce7/notes/302", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
@@ -2242,8 +2217,7 @@ func TestDiscussionsService_DeleteMergeRequestDiscussionNote(t *testing.T) {
 }
 
 func TestDiscussionsService_ListCommitDiscussions(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/repository/commits/abc123/discussions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -2349,8 +2323,7 @@ func TestDiscussionsService_ListCommitDiscussions(t *testing.T) {
 }
 
 func TestDiscussionsService_GetCommitDiscussion(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/repository/commits/abc123/discussions/6a9c1750b37d513a43987b574953fceb50b03ce7", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -2454,8 +2427,7 @@ func TestDiscussionsService_GetCommitDiscussion(t *testing.T) {
 }
 
 func TestDiscussionsService_CreateCommitDiscussion(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/repository/commits/abc123/discussions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -2559,8 +2531,7 @@ func TestDiscussionsService_CreateCommitDiscussion(t *testing.T) {
 }
 
 func TestDiscussionsService_AddCommitDiscussionNote(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/repository/commits/abc123/discussions/6a9c1750b37d513a43987b574953fceb50b03ce7/notes", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -2654,8 +2625,7 @@ func TestDiscussionsService_AddCommitDiscussionNote(t *testing.T) {
 }
 
 func TestDiscussionsService_UpdateCommitDiscussionNote(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/repository/commits/abc123/discussions/6a9c1750b37d513a43987b574953fceb50b03ce7/notes/302", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -2749,8 +2719,7 @@ func TestDiscussionsService_UpdateCommitDiscussionNote(t *testing.T) {
 }
 
 func TestDiscussionsService_DeleteCommitDiscussionNote(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/repository/commits/abc123/discussions/6a9c1750b37d513a43987b574953fceb50b03ce7/notes/302", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)

--- a/environments_test.go
+++ b/environments_test.go
@@ -29,8 +29,7 @@ import (
 )
 
 func TestListEnvironments(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/environments", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -70,8 +69,7 @@ func TestListEnvironments(t *testing.T) {
 }
 
 func TestGetEnvironment(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/environments/5949167", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -108,8 +106,7 @@ func TestGetEnvironment(t *testing.T) {
 }
 
 func TestCreateEnvironment(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/environments", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -129,8 +126,7 @@ func TestCreateEnvironment(t *testing.T) {
 }
 
 func TestEditEnvironment(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/environments/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -150,8 +146,7 @@ func TestEditEnvironment(t *testing.T) {
 }
 
 func TestDeleteEnvironment(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/environments/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
@@ -164,8 +159,7 @@ func TestDeleteEnvironment(t *testing.T) {
 }
 
 func TestStopEnvironment(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/environments/1/stop", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)

--- a/epic_issues_test.go
+++ b/epic_issues_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 func TestEpicIssuesService_ListEpicIssues(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/epics/5/issues", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -181,8 +180,7 @@ func TestEpicIssuesService_ListEpicIssues(t *testing.T) {
 }
 
 func TestEpicIssuesService_AssignEpicIssue(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/epics/5/issues/55", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -374,8 +372,7 @@ func TestEpicIssuesService_AssignEpicIssue(t *testing.T) {
 }
 
 func TestEpicIssuesService_RemoveEpicIssue(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/epics/5/issues/55", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
@@ -567,8 +564,7 @@ func TestEpicIssuesService_RemoveEpicIssue(t *testing.T) {
 }
 
 func TestEpicIssuesService_UpdateEpicIssueAssignment(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/epics/5/issues/2", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)

--- a/epics_test.go
+++ b/epics_test.go
@@ -25,8 +25,7 @@ import (
 )
 
 func TestGetEpic(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/7/epics/8", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -51,8 +50,7 @@ func TestGetEpic(t *testing.T) {
 }
 
 func TestDeleteEpic(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/7/epics/8", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
@@ -65,8 +63,7 @@ func TestDeleteEpic(t *testing.T) {
 }
 
 func TestListGroupEpics(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/7/epics", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -97,8 +94,7 @@ func TestListGroupEpics(t *testing.T) {
 }
 
 func TestCreateEpic(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/7/epics", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -128,8 +124,7 @@ func TestCreateEpic(t *testing.T) {
 }
 
 func TestUpdateEpic(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/7/epics/8", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)

--- a/error_tracking_test.go
+++ b/error_tracking_test.go
@@ -24,8 +24,7 @@ import (
 )
 
 func TestGetErrorTracking(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/error_tracking/settings", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -57,8 +56,7 @@ func TestGetErrorTracking(t *testing.T) {
 }
 
 func TestDisableErrorTracking(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/error_tracking/settings", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPatch)
@@ -96,8 +94,7 @@ func TestDisableErrorTracking(t *testing.T) {
 }
 
 func TestListErrorTrackingClientKeys(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/error_tracking/client_keys", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -129,8 +126,7 @@ func TestListErrorTrackingClientKeys(t *testing.T) {
 }
 
 func TestCreateClientKey(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/error_tracking/client_keys", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -160,8 +156,7 @@ func TestCreateClientKey(t *testing.T) {
 }
 
 func TestDeleteClientKey(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/error_tracking/client_keys/3", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)

--- a/events_test.go
+++ b/events_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 func TestUsersService_ListUserContributionEvents(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/users/1/events", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -92,8 +91,7 @@ func TestUsersService_ListUserContributionEvents(t *testing.T) {
 }
 
 func TestEventsService_ListCurrentUserContributionEvents(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/events", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -165,8 +163,7 @@ func TestEventsService_ListCurrentUserContributionEvents(t *testing.T) {
 }
 
 func TestEventsService_ListCurrentUserContributionEvents_StatusNotFound(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/events", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -180,8 +177,7 @@ func TestEventsService_ListCurrentUserContributionEvents_StatusNotFound(t *testi
 }
 
 func TestEventsService_ListProjectVisibleEvents(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/15/events", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)

--- a/external_status_checks_test.go
+++ b/external_status_checks_test.go
@@ -10,8 +10,7 @@ import (
 )
 
 func TestListMergeStatusChecks(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/merge_requests/1/status_checks", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -42,8 +41,7 @@ func TestListMergeStatusChecks(t *testing.T) {
 }
 
 func TestListProjectStatusChecks(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/external_status_checks", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)

--- a/feature_flags_test.go
+++ b/feature_flags_test.go
@@ -24,8 +24,7 @@ import (
 )
 
 func TestListFeatureFlags(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/features", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -66,8 +65,7 @@ func TestListFeatureFlags(t *testing.T) {
 }
 
 func TestSetFeatureFlag(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/features/new_library", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)

--- a/freeze_periods_test.go
+++ b/freeze_periods_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 func TestFreezePeriodsService_ListFreezePeriods(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/19/freeze_periods", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -57,8 +56,7 @@ func TestFreezePeriodsService_ListFreezePeriods(t *testing.T) {
 }
 
 func TestFreezePeriodsService_GetFreezePeriod(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/19/freeze_periods/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -101,8 +99,7 @@ func TestFreezePeriodsService_GetFreezePeriod(t *testing.T) {
 }
 
 func TestFreezePeriodsService_CreateFreezePeriodOptions(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/19/freeze_periods", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -145,8 +142,7 @@ func TestFreezePeriodsService_CreateFreezePeriodOptions(t *testing.T) {
 }
 
 func TestFreezePeriodsService_UpdateFreezePeriodOptions(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/19/freeze_periods/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -189,8 +185,7 @@ func TestFreezePeriodsService_UpdateFreezePeriodOptions(t *testing.T) {
 }
 
 func TestFreezePeriodsService_DeleteFreezePeriod(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/19/freeze_periods/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)

--- a/generic_packages_test.go
+++ b/generic_packages_test.go
@@ -25,8 +25,7 @@ import (
 )
 
 func TestPublishPackageFile(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1234/packages/generic/foo/0.1.2/bar-baz.txt", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -44,8 +43,7 @@ func TestPublishPackageFile(t *testing.T) {
 }
 
 func TestDownloadPackageFile(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1234/packages/generic/foo/0.1.2/bar-baz.txt", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)

--- a/geo_nodes_test.go
+++ b/geo_nodes_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 func TestGeoNodesService_CreateGeoNode(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/geo_nodes", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -83,8 +82,7 @@ func TestGeoNodesService_CreateGeoNode(t *testing.T) {
 }
 
 func TestGeoNodesService_CreateGeoNode_StatusNotFound(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/geo_nodes", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -98,8 +96,7 @@ func TestGeoNodesService_CreateGeoNode_StatusNotFound(t *testing.T) {
 }
 
 func TestGeoNodesService_ListGeoNodes(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/geo_nodes", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -176,8 +173,7 @@ func TestGeoNodesService_ListGeoNodes(t *testing.T) {
 }
 
 func TestGeoNodesService_ListGeoNodes_StatusNotFound(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/geo_nodes", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -191,8 +187,7 @@ func TestGeoNodesService_ListGeoNodes_StatusNotFound(t *testing.T) {
 }
 
 func TestGeoNodesService_GetGeoNode(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/geo_nodes/3", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -270,8 +265,7 @@ func TestGeoNodesService_GetGeoNode(t *testing.T) {
 }
 
 func TestGeoNodesService_EditGeoNode(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/geo_nodes/3", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -349,8 +343,7 @@ func TestGeoNodesService_EditGeoNode(t *testing.T) {
 }
 
 func TestGeoNodesService_DeleteGeoNode(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/geo_nodes/3", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
@@ -370,8 +363,7 @@ func TestGeoNodesService_DeleteGeoNode(t *testing.T) {
 }
 
 func TestGeoNodesService_RepairGeoNode(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/geo_nodes/3/repair", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -449,8 +441,7 @@ func TestGeoNodesService_RepairGeoNode(t *testing.T) {
 }
 
 func TestGeoNodesService_RetrieveStatusOfAllGeoNodes(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/geo_nodes/status", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -557,8 +548,7 @@ func TestGeoNodesService_RetrieveStatusOfAllGeoNodes(t *testing.T) {
 }
 
 func TestGeoNodesService_RetrieveStatusOfAllGeoNodes_StatusNotFound(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/geo_nodes/status", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -572,8 +562,7 @@ func TestGeoNodesService_RetrieveStatusOfAllGeoNodes_StatusNotFound(t *testing.T
 }
 
 func TestGeoNodesService_RetrieveStatusOfGeoNode(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/geo_nodes/1/status", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)

--- a/gitignore_templates_test.go
+++ b/gitignore_templates_test.go
@@ -24,8 +24,7 @@ import (
 )
 
 func TestListTemplates(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/templates/gitignores", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -206,8 +205,7 @@ func TestListTemplates(t *testing.T) {
 }
 
 func TestGetTemplates(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/templates/gitignores/Ruby", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)

--- a/gitlab_test.go
+++ b/gitlab_test.go
@@ -36,14 +36,12 @@ var timeLayout = "2006-01-02T15:04:05Z07:00"
 // setup sets up a test HTTP server along with a gitlab.Client that is
 // configured to talk to that test server.  Tests should register handlers on
 // mux which provide mock responses for the API method being tested.
-func setup(t *testing.T) (*http.ServeMux, *httptest.Server, *Client) {
+func setup(t *testing.T) (*http.ServeMux, *Client) {
 	// mux is the HTTP request multiplexer used with the test server.
 	mux := http.NewServeMux()
 
 	// server is a test HTTP server used to provide mock API responses.
 	server := httptest.NewServer(mux)
-
-	// TODO(asnyder): Individual tests no longer need to call `defer teardown()`.
 	t.Cleanup(server.Close)
 
 	// client is the Gitlab client being tested.
@@ -52,14 +50,7 @@ func setup(t *testing.T) (*http.ServeMux, *httptest.Server, *Client) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	return mux, server, client
-}
-
-// teardown closes the test HTTP server.
-//
-// Deprecated: The server will close itself without the need to call teardown() explicitly.
-func teardown(server *httptest.Server) {
-	server.Close()
+	return mux, client
 }
 
 func testURL(t *testing.T, r *http.Request, want string) {

--- a/gitlab_test.go
+++ b/gitlab_test.go
@@ -43,10 +43,12 @@ func setup(t *testing.T) (*http.ServeMux, *httptest.Server, *Client) {
 	// server is a test HTTP server used to provide mock API responses.
 	server := httptest.NewServer(mux)
 
+	// TODO(asnyder): Individual tests no longer need to call `defer teardown()`.
+	t.Cleanup(server.Close)
+
 	// client is the Gitlab client being tested.
 	client, err := NewClient("", WithBaseURL(server.URL))
 	if err != nil {
-		server.Close()
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
@@ -54,6 +56,8 @@ func setup(t *testing.T) (*http.ServeMux, *httptest.Server, *Client) {
 }
 
 // teardown closes the test HTTP server.
+//
+// Deprecated: The server will close itself without the need to call teardown() explicitly.
 func teardown(server *httptest.Server) {
 	server.Close()
 }

--- a/group_access_tokens_test.go
+++ b/group_access_tokens_test.go
@@ -24,8 +24,7 @@ import (
 )
 
 func TestListGroupAccessTokens(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/access_tokens", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -80,8 +79,7 @@ func TestListGroupAccessTokens(t *testing.T) {
 }
 
 func TestGetGroupAccessToken(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/access_tokens/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -115,8 +113,7 @@ func TestGetGroupAccessToken(t *testing.T) {
 }
 
 func TestCreateGroupAccessToken(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/access_tokens", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -151,8 +148,7 @@ func TestCreateGroupAccessToken(t *testing.T) {
 }
 
 func TestRevokeGroupAccessToken(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/access_tokens/1234", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)

--- a/group_badges_test.go
+++ b/group_badges_test.go
@@ -24,8 +24,7 @@ import (
 )
 
 func TestListGroupBadges(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/badges",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -45,8 +44,7 @@ func TestListGroupBadges(t *testing.T) {
 }
 
 func TestGetGroupBadge(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/badges/2",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -66,8 +64,7 @@ func TestGetGroupBadge(t *testing.T) {
 }
 
 func TestAddGroupBadge(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/badges",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -88,8 +85,7 @@ func TestAddGroupBadge(t *testing.T) {
 }
 
 func TestEditGroupBadge(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/badges/2",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -110,8 +106,7 @@ func TestEditGroupBadge(t *testing.T) {
 }
 
 func TestRemoveGroupBadge(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/badges/2",
 		func(w http.ResponseWriter, r *http.Request) {

--- a/group_boards_test.go
+++ b/group_boards_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 func TestGroupIssueBoardsService_ListGroupIssueBoards(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/5/boards", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -129,8 +128,7 @@ func TestGroupIssueBoardsService_ListGroupIssueBoards(t *testing.T) {
 }
 
 func TestGroupIssueBoardsService_CreateGroupIssueBoard(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/5/boards", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -187,8 +185,7 @@ func TestGroupIssueBoardsService_CreateGroupIssueBoard(t *testing.T) {
 }
 
 func TestGroupIssueBoardsService_GetGroupIssueBoard(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/5/boards/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -305,8 +302,7 @@ func TestGroupIssueBoardsService_GetGroupIssueBoard(t *testing.T) {
 }
 
 func TestGroupIssueBoardsService_UpdateIssueBoard(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/5/boards/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -391,8 +387,7 @@ func TestGroupIssueBoardsService_UpdateIssueBoard(t *testing.T) {
 }
 
 func TestGroupIssueBoardsService_DeleteIssueBoard(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/5/boards/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
@@ -416,8 +411,7 @@ func TestGroupIssueBoardsService_DeleteIssueBoard(t *testing.T) {
 }
 
 func TestGroupIssueBoardsService_ListGroupIssueBoardLists(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/5/boards/1/lists", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -506,8 +500,7 @@ func TestGroupIssueBoardsService_ListGroupIssueBoardLists(t *testing.T) {
 }
 
 func TestGroupIssueBoardsService_GetGroupIssueBoardList(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/5/boards/1/lists/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -556,8 +549,7 @@ func TestGroupIssueBoardsService_GetGroupIssueBoardList(t *testing.T) {
 }
 
 func TestGroupIssueBoardsService_CreateGroupIssueBoardList(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/5/boards/1/lists", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -615,8 +607,7 @@ func TestGroupIssueBoardsService_CreateGroupIssueBoardList(t *testing.T) {
 }
 
 func TestGroupIssueBoardsService_UpdateIssueBoardList(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/5/boards/1/lists/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -705,8 +696,7 @@ func TestGroupIssueBoardsService_UpdateIssueBoardList(t *testing.T) {
 }
 
 func TestGroupIssueBoardsService_DeleteGroupIssueBoardList(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/5/boards/1/lists/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)

--- a/group_clusters_test.go
+++ b/group_clusters_test.go
@@ -25,8 +25,7 @@ import (
 )
 
 func TestGroupListClusters(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/26/clusters", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -136,8 +135,7 @@ func TestGroupListClusters(t *testing.T) {
 }
 
 func TestGetGroupCluster(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/26/clusters/18", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -246,8 +244,7 @@ func TestGetGroupCluster(t *testing.T) {
 }
 
 func TestAddGroupCluster(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/26/clusters/user", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -332,8 +329,7 @@ func TestAddGroupCluster(t *testing.T) {
 }
 
 func TestEditGroupCluster(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/26/clusters/24", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -452,8 +448,7 @@ func TestEditGroupCluster(t *testing.T) {
 }
 
 func TestDeleteGroupCluster(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/26/clusters/23", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)

--- a/group_hooks_test.go
+++ b/group_hooks_test.go
@@ -25,8 +25,7 @@ import (
 )
 
 func TestListGroupHooks(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/hooks", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -88,8 +87,7 @@ func TestListGroupHooks(t *testing.T) {
 }
 
 func TestGetGroupHook(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/hooks/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -149,8 +147,7 @@ func TestGetGroupHook(t *testing.T) {
 }
 
 func TestAddGroupHook(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/hooks", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -216,8 +213,7 @@ func TestAddGroupHook(t *testing.T) {
 }
 
 func TestEditGroupHook(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/hooks/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -283,8 +279,7 @@ func TestEditGroupHook(t *testing.T) {
 }
 
 func TestDeleteGroupHook(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/hooks/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)

--- a/group_import_export_test.go
+++ b/group_import_export_test.go
@@ -11,8 +11,7 @@ import (
 )
 
 func TestGroupScheduleExport(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/export",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -27,8 +26,7 @@ func TestGroupScheduleExport(t *testing.T) {
 }
 
 func TestGroupExportDownload(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 	content := []byte("fake content")
 
 	mux.HandleFunc("/api/v4/groups/1/export/download",
@@ -54,8 +52,7 @@ func TestGroupExportDownload(t *testing.T) {
 }
 
 func TestGroupImport(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	content := []byte("temporary file's content")
 	tmpfile, err := os.CreateTemp(os.TempDir(), "example.*.tar.gz")

--- a/group_iterations_test.go
+++ b/group_iterations_test.go
@@ -8,8 +8,7 @@ import (
 )
 
 func TestListGroupIterations(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/5/iterations",
 		func(w http.ResponseWriter, r *http.Request) {

--- a/group_labels_test.go
+++ b/group_labels_test.go
@@ -25,8 +25,7 @@ import (
 )
 
 func TestCreateGroupGroupLabel(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/labels", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -49,8 +48,7 @@ func TestCreateGroupGroupLabel(t *testing.T) {
 }
 
 func TestDeleteGroupLabel(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/labels", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
@@ -67,8 +65,7 @@ func TestDeleteGroupLabel(t *testing.T) {
 }
 
 func TestUpdateGroupLabel(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/labels", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -99,8 +96,7 @@ func TestUpdateGroupLabel(t *testing.T) {
 }
 
 func TestSubscribeToGroupLabel(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/labels/5/subscribe", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -118,8 +114,7 @@ func TestSubscribeToGroupLabel(t *testing.T) {
 }
 
 func TestUnsubscribeFromGroupLabel(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/labels/5/unsubscribe", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -132,8 +127,7 @@ func TestUnsubscribeFromGroupLabel(t *testing.T) {
 }
 
 func TestListGroupLabels(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/labels", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -157,8 +151,7 @@ func TestListGroupLabels(t *testing.T) {
 }
 
 func TestGetGroupLabel(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/labels/5", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)

--- a/group_members_test.go
+++ b/group_members_test.go
@@ -25,8 +25,7 @@ import (
 )
 
 func TestListBillableGroupMembers(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/billable_members",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -72,8 +71,7 @@ func TestListBillableGroupMembers(t *testing.T) {
 }
 
 func TestListGroupMembersWithoutSAML(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/members",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -123,8 +121,7 @@ func TestListGroupMembersWithoutSAML(t *testing.T) {
 }
 
 func TestListGroupMembersWithSAML(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/members",
 		func(w http.ResponseWriter, r *http.Request) {

--- a/group_milestones_test.go
+++ b/group_milestones_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 func TestGroupMilestonesService_ListGroupMilestones(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/5/milestones", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -62,8 +61,7 @@ func TestGroupMilestonesService_ListGroupMilestones(t *testing.T) {
 }
 
 func TestGroupMilestonesService_GetGroupMilestone(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/5/milestones/12", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -113,8 +111,7 @@ func TestGroupMilestonesService_GetGroupMilestone(t *testing.T) {
 }
 
 func TestGroupMilestonesService_CreateGroupMilestone(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/5/milestones", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -164,8 +161,7 @@ func TestGroupMilestonesService_CreateGroupMilestone(t *testing.T) {
 }
 
 func TestGroupMilestonesService_UpdateGroupMilestone(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/5/milestones/12", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -215,8 +211,7 @@ func TestGroupMilestonesService_UpdateGroupMilestone(t *testing.T) {
 }
 
 func TestGroupMilestonesService_GetGroupMilestoneIssues(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/5/milestones/12/issues", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -335,8 +330,7 @@ func TestGroupMilestonesService_GetGroupMilestoneIssues(t *testing.T) {
 }
 
 func TestGroupMilestonesService_GetGroupMilestoneMergeRequests(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/3/milestones/12/merge_requests", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -550,8 +544,7 @@ func TestGroupMilestonesService_GetGroupMilestoneMergeRequests(t *testing.T) {
 }
 
 func TestGroupMilestonesService_GetGroupMilestoneBurndownChartEvents(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/3/milestones/12/burndown_events", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)

--- a/group_variables_test.go
+++ b/group_variables_test.go
@@ -24,8 +24,7 @@ import (
 )
 
 func TestListGroupVariabless(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/variables",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -53,8 +52,7 @@ func TestListGroupVariabless(t *testing.T) {
 }
 
 func TestGetGroupVariable(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/variables/TEST_VARIABLE_1",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -75,8 +73,7 @@ func TestGetGroupVariable(t *testing.T) {
 }
 
 func TestCreateGroupVariable(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/variables",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -103,8 +100,7 @@ func TestCreateGroupVariable(t *testing.T) {
 }
 
 func TestDeleteGroupVariable(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/variables/TEST_VARIABLE_1",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -125,8 +121,7 @@ func TestDeleteGroupVariable(t *testing.T) {
 }
 
 func TestUpdateGroupVariable(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/variables/TEST_VARIABLE_1",
 		func(w http.ResponseWriter, r *http.Request) {

--- a/group_wikis_test.go
+++ b/group_wikis_test.go
@@ -8,8 +8,7 @@ import (
 )
 
 func TestListGroupWikis(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/wikis",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -43,8 +42,7 @@ func TestListGroupWikis(t *testing.T) {
 }
 
 func TestGetGroupWikiPage(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/wikis/deploy",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -76,8 +74,7 @@ func TestGetGroupWikiPage(t *testing.T) {
 }
 
 func TestCreateGroupWikiPage(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/wikis",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -111,8 +108,7 @@ func TestCreateGroupWikiPage(t *testing.T) {
 }
 
 func TestEditGroupWikiPage(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/wikis/deploy",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -146,8 +142,7 @@ func TestEditGroupWikiPage(t *testing.T) {
 }
 
 func TestDeleteGroupWikiPage(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/wikis/deploy",
 		func(w http.ResponseWriter, r *http.Request) {

--- a/groups_test.go
+++ b/groups_test.go
@@ -8,8 +8,7 @@ import (
 )
 
 func TestListGroups(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -29,8 +28,7 @@ func TestListGroups(t *testing.T) {
 }
 
 func TestGetGroup(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/g",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -50,8 +48,7 @@ func TestGetGroup(t *testing.T) {
 }
 
 func TestGetGroupWithFileTemplateId(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/g",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -71,8 +68,7 @@ func TestGetGroupWithFileTemplateId(t *testing.T) {
 }
 
 func TestCreateGroup(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -97,8 +93,7 @@ func TestCreateGroup(t *testing.T) {
 }
 
 func TestTransferGroup(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/projects/2",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -118,8 +113,7 @@ func TestTransferGroup(t *testing.T) {
 }
 
 func TestTransferSubGroup(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/transfer",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -143,8 +137,7 @@ func TestTransferSubGroup(t *testing.T) {
 }
 
 func TestDeleteGroup(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -165,8 +158,7 @@ func TestDeleteGroup(t *testing.T) {
 }
 
 func TestSearchGroup(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -186,8 +178,7 @@ func TestSearchGroup(t *testing.T) {
 }
 
 func TestUpdateGroup(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -207,8 +198,7 @@ func TestUpdateGroup(t *testing.T) {
 }
 
 func TestListGroupProjects(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/22/projects",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -229,8 +219,7 @@ func TestListGroupProjects(t *testing.T) {
 }
 
 func TestListSubGroups(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/subgroups",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -250,8 +239,7 @@ func TestListSubGroups(t *testing.T) {
 }
 
 func TestListGroupLDAPLinks(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/ldap_group_links",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -293,8 +281,7 @@ func TestListGroupLDAPLinks(t *testing.T) {
 }
 
 func TestAddGroupLDAPLink(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/ldap_group_links",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -329,8 +316,7 @@ func TestAddGroupLDAPLink(t *testing.T) {
 }
 
 func TestAddGroupLDAPLinkFilter(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/ldap_group_links",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -365,8 +351,7 @@ func TestAddGroupLDAPLinkFilter(t *testing.T) {
 }
 
 func TestListGroupSAMLLinks(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/saml_group_links",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -404,8 +389,7 @@ func TestListGroupSAMLLinks(t *testing.T) {
 }
 
 func TestGetGroupSAMLLink(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/saml_group_links/gitlab_group_example_developer",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -432,8 +416,7 @@ func TestGetGroupSAMLLink(t *testing.T) {
 }
 
 func TestAddGroupSAMLLink(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/saml_group_links",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -465,8 +448,7 @@ func TestAddGroupSAMLLink(t *testing.T) {
 }
 
 func TestRestoreGroup(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 	mux.HandleFunc("/api/v4/groups/1/restore",
 		func(w http.ResponseWriter, r *http.Request) {
 			testMethod(t, r, http.MethodPost)
@@ -484,8 +466,7 @@ func TestRestoreGroup(t *testing.T) {
 }
 
 func TestShareGroupWithGroup(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 	mux.HandleFunc("/api/v4/groups/1/share",
 		func(w http.ResponseWriter, r *http.Request) {
 			testMethod(t, r, http.MethodPost)
@@ -506,8 +487,7 @@ func TestShareGroupWithGroup(t *testing.T) {
 }
 
 func TestUnshareGroupFromGroup(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 	mux.HandleFunc("/api/v4/groups/1/share/2",
 		func(w http.ResponseWriter, r *http.Request) {
 			testMethod(t, r, http.MethodDelete)
@@ -524,8 +504,7 @@ func TestUnshareGroupFromGroup(t *testing.T) {
 }
 
 func TestCreateGroupWithIPRestrictionRanges(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -551,8 +530,7 @@ func TestCreateGroupWithIPRestrictionRanges(t *testing.T) {
 }
 
 func TestUpdateGroupWithIPRestrictionRanges(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1",
 		func(w http.ResponseWriter, r *http.Request) {

--- a/instance_clusters_test.go
+++ b/instance_clusters_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 func TestInstanceClustersService_ListClusters(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/admin/clusters", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -87,8 +86,7 @@ func TestInstanceClustersService_ListClusters(t *testing.T) {
 }
 
 func TestInstanceClustersService_ListClusters_StatusNotFound(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/admin/clusters", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -102,8 +100,7 @@ func TestInstanceClustersService_ListClusters_StatusNotFound(t *testing.T) {
 }
 
 func TestInstanceClustersService_GetCluster(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/admin/clusters/9", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -183,8 +180,7 @@ func TestInstanceClustersService_GetCluster(t *testing.T) {
 }
 
 func TestInstanceClustersService_AddCluster(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/admin/clusters/add", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -259,8 +255,7 @@ func TestInstanceClustersService_AddCluster(t *testing.T) {
 }
 
 func TestInstanceClustersService_AddCluster_StatusInternalServerError(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/admin/clusters/add", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -274,8 +269,7 @@ func TestInstanceClustersService_AddCluster_StatusInternalServerError(t *testing
 }
 
 func TestInstanceClustersService_EditCluster(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/admin/clusters/11", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -355,8 +349,7 @@ func TestInstanceClustersService_EditCluster(t *testing.T) {
 }
 
 func TestInstanceClustersService_DeleteCluster(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/admin/clusters/11", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)

--- a/instance_variables_test.go
+++ b/instance_variables_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 func TestInstanceVariablesService_ListVariables(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/admin/ci/variables", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -47,8 +46,7 @@ func TestInstanceVariablesService_ListVariables(t *testing.T) {
 }
 
 func TestInstanceVariablesService_ListVariables_StatusNotFound(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/admin/ci/variables", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -62,8 +60,7 @@ func TestInstanceVariablesService_ListVariables_StatusNotFound(t *testing.T) {
 }
 
 func TestInstanceVariablesService_GetVariable(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/admin/ci/variables/TEST_VARIABLE_1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -103,8 +100,7 @@ func TestInstanceVariablesService_GetVariable(t *testing.T) {
 }
 
 func TestInstanceVariablesService_CreateVariable(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/admin/ci/variables", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -139,8 +135,7 @@ func TestInstanceVariablesService_CreateVariable(t *testing.T) {
 }
 
 func TestInstanceVariablesService_StatusInternalServerError(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/admin/ci/variables", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -154,8 +149,7 @@ func TestInstanceVariablesService_StatusInternalServerError(t *testing.T) {
 }
 
 func TestInstanceVariablesService_UpdateVariable(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/admin/ci/variables/NEW_VARIABLE", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -195,8 +189,7 @@ func TestInstanceVariablesService_UpdateVariable(t *testing.T) {
 }
 
 func TestInstanceVariablesService_RemoveVariable(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/admin/ci/variables/NEW_VARIABLE", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)

--- a/invites_test.go
+++ b/invites_test.go
@@ -8,8 +8,7 @@ import (
 )
 
 func TestListGroupPendingInvites(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/test/invitations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -32,8 +31,7 @@ func TestListGroupPendingInvites(t *testing.T) {
 }
 
 func TestGroupInvites(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/test/invitations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -56,8 +54,7 @@ func TestGroupInvites(t *testing.T) {
 }
 
 func TestGroupInvitesError(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/test/invitations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -80,8 +77,7 @@ func TestGroupInvitesError(t *testing.T) {
 }
 
 func TestListProjectPendingInvites(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/test/invitations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -104,8 +100,7 @@ func TestListProjectPendingInvites(t *testing.T) {
 }
 
 func TestProjectInvites(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/test/invitations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -128,8 +123,7 @@ func TestProjectInvites(t *testing.T) {
 }
 
 func TestProjectInvitesError(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/test/invitations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)

--- a/issue_links_test.go
+++ b/issue_links_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 func TestIssueLinksService_ListIssueRelations(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/4/issues/14/links", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -98,8 +97,7 @@ func TestIssueLinksService_ListIssueRelations(t *testing.T) {
 }
 
 func TestIssueLinksService_CreateIssueLink(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/4/issues/1/links", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -254,8 +252,7 @@ func TestIssueLinksService_CreateIssueLink(t *testing.T) {
 }
 
 func TestIssueLinksService_DeleteIssueLink(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/4/issues/1/links/83", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)

--- a/issues_statistics_test.go
+++ b/issues_statistics_test.go
@@ -25,8 +25,7 @@ import (
 )
 
 func TestGetIssuesStatistics(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/issues_statistics", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -68,8 +67,7 @@ func TestGetIssuesStatistics(t *testing.T) {
 }
 
 func TestGetGroupIssuesStatistics(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/issues_statistics", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -111,8 +109,7 @@ func TestGetGroupIssuesStatistics(t *testing.T) {
 }
 
 func TestGetProjectIssuesStatistics(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/issues_statistics", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)

--- a/issues_test.go
+++ b/issues_test.go
@@ -27,8 +27,7 @@ import (
 )
 
 func TestGetIssue(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/issues/5", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -54,8 +53,7 @@ func TestGetIssue(t *testing.T) {
 }
 
 func TestDeleteIssue(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/issues/5", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
@@ -69,8 +67,7 @@ func TestDeleteIssue(t *testing.T) {
 }
 
 func TestMoveIssue(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/issues/11/move", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -121,8 +118,7 @@ func TestMoveIssue(t *testing.T) {
 }
 
 func TestListIssues(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/issues", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -175,8 +171,7 @@ func TestListIssues(t *testing.T) {
 }
 
 func TestListIssuesWithLabelDetails(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/issues", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -247,8 +242,7 @@ func TestListIssuesWithLabelDetails(t *testing.T) {
 }
 
 func TestListIssuesSearchInTitle(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/issues", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -286,8 +280,7 @@ func TestListIssuesSearchInTitle(t *testing.T) {
 	}
 }
 func TestListIssuesSearchInDescription(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/issues", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -326,8 +319,7 @@ func TestListIssuesSearchInDescription(t *testing.T) {
 }
 
 func TestListIssuesSearchByIterationID(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/issues", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -378,11 +370,10 @@ func TestListIssuesSearchByIterationID(t *testing.T) {
 	if !reflect.DeepEqual(want, issues) {
 		t.Errorf("Issues.ListIssues returned %+v, want %+v", issues, want)
 	}
- }
+}
 
 func TestListProjectIssues(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/issues", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -412,8 +403,7 @@ func TestListProjectIssues(t *testing.T) {
 }
 
 func TestListProjectIssuesSearchByIterationID(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/issues", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -441,7 +431,7 @@ func TestListProjectIssuesSearchByIterationID(t *testing.T) {
 		IterationID: Int(90),
 	}
 
-	issues, _, err := client.Issues.ListProjectIssues(1 ,listProjectIssue)
+	issues, _, err := client.Issues.ListProjectIssues(1, listProjectIssue)
 
 	if err != nil {
 		log.Fatal(err)
@@ -464,11 +454,10 @@ func TestListProjectIssuesSearchByIterationID(t *testing.T) {
 	if !reflect.DeepEqual(want, issues) {
 		t.Errorf("Issues.ListIssues returned %+v, want %+v", issues, want)
 	}
- }
+}
 
 func TestListGroupIssues(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/issues", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -500,8 +489,7 @@ func TestListGroupIssues(t *testing.T) {
 }
 
 func TestListGroupIssuesSearchByIterationID(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/issues", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -552,11 +540,10 @@ func TestListGroupIssuesSearchByIterationID(t *testing.T) {
 	if !reflect.DeepEqual(want, issues) {
 		t.Errorf("Issues.ListIssues returned %+v, want %+v", issues, want)
 	}
- }
+}
 
 func TestCreateIssue(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/issues", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -588,8 +575,7 @@ func TestCreateIssue(t *testing.T) {
 }
 
 func TestUpdateIssue(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/issues/5", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -620,8 +606,7 @@ func TestUpdateIssue(t *testing.T) {
 }
 
 func TestSubscribeToIssue(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/issues/5/subscribe", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -648,8 +633,7 @@ func TestSubscribeToIssue(t *testing.T) {
 }
 
 func TestUnsubscribeFromIssue(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/issues/5/unsubscribe", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -675,8 +659,7 @@ func TestUnsubscribeFromIssue(t *testing.T) {
 }
 
 func TestListMergeRequestsClosingIssue(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/issues/5/closed_by", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -702,8 +685,7 @@ func TestListMergeRequestsClosingIssue(t *testing.T) {
 }
 
 func TestListMergeRequestsRelatedToIssue(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/issues/5/related_merge_requests", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -729,8 +711,7 @@ func TestListMergeRequestsRelatedToIssue(t *testing.T) {
 }
 
 func TestSetTimeEstimate(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/issues/5/time_estimate", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -753,8 +734,7 @@ func TestSetTimeEstimate(t *testing.T) {
 }
 
 func TestResetTimeEstimate(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/issues/5/reset_time_estimate", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -773,8 +753,7 @@ func TestResetTimeEstimate(t *testing.T) {
 }
 
 func TestAddSpentTime(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/issues/5/add_spent_time", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -797,8 +776,7 @@ func TestAddSpentTime(t *testing.T) {
 }
 
 func TestResetSpentTime(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/issues/5/reset_spent_time", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -818,8 +796,7 @@ func TestResetSpentTime(t *testing.T) {
 }
 
 func TestGetTimeSpent(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/issues/5/time_stats", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -839,8 +816,7 @@ func TestGetTimeSpent(t *testing.T) {
 }
 
 func TestGetIssueParticipants(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/issues/5/participants", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)

--- a/jobs_test.go
+++ b/jobs_test.go
@@ -27,8 +27,7 @@ import (
 )
 
 func TestListPipelineJobs(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/pipelines/1/jobs", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -47,8 +46,7 @@ func TestListPipelineJobs(t *testing.T) {
 }
 
 func TestJobsService_ListProjectJobs(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/jobs", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -192,8 +190,7 @@ func TestJobsService_ListProjectJobs(t *testing.T) {
 }
 
 func TestDownloadSingleArtifactsFileByTagOrBranch(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	wantContent := []byte("This is the file content")
 	mux.HandleFunc("/api/v4/projects/9/jobs/artifacts/abranch/raw/foo/bar.pdf", func(w http.ResponseWriter, r *http.Request) {

--- a/keys_test.go
+++ b/keys_test.go
@@ -24,8 +24,7 @@ import (
 )
 
 func TestGetKeyWithUser(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/keys/1",
 		func(w http.ResponseWriter, r *http.Request) {

--- a/labels_test.go
+++ b/labels_test.go
@@ -25,8 +25,7 @@ import (
 )
 
 func TestCreateLabel(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/labels", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -51,8 +50,7 @@ func TestCreateLabel(t *testing.T) {
 }
 
 func TestDeleteLabel(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/labels", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
@@ -70,8 +68,7 @@ func TestDeleteLabel(t *testing.T) {
 }
 
 func TestUpdateLabel(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/labels", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -104,8 +101,7 @@ func TestUpdateLabel(t *testing.T) {
 }
 
 func TestSubscribeToLabel(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/labels/5/subscribe", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -123,8 +119,7 @@ func TestSubscribeToLabel(t *testing.T) {
 }
 
 func TestUnsubscribeFromLabel(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/labels/5/unsubscribe", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -137,8 +132,7 @@ func TestUnsubscribeFromLabel(t *testing.T) {
 }
 
 func TestListLabels(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/labels", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -162,8 +156,7 @@ func TestListLabels(t *testing.T) {
 }
 
 func TestGetLabel(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/labels/5", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)

--- a/license_templates_test.go
+++ b/license_templates_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 func TestLicenseTemplatesService_ListLicenseTemplates(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/templates/licenses", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -71,8 +70,7 @@ func TestLicenseTemplatesService_ListLicenseTemplates(t *testing.T) {
 }
 
 func TestLicenseTemplatesService_ListLicenseTemplates_StatusNotFound(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/templates/licenses", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -86,8 +84,7 @@ func TestLicenseTemplatesService_ListLicenseTemplates_StatusNotFound(t *testing.
 }
 
 func TestLicenseTemplatesService_GetLicenseTemplate(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/templates/licenses/apache-2.0", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)

--- a/license_test.go
+++ b/license_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 func TestLicenseService_GetLicense(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/license", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -75,8 +74,7 @@ func TestLicenseService_GetLicense(t *testing.T) {
 }
 
 func TestLicenseService_GetLicense_StatusNotFound(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/license", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -90,8 +88,7 @@ func TestLicenseService_GetLicense_StatusNotFound(t *testing.T) {
 }
 
 func TestLicenseService_AddLicense(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/license", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -161,8 +158,7 @@ func TestLicenseService_AddLicense(t *testing.T) {
 }
 
 func TestLicenseService_AddLicense_StatusNotFound(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/license", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)

--- a/markdown_test.go
+++ b/markdown_test.go
@@ -9,8 +9,7 @@ import (
 const markdownHTMLResponse = "<h1>Testing</h1>"
 
 func TestRender(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/markdown", func(writer http.ResponseWriter, request *http.Request) {
 		testMethod(t, request, http.MethodPost)

--- a/merge_request_approvals_test.go
+++ b/merge_request_approvals_test.go
@@ -24,8 +24,7 @@ import (
 )
 
 func TestGetApprovalState(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/merge_requests/1/approval_state", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -180,8 +179,7 @@ func TestGetApprovalState(t *testing.T) {
 }
 
 func TestGetApprovalRules(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/merge_requests/1/approval_rules", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -308,8 +306,7 @@ func TestGetApprovalRules(t *testing.T) {
 }
 
 func TestCreateApprovalRules(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/merge_requests/1/approval_rules", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)

--- a/merge_requests_test.go
+++ b/merge_requests_test.go
@@ -101,8 +101,7 @@ var (
 )
 
 func TestGetMergeRequest(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	path := "/api/v4/projects/namespace/name/merge_requests/123"
 
@@ -148,8 +147,7 @@ func TestGetMergeRequest(t *testing.T) {
 }
 
 func TestListProjectMergeRequests(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	path := "/api/v4/projects/278964/merge_requests"
 
@@ -191,8 +189,7 @@ func TestListProjectMergeRequests(t *testing.T) {
 }
 
 func TestCreateMergeRequestPipeline(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/merge_requests/1/pipelines", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -210,8 +207,7 @@ func TestCreateMergeRequestPipeline(t *testing.T) {
 }
 
 func TestGetMergeRequestParticipants(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/merge_requests/5/participants", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -235,8 +231,7 @@ func TestGetMergeRequestParticipants(t *testing.T) {
 }
 
 func TestGetIssuesClosedOnMerge_Jira(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 	mux.HandleFunc("/api/v4/projects/1/merge_requests/1/closes_issues", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `[{"id":"PROJECT-123","title":"Title of this issue"}]`)

--- a/metadata_test.go
+++ b/metadata_test.go
@@ -24,8 +24,7 @@ import (
 )
 
 func TestGetMetadata(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/metadata",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -51,4 +50,3 @@ func TestGetMetadata(t *testing.T) {
 		t.Errorf("Metadata.GetMetadata returned %+v, want %+v", version, want)
 	}
 }
-

--- a/milestones_test.go
+++ b/milestones_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 func TestMilestonesService_ListMilestones(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/milestones", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -62,8 +61,7 @@ func TestMilestonesService_ListMilestones(t *testing.T) {
 }
 
 func TestMilestonesService_GetMilestone(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/milestones/12", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -113,8 +111,7 @@ func TestMilestonesService_GetMilestone(t *testing.T) {
 }
 
 func TestMilestonesService_CreateMilestone(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/milestones", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -164,8 +161,7 @@ func TestMilestonesService_CreateMilestone(t *testing.T) {
 }
 
 func TestMilestonesService_UpdateMilestone(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/milestones/12", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -215,8 +211,7 @@ func TestMilestonesService_UpdateMilestone(t *testing.T) {
 }
 
 func TestMilestonesService_DeleteMilestone(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/milestones/12", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
@@ -240,8 +235,7 @@ func TestMilestonesService_DeleteMilestone(t *testing.T) {
 }
 
 func TestMilestonesService_GetMilestoneIssues(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/milestones/12/issues", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -360,8 +354,7 @@ func TestMilestonesService_GetMilestoneIssues(t *testing.T) {
 }
 
 func TestMilestonesService_GetMilestoneMergeRequests(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/3/milestones/12/merge_requests", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)

--- a/namespaces_test.go
+++ b/namespaces_test.go
@@ -25,8 +25,7 @@ import (
 )
 
 func TestListNamespaces(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	trialEndsOn, _ := time.Parse(time.RFC3339, "2022-05-08T00:00:00Z")
 	trialEndsOnISOTime := ISOTime(trialEndsOn)
@@ -173,8 +172,7 @@ func TestListNamespaces(t *testing.T) {
 }
 
 func TestGetNamespace(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/namespaces/2", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -224,8 +222,7 @@ func TestGetNamespace(t *testing.T) {
 }
 
 func TestNamespaceExists(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/namespaces/my-group/exists", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -255,8 +252,7 @@ func TestNamespaceExists(t *testing.T) {
 }
 
 func TestSearchNamespace(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/namespaces", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)

--- a/notes_test.go
+++ b/notes_test.go
@@ -24,8 +24,7 @@ import (
 )
 
 func TestGetEpicNote(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/epics/4329/notes/3", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -54,8 +53,7 @@ func TestGetEpicNote(t *testing.T) {
 }
 
 func TestGetMergeRequestNote(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/merge_requests/4329/notes/3", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)

--- a/notifications_test.go
+++ b/notifications_test.go
@@ -24,8 +24,7 @@ import (
 )
 
 func TestGetGlobalSettings(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/notification_settings", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)

--- a/packages_test.go
+++ b/packages_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 func TestPackagesService_ListProjectPackages(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/3/packages", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -66,8 +65,7 @@ func TestPackagesService_ListProjectPackages(t *testing.T) {
 }
 
 func TestPackagesService_ListPackageFiles(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/3/packages/4/package_files", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -117,8 +115,7 @@ func TestPackagesService_ListPackageFiles(t *testing.T) {
 }
 
 func TestPackagesService_DeleteProjectPackage(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/3/packages/4", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)

--- a/pages_domains_test.go
+++ b/pages_domains_test.go
@@ -10,8 +10,7 @@ import (
 )
 
 func TestPagesDomainsService_ListPagesDomains(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/pages/domains", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -71,8 +70,7 @@ func TestPagesDomainsService_ListPagesDomains(t *testing.T) {
 }
 
 func TestPagesDomainsService_ListAllPagesDomains(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/pages/domains", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -120,8 +118,7 @@ func TestPagesDomainsService_ListAllPagesDomains(t *testing.T) {
 }
 
 func TestPagesDomainsService_ListAllPagesDomains_StatusNotFound(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/pages/domains", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -135,8 +132,7 @@ func TestPagesDomainsService_ListAllPagesDomains_StatusNotFound(t *testing.T) {
 }
 
 func TestPagesDomainsService_GetPagesDomain(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/pages/domains/www.domain.example", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -194,8 +190,7 @@ func TestPagesDomainsService_GetPagesDomain(t *testing.T) {
 }
 
 func TestPagesDomainsService_CreatePagesDomain(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/pages/domains", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -253,8 +248,7 @@ func TestPagesDomainsService_CreatePagesDomain(t *testing.T) {
 }
 
 func TestPagesDomainsService_UpdatePagesDomain(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/pages/domains/ssl.domain.example", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -312,8 +306,7 @@ func TestPagesDomainsService_UpdatePagesDomain(t *testing.T) {
 }
 
 func TestPagesDomainsService_DeletePagesDomain(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/pages/domains/ssl.domain.example", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)

--- a/pages_test.go
+++ b/pages_test.go
@@ -22,8 +22,7 @@ import (
 )
 
 func TestUnpublishPages(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/2/pages", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)

--- a/personal_access_tokens_test.go
+++ b/personal_access_tokens_test.go
@@ -24,8 +24,7 @@ import (
 )
 
 func TestListPersonalAccessTokensWithUserFilter(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/personal_access_tokens", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -87,8 +86,7 @@ func TestListPersonalAccessTokensWithUserFilter(t *testing.T) {
 }
 
 func TestListPersonalAccessTokensNoUserFilter(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/personal_access_tokens", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -150,8 +148,7 @@ func TestListPersonalAccessTokensNoUserFilter(t *testing.T) {
 }
 
 func TestDeletePersonalAccessToken(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/personal_access_tokens/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)

--- a/pipeline_schedules_test.go
+++ b/pipeline_schedules_test.go
@@ -23,8 +23,7 @@ import (
 )
 
 func TestRunPipelineSchedule(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/pipeline_schedules/1/play", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)

--- a/pipeline_triggers_test.go
+++ b/pipeline_triggers_test.go
@@ -24,8 +24,7 @@ import (
 )
 
 func TestRunPipeline(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/trigger/pipeline", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)

--- a/pipelines_test.go
+++ b/pipelines_test.go
@@ -26,8 +26,7 @@ import (
 )
 
 func TestListProjectPipelines(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/pipelines", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -47,8 +46,7 @@ func TestListProjectPipelines(t *testing.T) {
 }
 
 func TestGetPipeline(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/pipelines/5949167", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -67,8 +65,7 @@ func TestGetPipeline(t *testing.T) {
 }
 
 func TestGetPipelineVariables(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/pipelines/5949167/variables", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -87,8 +84,7 @@ func TestGetPipelineVariables(t *testing.T) {
 }
 
 func TestGetPipelineTestReport(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/pipelines/123456/test_report", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -189,8 +185,7 @@ func TestGetPipelineTestReport(t *testing.T) {
 }
 
 func TestGetLatestPipeline(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/pipelines/latest", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -205,8 +200,7 @@ func TestGetLatestPipeline(t *testing.T) {
 }
 
 func TestGetLatestPipeline_WithRef(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/pipelines/latest", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -223,8 +217,7 @@ func TestGetLatestPipeline_WithRef(t *testing.T) {
 }
 
 func TestCreatePipeline(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/pipeline", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -245,8 +238,7 @@ func TestCreatePipeline(t *testing.T) {
 }
 
 func TestRetryPipelineBuild(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/pipelines/5949167/retry", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -265,8 +257,7 @@ func TestRetryPipelineBuild(t *testing.T) {
 }
 
 func TestCancelPipelineBuild(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/pipelines/5949167/cancel", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -285,8 +276,7 @@ func TestCancelPipelineBuild(t *testing.T) {
 }
 
 func TestDeletePipeline(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/pipelines/5949167", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)

--- a/plan_limits_test.go
+++ b/plan_limits_test.go
@@ -24,8 +24,7 @@ import (
 )
 
 func TestGetCurrentPlanLimits(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/application/plan_limits", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -66,8 +65,7 @@ func TestGetCurrentPlanLimits(t *testing.T) {
 }
 
 func TestChangePlanLimits(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/application/plan_limits", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)

--- a/project_access_tokens_test.go
+++ b/project_access_tokens_test.go
@@ -24,8 +24,7 @@ import (
 )
 
 func TestListProjectAccessTokens(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/access_tokens", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -80,8 +79,7 @@ func TestListProjectAccessTokens(t *testing.T) {
 }
 
 func TestGetProjectAccessToken(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/access_tokens/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -115,8 +113,7 @@ func TestGetProjectAccessToken(t *testing.T) {
 }
 
 func TestCreateProjectAccessToken(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/access_tokens", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -151,8 +148,7 @@ func TestCreateProjectAccessToken(t *testing.T) {
 }
 
 func TestRevokeProjectAccessToken(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/access_tokens/1234", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)

--- a/project_badges_test.go
+++ b/project_badges_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 func TestProjectBadgesService_ListProjectBadges(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/badges", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -61,8 +60,7 @@ func TestProjectBadgesService_ListProjectBadges(t *testing.T) {
 }
 
 func TestProjectBadgesService_GetProjectBadge(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/badges/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -111,8 +109,7 @@ func TestProjectBadgesService_GetProjectBadge(t *testing.T) {
 }
 
 func TestProjectBadgesService_AddProjectBadge(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/badges", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -161,8 +158,7 @@ func TestProjectBadgesService_AddProjectBadge(t *testing.T) {
 }
 
 func TestProjectBadgesService_EditProjectBadge(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/badges/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -211,8 +207,7 @@ func TestProjectBadgesService_EditProjectBadge(t *testing.T) {
 }
 
 func TestProjectBadgesService_DeleteProjectBadge(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/badges/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
@@ -236,8 +231,7 @@ func TestProjectBadgesService_DeleteProjectBadge(t *testing.T) {
 }
 
 func TestProjectBadgesService_PreviewProjectBadge(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/badges/render", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)

--- a/project_clusters_test.go
+++ b/project_clusters_test.go
@@ -23,8 +23,7 @@ import (
 )
 
 func TestListClusters(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 	pid := 1234
 
 	mux.HandleFunc("/api/v4/projects/1234/clusters", func(w http.ResponseWriter, r *http.Request) {
@@ -80,8 +79,7 @@ func TestListClusters(t *testing.T) {
 }
 
 func TestGetCluster(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 	pid := 1234
 
 	mux.HandleFunc("/api/v4/projects/1234/clusters/1", func(w http.ResponseWriter, r *http.Request) {
@@ -160,8 +158,7 @@ func TestGetCluster(t *testing.T) {
 }
 
 func TestAddCluster(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 	pid := 1234
 
 	mux.HandleFunc("/api/v4/projects/1234/clusters/user", func(w http.ResponseWriter, r *http.Request) {
@@ -236,8 +233,7 @@ func TestAddCluster(t *testing.T) {
 }
 
 func TestEditCluster(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 	pid := 1234
 
 	mux.HandleFunc("/api/v4/projects/1234/clusters/1", func(w http.ResponseWriter, r *http.Request) {
@@ -312,8 +308,7 @@ func TestEditCluster(t *testing.T) {
 }
 
 func TestDeleteCluster(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1234/clusters/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)

--- a/project_feature_flags_test.go
+++ b/project_feature_flags_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 func TestListProjectFeatureFlags(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/333/feature_flags",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -86,8 +85,7 @@ func TestListProjectFeatureFlags(t *testing.T) {
 }
 
 func TestGetProjectFeatureFlag(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/feature_flags/testing", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -126,8 +124,7 @@ func TestGetProjectFeatureFlag(t *testing.T) {
 }
 
 func TestCreateProjectFeatureFlag(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/feature_flags/testing", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -169,8 +166,7 @@ func TestCreateProjectFeatureFlag(t *testing.T) {
 }
 
 func TestUpdateProjectFeatureFlag(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/feature_flags/testing", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -226,8 +222,7 @@ func TestUpdateProjectFeatureFlag(t *testing.T) {
 }
 
 func TestDeleteProjectFeatureFlag(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/feature_flags/testing", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)

--- a/project_import_export_test.go
+++ b/project_import_export_test.go
@@ -10,8 +10,7 @@ import (
 )
 
 func TestProjectImportExportService_ScheduleExport(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/export", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -36,8 +35,7 @@ func TestProjectImportExportService_ScheduleExport(t *testing.T) {
 }
 
 func TestProjectImportExportService_ExportStatus(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/export", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -98,8 +96,7 @@ func TestProjectImportExportService_ExportStatus(t *testing.T) {
 }
 
 func TestProjectImportExportService_ExportDownload(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/export/download", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -130,8 +127,7 @@ func TestProjectImportExportService_ExportDownload(t *testing.T) {
 }
 
 func TestProjectImportExportService_ImportFile(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/import", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -173,8 +169,7 @@ func TestProjectImportExportService_ImportFile(t *testing.T) {
 }
 
 func TestProjectImportExportService_ImportStatus(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/import", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)

--- a/project_iterations_test.go
+++ b/project_iterations_test.go
@@ -8,8 +8,7 @@ import (
 )
 
 func TestListProjectIterations(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/42/iterations",
 		func(w http.ResponseWriter, r *http.Request) {

--- a/project_managed_licenses_test.go
+++ b/project_managed_licenses_test.go
@@ -23,8 +23,7 @@ import (
 )
 
 func TestListManagedLicenses(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/managed_licenses", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -55,8 +54,7 @@ func TestListManagedLicenses(t *testing.T) {
 }
 
 func TestGetManagedLicenses(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/managed_licenses/3", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -80,8 +78,7 @@ func TestGetManagedLicenses(t *testing.T) {
 }
 
 func TestAddManagedLicenses(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/managed_licenses", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -110,8 +107,7 @@ func TestAddManagedLicenses(t *testing.T) {
 }
 
 func TestDeleteManagedLicenses(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/managed_licenses/3", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
@@ -124,8 +120,7 @@ func TestDeleteManagedLicenses(t *testing.T) {
 }
 
 func TestEditManagedLicenses(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/managed_licenses/3", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPatch)

--- a/project_members_test.go
+++ b/project_members_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 func TestProjectMembersService_ListProjectMembers(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/members", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -63,8 +62,7 @@ func TestProjectMembersService_ListProjectMembers(t *testing.T) {
 }
 
 func TestProjectMembersService_ListAllProjectMembers(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/members/all", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -117,8 +115,7 @@ func TestProjectMembersService_ListAllProjectMembers(t *testing.T) {
 }
 
 func TestProjectMembersService_GetProjectMember(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/members/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -172,8 +169,7 @@ func TestProjectMembersService_GetProjectMember(t *testing.T) {
 }
 
 func TestProjectMembersService_GetInheritedProjectMember(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/members/all/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -227,8 +223,7 @@ func TestProjectMembersService_GetInheritedProjectMember(t *testing.T) {
 }
 
 func TestProjectMembersService_AddProjectMember(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/members", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -282,8 +277,7 @@ func TestProjectMembersService_AddProjectMember(t *testing.T) {
 }
 
 func TestProjectMembersService_EditProjectMember(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/members/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -337,8 +331,7 @@ func TestProjectMembersService_EditProjectMember(t *testing.T) {
 }
 
 func TestProjectMembersService_DeleteProjectMember(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/members/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)

--- a/project_mirror_test.go
+++ b/project_mirror_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 func TestProjectMirrorService_ListProjectMirror(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/42/remote_mirrors", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -61,8 +60,7 @@ func TestProjectMirrorService_ListProjectMirror(t *testing.T) {
 }
 
 func TestProjectMirrorService_GetProjectMirror(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/42/remote_mirrors/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -96,8 +94,7 @@ func TestProjectMirrorService_GetProjectMirror(t *testing.T) {
 }
 
 func TestProjectMirrorService_AddProjectMirror(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/42/remote_mirrors", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -152,8 +149,7 @@ func TestProjectMirrorService_AddProjectMirror(t *testing.T) {
 }
 
 func TestProjectMirrorService_EditProjectMirror(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/42/remote_mirrors/101486", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)

--- a/project_snippets_test.go
+++ b/project_snippets_test.go
@@ -10,8 +10,7 @@ import (
 )
 
 func TestProjectSnippetsService_ListSnippets(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/snippets", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -82,8 +81,7 @@ func TestProjectSnippetsService_ListSnippets(t *testing.T) {
 }
 
 func TestProjectSnippetsService_GetSnippet(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/snippets/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -152,8 +150,7 @@ func TestProjectSnippetsService_GetSnippet(t *testing.T) {
 }
 
 func TestProjectSnippetsService_CreateSnippet(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/snippets", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -237,8 +234,7 @@ func TestProjectSnippetsService_CreateSnippet(t *testing.T) {
 }
 
 func TestProjectSnippetsService_UpdateSnippet(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/snippets/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -307,8 +303,7 @@ func TestProjectSnippetsService_UpdateSnippet(t *testing.T) {
 }
 
 func TestProjectSnippetsService_DeleteSnippet(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/snippets/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
@@ -350,8 +345,7 @@ func TestProjectSnippetsService_DeleteSnippet(t *testing.T) {
 }
 
 func TestProjectSnippetsService_SnippetContent(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/snippets/1/raw", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)

--- a/project_variables_test.go
+++ b/project_variables_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 func TestProjectVariablesService_ListVariables(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/variables", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -56,8 +55,7 @@ func TestProjectVariablesService_ListVariables(t *testing.T) {
 }
 
 func TestProjectVariablesService_GetVariable(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/variables/TEST_VARIABLE_1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -104,8 +102,7 @@ func TestProjectVariablesService_GetVariable(t *testing.T) {
 }
 
 func TestProjectVariablesService_CreateVariable(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/variables", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -152,8 +149,7 @@ func TestProjectVariablesService_CreateVariable(t *testing.T) {
 }
 
 func TestProjectVariablesService_UpdateVariable(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/variables/NEW_VARIABLE", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -201,8 +197,7 @@ func TestProjectVariablesService_UpdateVariable(t *testing.T) {
 }
 
 func TestProjectVariablesService_RemoveVariable(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/variables/VARIABLE_1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)

--- a/project_vulnerabilities_test.go
+++ b/project_vulnerabilities_test.go
@@ -24,8 +24,7 @@ import (
 )
 
 func TestListProjectVulnerabilities(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/vulnerabilities", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -48,8 +47,7 @@ func TestListProjectVulnerabilities(t *testing.T) {
 }
 
 func TestCreateVulnerability(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/vulnerabilities", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)

--- a/projects_test.go
+++ b/projects_test.go
@@ -28,8 +28,7 @@ import (
 )
 
 func TestListProjects(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -58,8 +57,7 @@ func TestListProjects(t *testing.T) {
 }
 
 func TestListUserProjects(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/users/1/projects", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -88,8 +86,7 @@ func TestListUserProjects(t *testing.T) {
 }
 
 func TestListUserStarredProjects(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/users/1/starred_projects", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -118,8 +115,7 @@ func TestListUserStarredProjects(t *testing.T) {
 }
 
 func TestListProjectsUsersByID(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/", func(w http.ResponseWriter, r *http.Request) {
 		testURL(t, r, "/api/v4/projects/1/users?page=2&per_page=3&search=query")
@@ -144,8 +140,7 @@ func TestListProjectsUsersByID(t *testing.T) {
 }
 
 func TestListProjectsUsersByName(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/", func(w http.ResponseWriter, r *http.Request) {
 		testURL(t, r, "/api/v4/projects/namespace%2Fname/users?page=2&per_page=3&search=query")
@@ -170,8 +165,7 @@ func TestListProjectsUsersByName(t *testing.T) {
 }
 
 func TestListProjectsGroupsByID(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/", func(w http.ResponseWriter, r *http.Request) {
 		testURL(t, r, "/api/v4/projects/1/groups?page=2&per_page=3&search=query")
@@ -196,8 +190,7 @@ func TestListProjectsGroupsByID(t *testing.T) {
 }
 
 func TestListProjectsGroupsByName(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/", func(w http.ResponseWriter, r *http.Request) {
 		testURL(t, r, "/api/v4/projects/namespace%2Fname/groups?page=2&per_page=3&search=query")
@@ -222,8 +215,7 @@ func TestListProjectsGroupsByName(t *testing.T) {
 }
 
 func TestListOwnedProjects(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -253,8 +245,7 @@ func TestListOwnedProjects(t *testing.T) {
 }
 
 func TestListStarredProjects(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -284,8 +275,7 @@ func TestListStarredProjects(t *testing.T) {
 }
 
 func TestGetProjectByID(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -329,8 +319,7 @@ func TestGetProjectByID(t *testing.T) {
 }
 
 func TestGetProjectByName(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/", func(w http.ResponseWriter, r *http.Request) {
 		testURL(t, r, "/api/v4/projects/namespace%2Fname")
@@ -350,8 +339,7 @@ func TestGetProjectByName(t *testing.T) {
 }
 
 func TestGetProjectWithOptions(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -394,8 +382,7 @@ func TestGetProjectWithOptions(t *testing.T) {
 }
 
 func TestCreateProject(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -419,8 +406,7 @@ func TestCreateProject(t *testing.T) {
 }
 
 func TestUploadFile(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/uploads", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -456,8 +442,7 @@ func TestUploadFile(t *testing.T) {
 }
 
 func TestUploadFile_Retry(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	tf, _ := os.CreateTemp(os.TempDir(), "test")
 	defer os.Remove(tf.Name())
@@ -501,8 +486,7 @@ func TestUploadFile_Retry(t *testing.T) {
 }
 
 func TestUploadAvatar(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -524,8 +508,7 @@ func TestUploadAvatar(t *testing.T) {
 }
 
 func TestUploadAvatar_Retry(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	isFirstRequest := true
 	mux.HandleFunc("/api/v4/projects/1", func(w http.ResponseWriter, r *http.Request) {
@@ -552,8 +535,7 @@ func TestUploadAvatar_Retry(t *testing.T) {
 }
 
 func TestListProjectForks(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/", func(w http.ResponseWriter, r *http.Request) {
 		testURL(t, r, "/api/v4/projects/namespace%2Fname/forks?archived=true&order_by=name&page=2&per_page=3&search=query&simple=true&sort=asc&visibility=public")
@@ -582,8 +564,7 @@ func TestListProjectForks(t *testing.T) {
 }
 
 func TestShareProjectWithGroup(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/share", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -601,8 +582,7 @@ func TestShareProjectWithGroup(t *testing.T) {
 }
 
 func TestDeleteSharedProjectFromGroup(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/share/2", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
@@ -615,8 +595,7 @@ func TestDeleteSharedProjectFromGroup(t *testing.T) {
 }
 
 func TestGetApprovalConfiguration(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/approvals", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -654,8 +633,7 @@ func TestGetApprovalConfiguration(t *testing.T) {
 }
 
 func TestChangeApprovalConfiguration(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/approvals", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -698,8 +676,7 @@ func TestChangeApprovalConfiguration(t *testing.T) {
 }
 
 func TestChangeAllowedApprovers(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/approvers", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -755,8 +732,7 @@ func TestChangeAllowedApprovers(t *testing.T) {
 }
 
 func TestForkProject(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	namespaceID := 42
 	name := "myreponame"
@@ -784,8 +760,7 @@ func TestForkProject(t *testing.T) {
 }
 
 func TestGetProjectApprovalRules(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/approval_rules", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -960,8 +935,7 @@ func TestGetProjectApprovalRules(t *testing.T) {
 }
 
 func TestGetProjectApprovalRule(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/approval_rules/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -1132,8 +1106,7 @@ func TestGetProjectApprovalRule(t *testing.T) {
 }
 
 func TestCreateProjectApprovalRule(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/approval_rules", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -1311,8 +1284,7 @@ func TestCreateProjectApprovalRule(t *testing.T) {
 }
 
 func TestCreateProjectApprovalRuleEligibleApprovers(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/approval_rules", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)

--- a/protected_branches_test.go
+++ b/protected_branches_test.go
@@ -24,8 +24,7 @@ import (
 )
 
 func TestListProtectedBranches(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/protected_branches", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -76,8 +75,7 @@ func TestListProtectedBranches(t *testing.T) {
 }
 
 func TestListProtectedBranchesWithoutCodeOwnerApproval(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/protected_branches", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -127,8 +125,7 @@ func TestListProtectedBranchesWithoutCodeOwnerApproval(t *testing.T) {
 }
 
 func TestProtectRepositoryBranches(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/protected_branches", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -183,8 +180,7 @@ func TestProtectRepositoryBranches(t *testing.T) {
 }
 
 func TestUpdateRepositoryBranches(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/protected_branches/master", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPatch)

--- a/protected_environments_test.go
+++ b/protected_environments_test.go
@@ -25,8 +25,7 @@ import (
 )
 
 func TestListProtectedEnvironments(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/protected_environments", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -79,8 +78,7 @@ func TestListProtectedEnvironments(t *testing.T) {
 }
 
 func TestGetProtectedEnvironment(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	// Test with RequiredApprovalCount
 	environmentName := "my-awesome-environment"
@@ -146,8 +144,7 @@ func TestGetProtectedEnvironment(t *testing.T) {
 }
 
 func TestProtectRepositoryEnvironments(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	// Test with RequiredApprovalCount
 	mux.HandleFunc("/api/v4/projects/1/protected_environments", func(w http.ResponseWriter, r *http.Request) {
@@ -223,8 +220,7 @@ func TestProtectRepositoryEnvironments(t *testing.T) {
 }
 
 func TestUnprotectRepositoryEnvironments(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/protected_environments/my-awesome-environment", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)

--- a/protected_tags_test.go
+++ b/protected_tags_test.go
@@ -25,8 +25,7 @@ import (
 )
 
 func TestListProtectedTags(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/protected_tags", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -61,8 +60,7 @@ func TestListProtectedTags(t *testing.T) {
 }
 
 func TestGetProtectedTag(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	tagName := "my-awesome-tag"
 
@@ -93,8 +91,7 @@ func TestGetProtectedTag(t *testing.T) {
 }
 
 func TestProtectRepositoryTags(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/protected_tags", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -132,8 +129,7 @@ func TestProtectRepositoryTags(t *testing.T) {
 }
 
 func TestUnprotectRepositoryTags(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/protected_tags/my-awesome-tag", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)

--- a/releaselinks_test.go
+++ b/releaselinks_test.go
@@ -26,8 +26,7 @@ import (
 )
 
 func TestReleaseLinksService_ListReleaseLinks(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/releases/v0.1/assets/links",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -112,8 +111,7 @@ func TestReleaseLinksService_CreateReleaseLink(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			mux, server, client := setup(t)
-			defer teardown(server)
+			mux, client := setup(t)
 
 			mux.HandleFunc("/api/v4/projects/1/releases/v0.1/assets/links",
 				func(w http.ResponseWriter, r *http.Request) {
@@ -130,8 +128,7 @@ func TestReleaseLinksService_CreateReleaseLink(t *testing.T) {
 }
 
 func TestReleaseLinksService_GetReleaseLink(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/releases/v0.1/assets/links/1",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -150,8 +147,7 @@ func TestReleaseLinksService_GetReleaseLink(t *testing.T) {
 }
 
 func TestReleaseLinksService_UpdateReleaseLink(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/releases/v0.1/assets/links/1",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -180,8 +176,7 @@ func TestReleaseLinksService_UpdateReleaseLink(t *testing.T) {
 }
 
 func TestReleaseLinksService_DeleteReleaseLink(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/releases/v0.1/assets/links/1",
 		func(w http.ResponseWriter, r *http.Request) {

--- a/releases_test.go
+++ b/releases_test.go
@@ -26,8 +26,7 @@ import (
 )
 
 func TestReleasesService_ListReleases(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/releases",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -46,8 +45,7 @@ func TestReleasesService_ListReleases(t *testing.T) {
 }
 
 func TestReleasesService_GetRelease(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/releases/v0.1",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -65,8 +63,7 @@ func TestReleasesService_GetRelease(t *testing.T) {
 }
 
 func TestReleasesService_CreateRelease(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/releases",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -110,8 +107,7 @@ func TestReleasesService_CreateRelease(t *testing.T) {
 }
 
 func TestReleasesService_CreateReleaseWithAsset(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/releases",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -160,8 +156,7 @@ func TestReleasesService_CreateReleaseWithAsset(t *testing.T) {
 }
 
 func TestReleasesService_CreateReleaseWithAssetAndNameMetadata(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/releases",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -210,8 +205,7 @@ func TestReleasesService_CreateReleaseWithAssetAndNameMetadata(t *testing.T) {
 }
 
 func TestReleasesService_CreateReleaseWithMilestones(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/releases",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -256,8 +250,7 @@ func TestReleasesService_CreateReleaseWithMilestones(t *testing.T) {
 }
 
 func TestReleasesService_CreateReleaseWithReleasedAt(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/releases",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -302,8 +295,7 @@ func TestReleasesService_CreateReleaseWithReleasedAt(t *testing.T) {
 }
 
 func TestReleasesService_UpdateRelease(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/releases/v0.1",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -338,8 +330,7 @@ func TestReleasesService_UpdateRelease(t *testing.T) {
 }
 
 func TestReleasesService_UpdateReleaseWithMilestones(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/releases/v0.1",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -375,8 +366,7 @@ func TestReleasesService_UpdateReleaseWithMilestones(t *testing.T) {
 }
 
 func TestReleasesService_UpdateReleaseWithReleasedAt(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/releases/v0.1",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -412,8 +402,7 @@ func TestReleasesService_UpdateReleaseWithReleasedAt(t *testing.T) {
 }
 
 func TestReleasesService_DeleteRelease(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/releases/v0.1",
 		func(w http.ResponseWriter, r *http.Request) {

--- a/repositories_test.go
+++ b/repositories_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 func TestRepositoriesService_ListTree(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/repository/tree", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -58,8 +57,7 @@ func TestRepositoriesService_ListTree(t *testing.T) {
 }
 
 func TestRepositoriesService_Blob(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/repository/blobs/2dc6aa325a317eda67812f05600bdf0fcdc70ab0", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -97,8 +95,7 @@ func TestRepositoriesService_Blob(t *testing.T) {
 }
 
 func TestRepositoriesService_RawBlobContent(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/repository/blobs/2dc6aa325a317eda67812f05600bdf0fcdc70ab0/raw", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -136,8 +133,7 @@ func TestRepositoriesService_RawBlobContent(t *testing.T) {
 }
 
 func TestRepositoriesService_Archive(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/repository/archive.gz", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -176,8 +172,7 @@ func TestRepositoriesService_Archive(t *testing.T) {
 }
 
 func TestRepositoriesService_StreamArchive(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/repository/archive.gz", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -204,8 +199,7 @@ func TestRepositoriesService_StreamArchive(t *testing.T) {
 }
 
 func TestRepositoriesService_Compare(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/12d65c8dd2b2676fa3ac47d955accc085a37a9c1/repository/compare", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -297,8 +291,7 @@ func TestRepositoriesService_Compare(t *testing.T) {
 }
 
 func TestRepositoriesService_Contributors(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/12d65c8dd2b2676fa3ac47d955accc085a37a9c1/repository/contributors", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -343,8 +336,7 @@ func TestRepositoriesService_Contributors(t *testing.T) {
 }
 
 func TestRepositoriesService_MergeBase(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1a0b36b3cdad1d2ee32457c102a8c0b7056fa863/repository/merge_base", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)

--- a/repository_files_test.go
+++ b/repository_files_test.go
@@ -10,8 +10,7 @@ import (
 )
 
 func TestRepositoryFilesService_GetFile(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/13083/repository/files/app%2Fmodels%2Fkey%2Erb?ref=master", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -68,8 +67,7 @@ func TestRepositoryFilesService_GetFile(t *testing.T) {
 }
 
 func TestRepositoryFilesService_GetFileMetaData(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/13083/repository/files/app%2Fmodels%2Fkey%2Erb?ref=master", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodHead)
@@ -120,8 +118,7 @@ func TestRepositoryFilesService_GetFileMetaData(t *testing.T) {
 }
 
 func TestRepositoryFilesService_GetFileBlame(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/13083/repository/files/path%2Fto%2Ffile.rb/blame", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -193,8 +190,7 @@ func TestRepositoryFilesService_GetFileBlame(t *testing.T) {
 }
 
 func TestRepositoryFilesService_GetRawFile(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/13083/repository/files/app%2Fmodels%2Fkey%2Erb/raw", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -248,8 +244,7 @@ func TestRepositoryFilesService_GetRawFile(t *testing.T) {
 }
 
 func TestRepositoryFilesService_CreateFile(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/13083/repository/files/app%2Fproject%2Erb", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -293,8 +288,7 @@ func TestRepositoryFilesService_CreateFile(t *testing.T) {
 }
 
 func TestRepositoryFilesService_UpdateFile(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/13083/repository/files/app%2Fproject%2Erb", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -338,8 +332,7 @@ func TestRepositoryFilesService_UpdateFile(t *testing.T) {
 }
 
 func TestRepositoryFilesService_DeleteFile(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/13083/repository/files/app%2Fproject%2Erb", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)

--- a/repository_submodules_test.go
+++ b/repository_submodules_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 func TestRepositorySubmodulesService_UpdateSubmodule(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/13083/repository/submodules/app%2Fproject", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)

--- a/resource_label_events_test.go
+++ b/resource_label_events_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 func TestResourceLabelEventsService_ListIssueLabelEvents(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/issues/11/resource_label_events", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -97,8 +96,7 @@ func TestResourceLabelEventsService_ListIssueLabelEvents(t *testing.T) {
 }
 
 func TestResourceLabelEventsService_GetIssueLabelEvent(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/issues/11/resource_label_events/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -183,8 +181,7 @@ func TestResourceLabelEventsService_GetIssueLabelEvent(t *testing.T) {
 }
 
 func TestResourceLabelEventsService_ListGroupEpicLabelEvents(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/epics/11/resource_label_events", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -271,8 +268,7 @@ func TestResourceLabelEventsService_ListGroupEpicLabelEvents(t *testing.T) {
 }
 
 func TestResourceLabelEventsService_GetGroupEpicLabelEvent(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/epics/11/resource_label_events/107", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -357,8 +353,7 @@ func TestResourceLabelEventsService_GetGroupEpicLabelEvent(t *testing.T) {
 }
 
 func TestResourceLabelEventsService_ListMergeRequestsLabelEvents(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/merge_requests/11/resource_label_events", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -445,8 +440,7 @@ func TestResourceLabelEventsService_ListMergeRequestsLabelEvents(t *testing.T) {
 }
 
 func TestResourceLabelEventsService_GetMergeRequestLabelEvent(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/merge_requests/11/resource_label_events/120", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)

--- a/resource_milestone_events_test.go
+++ b/resource_milestone_events_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 func ListIssueMilestoneEvents(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/issues/11/resource_milestone_events", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -73,8 +72,7 @@ func ListIssueMilestoneEvents(t *testing.T) {
 }
 
 func GetIssueMilestoneEvent(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/issues/11/resource_milestone_events/143", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -135,8 +133,7 @@ func GetIssueMilestoneEvent(t *testing.T) {
 }
 
 func ListMergeMilestoneEvents(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/merge_requests/11/resource_milestone_events", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -199,8 +196,7 @@ func ListMergeMilestoneEvents(t *testing.T) {
 }
 
 func GetMergeRequestMilestoneEvent(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/merge_requests/11/resource_milestone_events/120", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)

--- a/resource_state_events_test.go
+++ b/resource_state_events_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 func TestResourceStateEventsService_ListIssueStateEvents(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/issues/11/resource_state_events", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -55,8 +54,7 @@ func TestResourceStateEventsService_ListIssueStateEvents(t *testing.T) {
 }
 
 func TestResourceStateEventsService_GetIssueStateEvent(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/issues/11/resource_state_events/143", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -99,8 +97,7 @@ func TestResourceStateEventsService_GetIssueStateEvent(t *testing.T) {
 }
 
 func TestResourceStateEventsService_ListMergeStateEvents(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/merge_requests/11/resource_state_events", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -145,8 +142,7 @@ func TestResourceStateEventsService_ListMergeStateEvents(t *testing.T) {
 }
 
 func TestResourceStateEventsService_GetMergeRequestStateEvent(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/merge_requests/11/resource_state_events/120", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)

--- a/resource_weight_events_test.go
+++ b/resource_weight_events_test.go
@@ -10,8 +10,7 @@ import (
 )
 
 func TestResourceWeightEventsService_ListIssueWightEvents(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/5/issues/11/resource_weight_events", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)

--- a/runners_test.go
+++ b/runners_test.go
@@ -25,8 +25,7 @@ import (
 )
 
 func TestDisableRunner(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/runners/2", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
@@ -40,8 +39,7 @@ func TestDisableRunner(t *testing.T) {
 }
 
 func TestListRunnersJobs(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/runners/1/jobs", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -124,8 +122,7 @@ func TestListRunnersJobs(t *testing.T) {
 }
 
 func TestRemoveRunner(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/runners/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
@@ -139,8 +136,7 @@ func TestRemoveRunner(t *testing.T) {
 }
 
 func TestUpdateRunnersDetails(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/runners/6", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -191,8 +187,7 @@ func TestUpdateRunnersDetails(t *testing.T) {
 }
 
 func TestGetRunnerDetails(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/runners/6", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -241,8 +236,7 @@ func TestGetRunnerDetails(t *testing.T) {
 }
 
 func TestRegisterNewRunner(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/runners", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -275,8 +269,7 @@ func TestRegisterNewRunner(t *testing.T) {
 // Similar to TestRegisterNewRunner but sends info struct and some extra other
 // fields too.
 func TestRegisterNewRunnerInfo(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/runners", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -336,8 +329,7 @@ func TestRegisterNewRunnerInfo(t *testing.T) {
 }
 
 func TestDeleteRegisteredRunner(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/runners", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
@@ -358,8 +350,7 @@ func TestDeleteRegisteredRunner(t *testing.T) {
 }
 
 func TestDeleteRegisteredRunnerByID(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/runners/11111", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
@@ -380,8 +371,7 @@ func TestDeleteRegisteredRunnerByID(t *testing.T) {
 }
 
 func TestVerifyRegisteredRunner(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/runners/verify", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -402,8 +392,7 @@ func TestVerifyRegisteredRunner(t *testing.T) {
 }
 
 func TestResetInstanceRunnerRegistrationToken(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/runners/reset_registration_token", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -434,8 +423,7 @@ func TestResetInstanceRunnerRegistrationToken(t *testing.T) {
 }
 
 func TestResetGroupRunnerRegistrationToken(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/foobar/runners/reset_registration_token", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -466,8 +454,7 @@ func TestResetGroupRunnerRegistrationToken(t *testing.T) {
 }
 
 func TestResetProjectRunnerRegistrationToken(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/9/runners/reset_registration_token", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -498,8 +485,7 @@ func TestResetProjectRunnerRegistrationToken(t *testing.T) {
 }
 
 func TestResetRunnerAuthenticationToken(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/runners/42/reset_authentication_token", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)

--- a/search_test.go
+++ b/search_test.go
@@ -24,8 +24,7 @@ import (
 )
 
 func TestSearchService_Users(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/search", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -49,8 +48,7 @@ func TestSearchService_Users(t *testing.T) {
 }
 
 func TestSearchService_UsersByGroup(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/3/-/search", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -74,8 +72,7 @@ func TestSearchService_UsersByGroup(t *testing.T) {
 }
 
 func TestSearchService_UsersByProject(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/6/-/search", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)

--- a/services_test.go
+++ b/services_test.go
@@ -24,8 +24,7 @@ import (
 )
 
 func TestListServices(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/services", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -43,8 +42,7 @@ func TestListServices(t *testing.T) {
 }
 
 func TestCustomIssueTrackerService(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/services/custom-issue-tracker", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -73,8 +71,7 @@ func TestCustomIssueTrackerService(t *testing.T) {
 }
 
 func TestSetCustomIssueTrackerService(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/services/custom-issue-tracker", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -96,8 +93,7 @@ func TestSetCustomIssueTrackerService(t *testing.T) {
 }
 
 func TestDeleteCustomIssueTrackerService(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/services/custom-issue-tracker", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
@@ -110,8 +106,7 @@ func TestDeleteCustomIssueTrackerService(t *testing.T) {
 }
 
 func TestGetDroneCIService(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/services/drone-ci", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -129,8 +124,7 @@ func TestGetDroneCIService(t *testing.T) {
 }
 
 func TestSetDroneCIService(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/services/drone-ci", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -145,8 +139,7 @@ func TestSetDroneCIService(t *testing.T) {
 }
 
 func TestDeleteDroneCIService(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/services/drone-ci", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
@@ -159,8 +152,7 @@ func TestDeleteDroneCIService(t *testing.T) {
 }
 
 func TestGetEmailsOnPushService(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/integrations/emails-on-push", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -178,8 +170,7 @@ func TestGetEmailsOnPushService(t *testing.T) {
 }
 
 func TestSetEmailsOnPushService(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/integrations/emails-on-push", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -194,8 +185,7 @@ func TestSetEmailsOnPushService(t *testing.T) {
 }
 
 func TestDeleteEmailsOnPushService(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/integrations/emails-on-push", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
@@ -208,8 +198,7 @@ func TestDeleteEmailsOnPushService(t *testing.T) {
 }
 
 func TestGetJiraService(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/0/services/jira", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -269,8 +258,7 @@ func TestGetJiraService(t *testing.T) {
 }
 
 func TestSetJiraService(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/services/jira", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -296,8 +284,7 @@ func TestSetJiraService(t *testing.T) {
 }
 
 func TestDeleteJiraService(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/services/jira", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
@@ -310,8 +297,7 @@ func TestDeleteJiraService(t *testing.T) {
 }
 
 func TestGetMattermostService(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/services/mattermost", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -329,8 +315,7 @@ func TestGetMattermostService(t *testing.T) {
 }
 
 func TestSetMattermostService(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/services/mattermost", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -349,8 +334,7 @@ func TestSetMattermostService(t *testing.T) {
 }
 
 func TestDeleteMattermostService(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/services/mattermost", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
@@ -363,8 +347,7 @@ func TestDeleteMattermostService(t *testing.T) {
 }
 
 func TestGetPipelinesEmailService(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/services/pipelines-email", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -382,8 +365,7 @@ func TestGetPipelinesEmailService(t *testing.T) {
 }
 
 func TestSetPipelinesEmailService(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/services/pipelines-email", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -405,8 +387,7 @@ func TestSetPipelinesEmailService(t *testing.T) {
 }
 
 func TestDeletePipelinesEmailService(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/services/pipelines-email", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
@@ -419,8 +400,7 @@ func TestDeletePipelinesEmailService(t *testing.T) {
 }
 
 func TestGetPrometheusService(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/services/prometheus", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -438,8 +418,7 @@ func TestGetPrometheusService(t *testing.T) {
 }
 
 func TestSetPrometheusService(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/services/prometheus", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -454,8 +433,7 @@ func TestSetPrometheusService(t *testing.T) {
 }
 
 func TestDeletePrometheusService(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/services/prometheus", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
@@ -468,8 +446,7 @@ func TestDeletePrometheusService(t *testing.T) {
 }
 
 func TestGetSlackService(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/services/slack", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -487,8 +464,7 @@ func TestGetSlackService(t *testing.T) {
 }
 
 func TestSetSlackService(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/services/slack", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -507,8 +483,7 @@ func TestSetSlackService(t *testing.T) {
 }
 
 func TestDeleteSlackService(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/services/slack", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
@@ -521,8 +496,7 @@ func TestDeleteSlackService(t *testing.T) {
 }
 
 func TestGetYouTrackService(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/services/youtrack", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -540,8 +514,7 @@ func TestGetYouTrackService(t *testing.T) {
 }
 
 func TestSetYouTrackService(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/services/youtrack", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -561,8 +534,7 @@ func TestSetYouTrackService(t *testing.T) {
 }
 
 func TestDeleteYouTrackService(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/services/youtrack", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
@@ -575,8 +547,7 @@ func TestDeleteYouTrackService(t *testing.T) {
 }
 
 func TestGetSlackSlashCommandsService(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/services/slack-slash-commands", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -594,8 +565,7 @@ func TestGetSlackSlashCommandsService(t *testing.T) {
 }
 
 func TestSetSlackSlashCommandsService(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/services/slack-slash-commands", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -612,8 +582,7 @@ func TestSetSlackSlashCommandsService(t *testing.T) {
 }
 
 func TestDeleteSlackSlashCommandsService(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/services/slack-slash-commands", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
@@ -626,8 +595,7 @@ func TestDeleteSlackSlashCommandsService(t *testing.T) {
 }
 
 func TestGetMattermostSlashCommandsService(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/services/mattermost-slash-commands", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -645,8 +613,7 @@ func TestGetMattermostSlashCommandsService(t *testing.T) {
 }
 
 func TestSetMattermostSlashCommandsService(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/services/mattermost-slash-commands", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -664,8 +631,7 @@ func TestSetMattermostSlashCommandsService(t *testing.T) {
 }
 
 func TestDeleteMattermostSlashCommandsService(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/services/mattermost-slash-commands", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)

--- a/settings_test.go
+++ b/settings_test.go
@@ -24,8 +24,7 @@ import (
 )
 
 func TestGetSettings(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/application/settings", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -44,8 +43,7 @@ func TestGetSettings(t *testing.T) {
 }
 
 func TestUpdateSettings(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/application/settings", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)

--- a/sidekiq_metrics_test.go
+++ b/sidekiq_metrics_test.go
@@ -10,8 +10,7 @@ import (
 )
 
 func TestSidekiqService_GetQueueMetrics(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/sidekiq/queue_metrics", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -29,8 +28,7 @@ func TestSidekiqService_GetQueueMetrics(t *testing.T) {
 }
 
 func TestSidekiqService_GetProcessMetrics(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/sidekiq/process_metrics", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -54,8 +52,7 @@ func TestSidekiqService_GetProcessMetrics(t *testing.T) {
 }
 
 func TestSidekiqService_GetJobStats(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/sidekiq/job_stats", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -78,8 +75,7 @@ func TestSidekiqService_GetJobStats(t *testing.T) {
 }
 
 func TestSidekiqService_GetCompoundMetrics(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/sidekiq/compound_metrics", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)

--- a/snippets_test.go
+++ b/snippets_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 func TestSnippetsService_ListSnippets(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/snippets", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -27,8 +26,7 @@ func TestSnippetsService_ListSnippets(t *testing.T) {
 }
 
 func TestSnippetsService_GetSnippet(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/snippets/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -43,8 +41,7 @@ func TestSnippetsService_GetSnippet(t *testing.T) {
 }
 
 func TestSnippetsService_CreateSnippet(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/snippets", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -67,8 +64,7 @@ func TestSnippetsService_CreateSnippet(t *testing.T) {
 }
 
 func TestSnippetsService_UpdateSnippet(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/snippets/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -91,8 +87,7 @@ func TestSnippetsService_UpdateSnippet(t *testing.T) {
 }
 
 func TestSnippetsService_DeleteSnippet(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/snippets/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
@@ -104,8 +99,7 @@ func TestSnippetsService_DeleteSnippet(t *testing.T) {
 }
 
 func TestSnippetsService_SnippetContent(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/snippets/1/raw", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -120,8 +114,7 @@ func TestSnippetsService_SnippetContent(t *testing.T) {
 }
 
 func TestSnippetsService_ExploreSnippets(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/snippets/public", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)

--- a/system_hooks_test.go
+++ b/system_hooks_test.go
@@ -10,8 +10,7 @@ import (
 )
 
 func TestSystemHooksService_ListHooks(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/hooks", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -48,8 +47,7 @@ func TestSystemHooksService_ListHooks(t *testing.T) {
 }
 
 func TestSystemHooksService_GetHook(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/hooks/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -84,8 +82,7 @@ func TestSystemHooksService_GetHook(t *testing.T) {
 }
 
 func TestSystemHooksService_AddHook(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/hooks", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -104,8 +101,7 @@ func TestSystemHooksService_AddHook(t *testing.T) {
 }
 
 func TestSystemHooksService_TestHook(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/hooks/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -128,8 +124,7 @@ func TestSystemHooksService_TestHook(t *testing.T) {
 }
 
 func TestSystemHooksService_DeleteHook(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/hooks/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)

--- a/tags_test.go
+++ b/tags_test.go
@@ -24,8 +24,7 @@ import (
 )
 
 func TestTagsService_ListTags(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/repository/tags", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -67,8 +66,7 @@ func TestTagsService_ListTags(t *testing.T) {
 }
 
 func TestTagsService_CreateReleaseNote(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/repository/tags/1.0.0/release",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -90,8 +88,7 @@ func TestTagsService_CreateReleaseNote(t *testing.T) {
 }
 
 func TestTagsService_UpdateReleaseNote(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/repository/tags/1.0.0/release",
 		func(w http.ResponseWriter, r *http.Request) {

--- a/todos_test.go
+++ b/todos_test.go
@@ -24,8 +24,7 @@ import (
 )
 
 func TestListTodos(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/todos", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -42,8 +41,7 @@ func TestListTodos(t *testing.T) {
 }
 
 func TestMarkAllTodosAsDone(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/todos/mark_as_done", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -55,8 +53,7 @@ func TestMarkAllTodosAsDone(t *testing.T) {
 }
 
 func TestMarkTodoAsDone(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/todos/1/mark_as_done", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)

--- a/topics_test.go
+++ b/topics_test.go
@@ -24,8 +24,7 @@ import (
 )
 
 func TestTopicsService_ListTopics(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/topics", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -89,8 +88,7 @@ func TestTopicsService_ListTopics(t *testing.T) {
 }
 
 func TestTopicsService_GetTopic(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/topics/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -123,8 +121,7 @@ func TestTopicsService_GetTopic(t *testing.T) {
 }
 
 func TestTopicsService_CreateTopic(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/topics", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -151,8 +148,7 @@ func TestTopicsService_CreateTopic(t *testing.T) {
 }
 
 func TestTopicsService_UpdateTopic(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/topics/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)

--- a/users_test.go
+++ b/users_test.go
@@ -30,8 +30,7 @@ import (
 )
 
 func TestGetUser(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	path := "/api/v4/users/1"
 
@@ -65,8 +64,7 @@ func TestGetUser(t *testing.T) {
 }
 
 func TestGetUserAdmin(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	path := "/api/v4/users/1"
 
@@ -121,8 +119,7 @@ func TestGetUserAdmin(t *testing.T) {
 }
 
 func TestBlockUser(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	path := fmt.Sprintf("/%susers/1/block", apiVersionPath)
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
@@ -137,8 +134,7 @@ func TestBlockUser(t *testing.T) {
 }
 
 func TestBlockUser_UserNotFound(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	path := fmt.Sprintf("/%susers/1/block", apiVersionPath)
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
@@ -153,8 +149,7 @@ func TestBlockUser_UserNotFound(t *testing.T) {
 }
 
 func TestBlockUser_BlockPrevented(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	path := fmt.Sprintf("/%susers/1/block", apiVersionPath)
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
@@ -169,8 +164,7 @@ func TestBlockUser_BlockPrevented(t *testing.T) {
 }
 
 func TestBlockUser_UnknownError(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	path := fmt.Sprintf("/%susers/1/block", apiVersionPath)
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
@@ -187,8 +181,7 @@ func TestBlockUser_UnknownError(t *testing.T) {
 }
 
 func TestUnblockUser(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	path := fmt.Sprintf("/%susers/1/unblock", apiVersionPath)
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
@@ -203,8 +196,7 @@ func TestUnblockUser(t *testing.T) {
 }
 
 func TestUnblockUser_UserNotFound(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	path := fmt.Sprintf("/%susers/1/unblock", apiVersionPath)
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
@@ -219,8 +211,7 @@ func TestUnblockUser_UserNotFound(t *testing.T) {
 }
 
 func TestUnblockUser_UnblockPrevented(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	path := fmt.Sprintf("/%susers/1/unblock", apiVersionPath)
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
@@ -235,8 +226,7 @@ func TestUnblockUser_UnblockPrevented(t *testing.T) {
 }
 
 func TestUnblockUser_UnknownError(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	path := fmt.Sprintf("/%susers/1/unblock", apiVersionPath)
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
@@ -253,8 +243,7 @@ func TestUnblockUser_UnknownError(t *testing.T) {
 }
 
 func TestBanUser(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	path := fmt.Sprintf("/%susers/1/block", apiVersionPath)
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
@@ -269,8 +258,7 @@ func TestBanUser(t *testing.T) {
 }
 
 func TestBanUser_UserNotFound(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	path := fmt.Sprintf("/%susers/1/ban", apiVersionPath)
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
@@ -285,8 +273,7 @@ func TestBanUser_UserNotFound(t *testing.T) {
 }
 
 func TestBanUser_UnknownError(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	path := fmt.Sprintf("/%susers/1/ban", apiVersionPath)
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
@@ -303,8 +290,7 @@ func TestBanUser_UnknownError(t *testing.T) {
 }
 
 func TestUnbanUser(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	path := fmt.Sprintf("/%susers/1/unban", apiVersionPath)
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
@@ -319,8 +305,7 @@ func TestUnbanUser(t *testing.T) {
 }
 
 func TestUnbanUser_UserNotFound(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	path := fmt.Sprintf("/%susers/1/unban", apiVersionPath)
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
@@ -335,8 +320,7 @@ func TestUnbanUser_UserNotFound(t *testing.T) {
 }
 
 func TestUnbanUser_UnknownError(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	path := fmt.Sprintf("/%susers/1/unban", apiVersionPath)
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
@@ -353,8 +337,7 @@ func TestUnbanUser_UnknownError(t *testing.T) {
 }
 
 func TestDeactivateUser(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	path := fmt.Sprintf("/%susers/1/deactivate", apiVersionPath)
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
@@ -369,8 +352,7 @@ func TestDeactivateUser(t *testing.T) {
 }
 
 func TestDeactivateUser_UserNotFound(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	path := fmt.Sprintf("/%susers/1/deactivate", apiVersionPath)
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
@@ -385,8 +367,7 @@ func TestDeactivateUser_UserNotFound(t *testing.T) {
 }
 
 func TestDeactivateUser_DeactivatePrevented(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	path := fmt.Sprintf("/%susers/1/deactivate", apiVersionPath)
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
@@ -401,8 +382,7 @@ func TestDeactivateUser_DeactivatePrevented(t *testing.T) {
 }
 
 func TestActivateUser(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	path := fmt.Sprintf("/%susers/1/activate", apiVersionPath)
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
@@ -417,8 +397,7 @@ func TestActivateUser(t *testing.T) {
 }
 
 func TestActivateUser_ActivatePrevented(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	path := fmt.Sprintf("/%susers/1/activate", apiVersionPath)
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
@@ -433,8 +412,7 @@ func TestActivateUser_ActivatePrevented(t *testing.T) {
 }
 
 func TestActivateUser_UserNotFound(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	path := fmt.Sprintf("/%susers/1/activate", apiVersionPath)
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
@@ -449,8 +427,7 @@ func TestActivateUser_UserNotFound(t *testing.T) {
 }
 
 func TestApproveUser(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	path := fmt.Sprintf("/%susers/1/approve", apiVersionPath)
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
@@ -465,8 +442,7 @@ func TestApproveUser(t *testing.T) {
 }
 
 func TestApproveUser_UserNotFound(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	path := fmt.Sprintf("/%susers/1/approve", apiVersionPath)
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
@@ -481,8 +457,7 @@ func TestApproveUser_UserNotFound(t *testing.T) {
 }
 
 func TestApproveUser_ApprovePrevented(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	path := fmt.Sprintf("/%susers/1/approve", apiVersionPath)
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
@@ -497,8 +472,7 @@ func TestApproveUser_ApprovePrevented(t *testing.T) {
 }
 
 func TestApproveUser_UnknownError(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	path := fmt.Sprintf("/%susers/1/approve", apiVersionPath)
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
@@ -515,8 +489,7 @@ func TestApproveUser_UnknownError(t *testing.T) {
 }
 
 func TestRejectUser(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	path := fmt.Sprintf("/%susers/1/reject", apiVersionPath)
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
@@ -531,8 +504,7 @@ func TestRejectUser(t *testing.T) {
 }
 
 func TestRejectUser_UserNotFound(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	path := fmt.Sprintf("/%susers/1/reject", apiVersionPath)
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
@@ -547,8 +519,7 @@ func TestRejectUser_UserNotFound(t *testing.T) {
 }
 
 func TestRejectUser_RejectPrevented(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	path := fmt.Sprintf("/%susers/1/reject", apiVersionPath)
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
@@ -563,8 +534,7 @@ func TestRejectUser_RejectPrevented(t *testing.T) {
 }
 
 func TestRejectUser_Conflict(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	path := fmt.Sprintf("/%susers/1/reject", apiVersionPath)
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
@@ -579,8 +549,7 @@ func TestRejectUser_Conflict(t *testing.T) {
 }
 
 func TestRejectUser_UnknownError(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	path := fmt.Sprintf("/%susers/1/reject", apiVersionPath)
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
@@ -597,8 +566,7 @@ func TestRejectUser_UnknownError(t *testing.T) {
 }
 
 func TestGetMemberships(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	path := fmt.Sprintf("/%susers/1/memberships", apiVersionPath)
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
@@ -616,8 +584,7 @@ func TestGetMemberships(t *testing.T) {
 }
 
 func TestGetSingleSSHKeyForUser(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/users/1/keys/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -651,8 +618,7 @@ func TestGetSingleSSHKeyForUser(t *testing.T) {
 }
 
 func TestDisableUser2FA(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	path := fmt.Sprintf("/%susers/1/disable_two_factor", apiVersionPath)
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {

--- a/validate_test.go
+++ b/validate_test.go
@@ -72,8 +72,7 @@ func TestValidate(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			mux, server, client := setup(t)
-			defer teardown(server)
+			mux, client := setup(t)
 
 			mux.HandleFunc("/api/v4/ci/lint", func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, http.MethodPost)
@@ -133,8 +132,7 @@ func TestValidateProject(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			mux, server, client := setup(t)
-			defer teardown(server)
+			mux, client := setup(t)
 
 			mux.HandleFunc("/api/v4/projects/1/ci/lint", func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, http.MethodGet)
@@ -204,8 +202,7 @@ func TestValidateProjectNamespace(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			mux, server, client := setup(t)
-			defer teardown(server)
+			mux, client := setup(t)
 
 			mux.HandleFunc("/api/v4/projects/1/ci/lint", func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, http.MethodPost)

--- a/version_test.go
+++ b/version_test.go
@@ -24,8 +24,7 @@ import (
 )
 
 func TestGetVersion(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/version",
 		func(w http.ResponseWriter, r *http.Request) {

--- a/wikis_test.go
+++ b/wikis_test.go
@@ -23,8 +23,7 @@ import (
 )
 
 func TestListWikis(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/wikis", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -82,8 +81,7 @@ func TestListWikis(t *testing.T) {
 }
 
 func TestGetWikiPage(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/wikis/home", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
@@ -115,8 +113,7 @@ func TestGetWikiPage(t *testing.T) {
 }
 
 func TestCreateWikiPage(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/wikis", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -151,8 +148,7 @@ func TestCreateWikiPage(t *testing.T) {
 }
 
 func TestEditWikiPage(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/wikis/foo", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPut)
@@ -187,8 +183,7 @@ func TestEditWikiPage(t *testing.T) {
 }
 
 func TestDeleteWikiPage(t *testing.T) {
-	mux, server, client := setup(t)
-	defer teardown(server)
+	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/wikis/foo", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)


### PR DESCRIPTION
See https://pkg.go.dev/testing#T.Cleanup

> Cleanup registers a function to be called when the test (or subtest) and all its subtests complete. Cleanup functions will be called in last added, first called order.
