### PR TITLE
Add more "changes" fields to IssueEvent and MergeEvent

### DIFF
--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -25,7 +25,8 @@ import (
 
 // StateID identifies the state of an issue or merge request.
 //
-// There are no GitLab API docs on the subject, but the mappings can be found in GitLab's codebase:
+// There are no GitLab API docs on the subject, but the mappings can be found in
+// GitLab's codebase:
 // https://gitlab.com/gitlab-org/gitlab-foss/-/blob/ba5be4989e/app/models/concerns/issuable.rb#L39-42
 type StateID int
 

--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -23,6 +23,20 @@ import (
 	"time"
 )
 
+// StateID identifies the state of an issue or merge request.
+//
+// There are no GitLab API docs on the subject, but the mappings can be found in GitLab's codebase:
+// https://gitlab.com/gitlab-org/gitlab-foss/-/blob/ba5be4989e/app/models/concerns/issuable.rb#L39-42
+type StateID int
+
+const (
+	StateIDNone   StateID = 0
+	StateIDOpen   StateID = 1
+	StateIDClosed StateID = 2
+	StateIDMerged StateID = 3
+	StateIDLocked StateID = 4
+)
+
 // BuildEvent represents a build event.
 //
 // GitLab API docs:
@@ -292,6 +306,18 @@ type IssueEvent struct {
 			Previous string `json:"previous"`
 			Current  string `json:"current"`
 		} `json:"title"`
+		ClosedAt struct {
+			Previous string `json:"previous"`
+			Current  string `json:"current"`
+		} `json:"closed_at"`
+		StateID struct {
+			Previous StateID `json:"previous"`
+			Current  StateID `json:"current"`
+		} `json:"state_id"`
+		UpdatedAt struct {
+			Previous string `json:"previous"`
+			Current  string `json:"current"`
+		} `json:"updated_at"`
 		UpdatedByID struct {
 			Previous int `json:"previous"`
 			Current  int `json:"current"`
@@ -580,8 +606,8 @@ type MergeEvent struct {
 			Current  int `json:"current"`
 		} `json:"source_project_id"`
 		StateID struct {
-			Previous int `json:"previous"`
-			Current  int `json:"current"`
+			Previous StateID `json:"previous"`
+			Current  StateID `json:"current"`
 		} `json:"state_id"`
 		TargetBranch struct {
 			Previous string `json:"previous"`
@@ -595,6 +621,10 @@ type MergeEvent struct {
 			Previous string `json:"previous"`
 			Current  string `json:"current"`
 		} `json:"title"`
+		UpdatedAt struct {
+			Previous string `json:"previous"`
+			Current  string `json:"current"`
+		} `json:"updated_at"`
 		UpdatedByID struct {
 			Previous int `json:"previous"`
 			Current  int `json:"current"`

--- a/event_webhook_types_test.go
+++ b/event_webhook_types_test.go
@@ -236,6 +236,15 @@ func TestIssueEventUnmarshal(t *testing.T) {
 			GroupID:     41,
 		},
 	}, event.Changes.Labels.Current)
+
+	assert.Equal(t, "2017-09-15 16:54:55 UTC", event.Changes.ClosedAt.Previous)
+	assert.Equal(t, "2017-09-15 16:56:00 UTC", event.Changes.ClosedAt.Current)
+
+	assert.Equal(t, StateIDOpen, event.Changes.StateID.Previous)
+	assert.Equal(t, StateIDClosed, event.Changes.StateID.Current)
+
+	assert.Equal(t, "2017-09-15 16:50:55 UTC", event.Changes.UpdatedAt.Previous)
+	assert.Equal(t, "2017-09-15 16:52:00 UTC", event.Changes.UpdatedAt.Current)
 }
 
 func TestMergeEventUnmarshal(t *testing.T) {
@@ -371,6 +380,12 @@ func TestMergeEventUnmarshal(t *testing.T) {
 			GroupID:     41,
 		},
 	}, event.Changes.Labels.Current)
+
+	assert.Equal(t, StateIDLocked, event.Changes.StateID.Previous)
+	assert.Equal(t, StateIDMerged, event.Changes.StateID.Current)
+
+	assert.Equal(t, "2017-09-15 16:50:55 UTC", event.Changes.UpdatedAt.Previous)
+	assert.Equal(t, "2017-09-15 16:52:00 UTC", event.Changes.UpdatedAt.Current)
 }
 
 func TestMemberEventUnmarshal(t *testing.T) {

--- a/testdata/webhooks/issue.json
+++ b/testdata/webhooks/issue.json
@@ -87,6 +87,14 @@
       "previous": "2017-09-15 16:50:55 UTC",
       "current": "2017-09-15 16:52:00 UTC"
     },
+    "closed_at": {
+      "previous": "2017-09-15 16:54:55 UTC",
+      "current": "2017-09-15 16:56:00 UTC"
+    },
+    "state_id": {
+      "previous": 1,
+      "current": 2
+    },
     "labels": {
       "previous": [
         {

--- a/testdata/webhooks/merge_request.json
+++ b/testdata/webhooks/merge_request.json
@@ -130,6 +130,10 @@
       "previous": "2017-09-15 16:50:55 UTC",
       "current":"2017-09-15 16:52:00 UTC"
     },
+    "state_id": {
+      "previous": 4,
+      "current": 3
+    },
     "labels": {
       "previous": [{
         "id": 206,


### PR DESCRIPTION
- Add "closed_at" to IssueEvent
- Add "state_id" to IssueEvent
- Add "updated_at" to IssueEvent
- Add "updated_at" to MergeEvent
- Modify "state_id" type from int to StateID in MergeEvent

I modified the testdata so that I could test the fields. These new fields came from webhook payloads that I observed on GitLab 15.3.4-ee.