### PR TITLE
Add Dockerfile templates API

### DIFF
--- a/dockerfile_templates.go
+++ b/dockerfile_templates.go
@@ -1,0 +1,93 @@
+//
+// Copyright 2022, FantasyTeddy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package gitlab
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+// DockerfileTemplatesService handles communication with the Dockerfile
+// templates related methods of the GitLab API.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/templates/dockerfiles.html
+type DockerfileTemplatesService struct {
+	client *Client
+}
+
+// DockerfileTemplate represents a GitLab Dockerfile template.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/templates/dockerfiles.html
+type DockerfileTemplate struct {
+	Name    string `json:"name"`
+	Content string `json:"content"`
+}
+
+// DockerfileTemplateListItem represents a GitLab Dockerfile template from the list.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/templates/dockerfiles.html
+type DockerfileTemplateListItem struct {
+	Key  string `json:"key"`
+	Name string `json:"name"`
+}
+
+// ListDockerfileTemplatesOptions represents the available ListAllTemplates() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/templates/dockerfiles.html#list-dockerfile-templates
+type ListDockerfileTemplatesOptions ListOptions
+
+// ListTemplates get a list of available Dockerfile templates.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/templates/dockerfiles.html#list-dockerfile-templates
+func (s *DockerfileTemplatesService) ListTemplates(opt *ListDockerfileTemplatesOptions, options ...RequestOptionFunc) ([]*DockerfileTemplateListItem, *Response, error) {
+	req, err := s.client.NewRequest(http.MethodGet, "templates/dockerfiles", opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var gs []*DockerfileTemplateListItem
+	resp, err := s.client.Do(req, &gs)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return gs, resp, err
+}
+
+// GetTemplate get a single Dockerfile template.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/templates/dockerfiles.html#single-dockerfile-template
+func (s *DockerfileTemplatesService) GetTemplate(key string, options ...RequestOptionFunc) (*DockerfileTemplate, *Response, error) {
+	u := fmt.Sprintf("templates/dockerfiles/%s", url.PathEscape(key))
+
+	req, err := s.client.NewRequest(http.MethodGet, u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	g := new(DockerfileTemplate)
+	resp, err := s.client.Do(req, g)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return g, resp, err
+}

--- a/dockerfile_templates_test.go
+++ b/dockerfile_templates_test.go
@@ -1,0 +1,118 @@
+//
+// Copyright 2022, FantasyTeddy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package gitlab
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestDockerfileTemplatesService_ListTemplates(t *testing.T) {
+	mux, client := setup(t)
+
+	mux.HandleFunc("/api/v4/templates/dockerfiles", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprintf(w, `[
+			{
+			  "key":"Binary",
+			  "name":"Binary"
+			},
+			{
+			  "key":"Binary-alpine",
+			  "name":"Binary-alpine"
+			},
+			{
+			  "key":"Binary-scratch",
+			  "name":"Binary-scratch"
+			},
+			{
+			  "key":"Golang",
+			  "name":"Golang"
+			},
+			{
+			  "key":"Golang-alpine",
+			  "name":"Golang-alpine"
+			},
+			{
+			  "key":"Golang-scratch",
+			  "name":"Golang-scratch"
+			}
+		  ]`)
+	})
+
+	templates, _, err := client.DockerfileTemplate.ListTemplates(&ListDockerfileTemplatesOptions{})
+	if err != nil {
+		t.Errorf("DockerfileTemplate.ListTemplates returned error: %v", err)
+	}
+
+	want := []*DockerfileTemplateListItem{
+		{
+			Key:  "Binary",
+			Name: "Binary",
+		},
+		{
+			Key:  "Binary-alpine",
+			Name: "Binary-alpine",
+		},
+		{
+			Key:  "Binary-scratch",
+			Name: "Binary-scratch",
+		},
+		{
+			Key:  "Golang",
+			Name: "Golang",
+		},
+		{
+			Key:  "Golang-alpine",
+			Name: "Golang-alpine",
+		},
+		{
+			Key:  "Golang-scratch",
+			Name: "Golang-scratch",
+		},
+	}
+	if !reflect.DeepEqual(want, templates) {
+		t.Errorf("DockerfileTemplate.ListTemplates returned %+v, want %+v", templates, want)
+	}
+}
+
+func TestDockerfileTemplatesService_GetTemplate(t *testing.T) {
+	mux, client := setup(t)
+
+	mux.HandleFunc("/api/v4/templates/dockerfiles/Binary", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprintf(w, `{
+			"name": "Binary",
+			"content": "# This file is a template, and might need editing before it works on your project."
+		  }`)
+	})
+
+	template, _, err := client.DockerfileTemplate.GetTemplate("Binary")
+	if err != nil {
+		t.Errorf("DockerfileTemplate.GetTemplate returned error: %v", err)
+	}
+
+	want := &DockerfileTemplate{
+		Name:    "Binary",
+		Content: "# This file is a template, and might need editing before it works on your project.",
+	}
+	if !reflect.DeepEqual(want, template) {
+		t.Errorf("DockerfileTemplate.GetTemplate returned %+v, want %+v", template, want)
+	}
+}

--- a/gitlab.go
+++ b/gitlab.go
@@ -118,6 +118,7 @@ type Client struct {
 	DeploymentMergeRequests *DeploymentMergeRequestsService
 	Deployments             *DeploymentsService
 	Discussions             *DiscussionsService
+	DockerfileTemplate      *DockerfileTemplatesService
 	Environments            *EnvironmentsService
 	EpicIssues              *EpicIssuesService
 	Epics                   *EpicsService
@@ -324,6 +325,7 @@ func newClient(options ...ClientOptionFunc) (*Client, error) {
 	c.DeploymentMergeRequests = &DeploymentMergeRequestsService{client: c}
 	c.Deployments = &DeploymentsService{client: c}
 	c.Discussions = &DiscussionsService{client: c}
+	c.DockerfileTemplate = &DockerfileTemplatesService{client: c}
 	c.Environments = &EnvironmentsService{client: c}
 	c.EpicIssues = &EpicIssuesService{client: c}
 	c.Epics = &EpicsService{client: c}


### PR DESCRIPTION
This adds support for the [Dockerfiles API](https://docs.gitlab.com/ce/api/templates/dockerfiles.html).