### PR TITLE
Update the broadcast messages API

### DIFF
--- a/broadcast_messages.go
+++ b/broadcast_messages.go
@@ -35,13 +35,19 @@ type BroadcastMessagesService struct {
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/broadcast_messages.html#get-all-broadcast-messages
 type BroadcastMessage struct {
-	Message  string     `json:"message"`
-	StartsAt *time.Time `json:"starts_at"`
-	EndsAt   *time.Time `json:"ends_at"`
-	Color    string     `json:"color"`
-	Font     string     `json:"font"`
-	ID       int        `json:"id"`
-	Active   bool       `json:"active"`
+	Message            string             `json:"message"`
+	StartsAt           *time.Time         `json:"starts_at"`
+	EndsAt             *time.Time         `json:"ends_at"`
+	Font               string             `json:"font"`
+	ID                 int                `json:"id"`
+	Active             bool               `json:"active"`
+	TargetAccessLevels []AccessLevelValue `json:"target_access_levels"`
+	TargetPath         string             `json:"target_path"`
+	BroadcastType      string             `json:"broadcast_type"`
+	Dismissable        bool               `json:"dismissable"`
+
+	// Deprecated: This parameter was removed in GitLab 15.6.
+	Color string `json:"color"`
 }
 
 // ListBroadcastMessagesOptions represents the available ListBroadcastMessages()
@@ -97,11 +103,17 @@ func (s *BroadcastMessagesService) GetBroadcastMessage(broadcast int, options ..
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/broadcast_messages.html#create-a-broadcast-message
 type CreateBroadcastMessageOptions struct {
-	Message  *string    `url:"message" json:"message"`
-	StartsAt *time.Time `url:"starts_at,omitempty" json:"starts_at,omitempty"`
-	EndsAt   *time.Time `url:"ends_at,omitempty" json:"ends_at,omitempty"`
-	Color    *string    `url:"color,omitempty" json:"color,omitempty"`
-	Font     *string    `url:"font,omitempty" json:"font,omitempty"`
+	Message            *string            `url:"message" json:"message"`
+	StartsAt           *time.Time         `url:"starts_at,omitempty" json:"starts_at,omitempty"`
+	EndsAt             *time.Time         `url:"ends_at,omitempty" json:"ends_at,omitempty"`
+	Font               *string            `url:"font,omitempty" json:"font,omitempty"`
+	TargetAccessLevels []AccessLevelValue `url:"target_access_levels,omitempty" json:"target_access_levels,omitempty"`
+	TargetPath         *string            `url:"target_path,omitempty" json:"target_path,omitempty"`
+	BroadcastType      *string            `url:"broadcast_type,omitempty" json:"broadcast_type,omitempty"`
+	Dismissable        *bool              `url:"dismissable,omitempty" json:"dismissable,omitempty"`
+
+	// Deprecated: This parameter was removed in GitLab 15.6.
+	Color *string `url:"color,omitempty" json:"color,omitempty"`
 }
 
 // CreateBroadcastMessage creates a message to broadcast.
@@ -129,11 +141,17 @@ func (s *BroadcastMessagesService) CreateBroadcastMessage(opt *CreateBroadcastMe
 // GitLab API docs:
 // https://docs.gitlab.com/ce/api/broadcast_messages.html#update-a-broadcast-message
 type UpdateBroadcastMessageOptions struct {
-	Message  *string    `url:"message,omitempty" json:"message,omitempty"`
-	StartsAt *time.Time `url:"starts_at,omitempty" json:"starts_at,omitempty"`
-	EndsAt   *time.Time `url:"ends_at,omitempty" json:"ends_at,omitempty"`
-	Color    *string    `url:"color,omitempty" json:"color,omitempty"`
-	Font     *string    `url:"font,omitempty" json:"font,omitempty"`
+	Message            *string            `url:"message,omitempty" json:"message,omitempty"`
+	StartsAt           *time.Time         `url:"starts_at,omitempty" json:"starts_at,omitempty"`
+	EndsAt             *time.Time         `url:"ends_at,omitempty" json:"ends_at,omitempty"`
+	Font               *string            `url:"font,omitempty" json:"font,omitempty"`
+	TargetAccessLevels []AccessLevelValue `url:"target_access_levels,omitempty" json:"target_access_levels,omitempty"`
+	TargetPath         *string            `url:"target_path,omitempty" json:"target_path,omitempty"`
+	BroadcastType      *string            `url:"broadcast_type,omitempty" json:"broadcast_type,omitempty"`
+	Dismissable        *bool              `url:"dismissable,omitempty" json:"dismissable,omitempty"`
+
+	// Deprecated: This parameter was removed in GitLab 15.6.
+	Color *string `url:"color,omitempty" json:"color,omitempty"`
 }
 
 // UpdateBroadcastMessage update a broadcasted message.

--- a/broadcast_messages_test.go
+++ b/broadcast_messages_test.go
@@ -36,7 +36,11 @@ func TestListBroadcastMessages(t *testing.T) {
 			"color": "#E75E40",
 			"font": "#FFFFFF",
 			"id": 1,
-			"active": false
+			"active": false,
+			"target_access_levels": [10,30],
+			"target_path": "*/welcome",
+			"broadcast_type": "banner",
+			"dismissable": false
 		},{
 			"message": "SomeMessage2",
 			"starts_at": "2015-04-27T06:43:00.000Z",
@@ -44,7 +48,11 @@ func TestListBroadcastMessages(t *testing.T) {
 			"color": "#AA33EE",
 			"font": "#224466",
 			"id": 2,
-			"active": true
+			"active": true,
+			"target_access_levels": [],
+			"target_path": "*/*",
+			"broadcast_type": "notification",
+			"dismissable": true
 		}]`)
 	})
 
@@ -60,21 +68,29 @@ func TestListBroadcastMessages(t *testing.T) {
 	wantedSecondEndsAt := time.Date(2015, 04, 28, 20, 43, 0, 0, time.UTC)
 
 	want := []*BroadcastMessage{{
-		Message:  "Some Message",
-		StartsAt: &wantedFirstStartsAt,
-		EndsAt:   &wantedFirstEndsAt,
-		Color:    "#E75E40",
-		Font:     "#FFFFFF",
-		ID:       1,
-		Active:   false,
+		Message:            "Some Message",
+		StartsAt:           &wantedFirstStartsAt,
+		EndsAt:             &wantedFirstEndsAt,
+		Color:              "#E75E40",
+		Font:               "#FFFFFF",
+		ID:                 1,
+		Active:             false,
+		TargetAccessLevels: []AccessLevelValue{GuestPermissions, DeveloperPermissions},
+		TargetPath:         "*/welcome",
+		BroadcastType:      "banner",
+		Dismissable:        false,
 	}, {
-		Message:  "SomeMessage2",
-		StartsAt: &wantedSecondStartsAt,
-		EndsAt:   &wantedSecondEndsAt,
-		Color:    "#AA33EE",
-		Font:     "#224466",
-		ID:       2,
-		Active:   true,
+		Message:            "SomeMessage2",
+		StartsAt:           &wantedSecondStartsAt,
+		EndsAt:             &wantedSecondEndsAt,
+		Color:              "#AA33EE",
+		Font:               "#224466",
+		ID:                 2,
+		Active:             true,
+		TargetAccessLevels: []AccessLevelValue{},
+		TargetPath:         "*/*",
+		BroadcastType:      "notification",
+		Dismissable:        true,
 	}}
 
 	if !reflect.DeepEqual(got, want) {
@@ -94,7 +110,11 @@ func TestGetBroadcastMessages(t *testing.T) {
 			"color": "#E75E40",
 			"font": "#FFFFFF",
 			"id": 1,
-			"active": false
+			"active": false,
+			"target_access_levels": [10,30],
+			"target_path": "*/welcome",
+			"broadcast_type": "banner",
+			"dismissable": false
 		}`)
 	})
 
@@ -107,13 +127,17 @@ func TestGetBroadcastMessages(t *testing.T) {
 	wantedEndsAt := time.Date(2017, time.June, 27, 12, 59, 0, 0, time.UTC)
 
 	want := &BroadcastMessage{
-		Message:  "Some Message",
-		StartsAt: &wantedStartsAt,
-		EndsAt:   &wantedEndsAt,
-		Color:    "#E75E40",
-		Font:     "#FFFFFF",
-		ID:       1,
-		Active:   false,
+		Message:            "Some Message",
+		StartsAt:           &wantedStartsAt,
+		EndsAt:             &wantedEndsAt,
+		Color:              "#E75E40",
+		Font:               "#FFFFFF",
+		ID:                 1,
+		Active:             false,
+		TargetAccessLevels: []AccessLevelValue{GuestPermissions, DeveloperPermissions},
+		TargetPath:         "*/welcome",
+		BroadcastType:      "banner",
+		Dismissable:        false,
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("GetBroadcastMessage returned \ngot:\n%v\nwant:\n%v", Stringify(got), Stringify(want))
@@ -135,16 +159,24 @@ func TestCreateBroadcastMessages(t *testing.T) {
 			"color": "#E75E40",
 			"font": "#FFFFFF",
 			"id": 42,
-			"active": false
+			"active": false,
+			"target_access_levels": [10,30],
+			"target_path": "*/welcome",
+			"broadcast_type": "banner",
+			"dismissable": false
 		}`)
 	})
 
 	opt := &CreateBroadcastMessageOptions{
-		Message:  String("Some Message"),
-		StartsAt: &wantedStartsAt,
-		EndsAt:   &wantedEndsAt,
-		Color:    String("#E75E40"),
-		Font:     String("#FFFFFF"),
+		Message:            String("Some Message"),
+		StartsAt:           &wantedStartsAt,
+		EndsAt:             &wantedEndsAt,
+		Color:              String("#E75E40"),
+		Font:               String("#FFFFFF"),
+		TargetAccessLevels: []AccessLevelValue{GuestPermissions, DeveloperPermissions},
+		TargetPath:         String("*/welcome"),
+		BroadcastType:      String("banner"),
+		Dismissable:        Bool(false),
 	}
 
 	got, _, err := client.BroadcastMessage.CreateBroadcastMessage(opt)
@@ -153,13 +185,17 @@ func TestCreateBroadcastMessages(t *testing.T) {
 	}
 
 	want := &BroadcastMessage{
-		Message:  "Some Message",
-		StartsAt: &wantedStartsAt,
-		EndsAt:   &wantedEndsAt,
-		Color:    "#E75E40",
-		Font:     "#FFFFFF",
-		ID:       42,
-		Active:   false,
+		Message:            "Some Message",
+		StartsAt:           &wantedStartsAt,
+		EndsAt:             &wantedEndsAt,
+		Color:              "#E75E40",
+		Font:               "#FFFFFF",
+		ID:                 42,
+		Active:             false,
+		TargetAccessLevels: []AccessLevelValue{GuestPermissions, DeveloperPermissions},
+		TargetPath:         "*/welcome",
+		BroadcastType:      "banner",
+		Dismissable:        false,
 	}
 
 	if !reflect.DeepEqual(got, want) {
@@ -182,16 +218,24 @@ func TestUpdateBroadcastMessages(t *testing.T) {
 			"color": "#E75E40",
 			"font": "#FFFFFF",
 			"id": 42,
-			"active": false
+			"active": false,
+			"target_access_levels": [10,30],
+			"target_path": "*/welcome",
+			"broadcast_type": "banner",
+			"dismissable": false
 		}`)
 	})
 
 	opt := &UpdateBroadcastMessageOptions{
-		Message:  String("Some Message Updated"),
-		StartsAt: &wantedStartsAt,
-		EndsAt:   &wantedEndsAt,
-		Color:    String("#E75E40"),
-		Font:     String("#FFFFFF"),
+		Message:            String("Some Message Updated"),
+		StartsAt:           &wantedStartsAt,
+		EndsAt:             &wantedEndsAt,
+		Color:              String("#E75E40"),
+		Font:               String("#FFFFFF"),
+		TargetAccessLevels: []AccessLevelValue{GuestPermissions, DeveloperPermissions},
+		TargetPath:         String("*/welcome"),
+		BroadcastType:      String("banner"),
+		Dismissable:        Bool(false),
 	}
 
 	got, _, err := client.BroadcastMessage.UpdateBroadcastMessage(1, opt)
@@ -200,13 +244,17 @@ func TestUpdateBroadcastMessages(t *testing.T) {
 	}
 
 	want := &BroadcastMessage{
-		Message:  "Some Message Updated",
-		StartsAt: &wantedStartsAt,
-		EndsAt:   &wantedEndsAt,
-		Color:    "#E75E40",
-		Font:     "#FFFFFF",
-		ID:       42,
-		Active:   false,
+		Message:            "Some Message Updated",
+		StartsAt:           &wantedStartsAt,
+		EndsAt:             &wantedEndsAt,
+		Color:              "#E75E40",
+		Font:               "#FFFFFF",
+		ID:                 42,
+		Active:             false,
+		TargetAccessLevels: []AccessLevelValue{GuestPermissions, DeveloperPermissions},
+		TargetPath:         "*/welcome",
+		BroadcastType:      "banner",
+		Dismissable:        false,
 	}
 
 	if !reflect.DeepEqual(got, want) {


### PR DESCRIPTION
Mark the `Color` field as deprecated ([removed in GitLab 15.6](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/95829))

Add the following new fields according to the [API documentation](https://docs.gitlab.com/ee/api/broadcast_messages.html):
- `TargetAccessLevels`: Target access levels (roles) of the broadcast message.
- `TargetPath`: Target path of the broadcast message.
- `BroadcastType`: Appearance type (defaults to banner)
- `Dismissable`: Can the user dismiss the message?