### PR TITLE
Use standardized "Deprecated:" comments

### DIFF
--- a/container_registry.go
+++ b/container_registry.go
@@ -279,7 +279,7 @@ type DeleteRegistryRepositoryTagsOptions struct {
 	KeepN            *int    `url:"keep_n,omitempty" json:"keep_n,omitempty"`
 	OlderThan        *string `url:"older_than,omitempty" json:"older_than,omitempty"`
 
-	// Deprecated members
+	// Deprecated: NameRegexp is deprecated in favor of NameRegexpDelete.
 	NameRegexp *string `url:"name_regex,omitempty" json:"name_regex,omitempty"`
 }
 

--- a/merge_requests.go
+++ b/merge_requests.go
@@ -108,7 +108,7 @@ type MergeRequest struct {
 	BlockingDiscussionsResolved bool                   `json:"blocking_discussions_resolved"`
 	Overflow                    bool                   `json:"overflow"`
 
-	// Deprecated members
+	// Deprecated: This parameter is replaced by DetailedMergeStatus in GitLab 15.6.
 	MergeStatus string `json:"merge_status"`
 }
 

--- a/projects.go
+++ b/projects.go
@@ -678,21 +678,21 @@ type CreateProjectOptions struct {
 	Visibility                                *VisibilityValue                     `url:"visibility,omitempty" json:"visibility,omitempty"`
 	WikiAccessLevel                           *AccessControlValue                  `url:"wiki_access_level,omitempty" json:"wiki_access_level,omitempty"`
 
-	// Deprecated: Unknown reason.
+	// Deprecated: No longer supported in recent versions.
 	CIForwardDeploymentEnabled *bool `url:"ci_forward_deployment_enabled,omitempty" json:"ci_forward_deployment_enabled,omitempty"`
 	// Deprecated: Use ContainerRegistryAccessLevel instead.
 	ContainerRegistryEnabled *bool `url:"container_registry_enabled,omitempty" json:"container_registry_enabled,omitempty"`
 	// Deprecated: Use IssuesAccessLevel instead.
 	IssuesEnabled *bool `url:"issues_enabled,omitempty" json:"issues_enabled,omitempty"`
-	// Deprecated: Unknown reason.
+	// Deprecated: No longer supported in recent versions.
 	IssuesTemplate *string `url:"issues_template,omitempty" json:"issues_template,omitempty"`
 	// Deprecated: Use BuildsAccessLevel instead.
 	JobsEnabled *bool `url:"jobs_enabled,omitempty" json:"jobs_enabled,omitempty"`
 	// Deprecated: Use MergeRequestsAccessLevel instead.
 	MergeRequestsEnabled *bool `url:"merge_requests_enabled,omitempty" json:"merge_requests_enabled,omitempty"`
-	// Deprecated: Unknown reason.
+	// Deprecated: No longer supported in recent versions.
 	MergeRequestsTemplate *string `url:"merge_requests_template,omitempty" json:"merge_requests_template,omitempty"`
-	// Deprecated: Unknown reason.
+	// Deprecated: No longer supported in recent versions.
 	ServiceDeskEnabled *bool `url:"service_desk_enabled,omitempty" json:"service_desk_enabled,omitempty"`
 	// Deprecated: Use SnippetsAccessLevel instead.
 	SnippetsEnabled *bool `url:"snippets_enabled,omitempty" json:"snippets_enabled,omitempty"`
@@ -843,6 +843,7 @@ type EditProjectOptions struct {
 	BuildsAccessLevel                         *AccessControlValue                  `url:"builds_access_level,omitempty" json:"builds_access_level,omitempty"`
 	CIConfigPath                              *string                              `url:"ci_config_path,omitempty" json:"ci_config_path,omitempty"`
 	CIDefaultGitDepth                         *int                                 `url:"ci_default_git_depth,omitempty" json:"ci_default_git_depth,omitempty"`
+	CIForwardDeploymentEnabled                *bool                                `url:"ci_forward_deployment_enabled,omitempty" json:"ci_forward_deployment_enabled,omitempty"`
 	CISeperateCache                           *bool                                `url:"ci_separated_caches,omitempty" json:"ci_separated_caches,omitempty"`
 	ContainerExpirationPolicyAttributes       *ContainerExpirationPolicyAttributes `url:"container_expiration_policy_attributes,omitempty" json:"container_expiration_policy_attributes,omitempty"`
 	ContainerRegistryAccessLevel              *AccessControlValue                  `url:"container_registry_access_level,omitempty" json:"container_registry_access_level,omitempty"`
@@ -854,6 +855,7 @@ type EditProjectOptions struct {
 	ForkingAccessLevel                        *AccessControlValue                  `url:"forking_access_level,omitempty" json:"forking_access_level,omitempty"`
 	ImportURL                                 *string                              `url:"import_url,omitempty" json:"import_url,omitempty"`
 	IssuesAccessLevel                         *AccessControlValue                  `url:"issues_access_level,omitempty" json:"issues_access_level,omitempty"`
+	IssuesTemplate                            *string                              `url:"issues_template,omitempty" json:"issues_template,omitempty"`
 	KeepLatestArtifact                        *bool                                `url:"keep_latest_artifact,omitempty" json:"keep_latest_artifact,omitempty"`
 	LFSEnabled                                *bool                                `url:"lfs_enabled,omitempty" json:"lfs_enabled,omitempty"`
 	MergeCommitTemplate                       *string                              `url:"merge_commit_template,omitempty" json:"merge_commit_template,omitempty"`
@@ -861,6 +863,7 @@ type EditProjectOptions struct {
 	MergeMethod                               *MergeMethodValue                    `url:"merge_method,omitempty" json:"merge_method,omitempty"`
 	MergePipelinesEnabled                     *bool                                `url:"merge_pipelines_enabled,omitempty" json:"merge_pipelines_enabled,omitempty"`
 	MergeRequestsAccessLevel                  *AccessControlValue                  `url:"merge_requests_access_level,omitempty" json:"merge_requests_access_level,omitempty"`
+	MergeRequestsTemplate                     *string                              `url:"merge_requests_template,omitempty" json:"merge_requests_template,omitempty"`
 	MergeTrainsEnabled                        *bool                                `url:"merge_trains_enabled,omitempty" json:"merge_trains_enabled,omitempty"`
 	Mirror                                    *bool                                `url:"mirror,omitempty" json:"mirror,omitempty"`
 	MirrorOverwritesDivergedBranches          *bool                                `url:"mirror_overwrites_diverged_branches,omitempty" json:"mirror_overwrites_diverged_branches,omitempty"`
@@ -885,6 +888,7 @@ type EditProjectOptions struct {
 	ResolveOutdatedDiffDiscussions            *bool                                `url:"resolve_outdated_diff_discussions,omitempty" json:"resolve_outdated_diff_discussions,omitempty"`
 	RestrictUserDefinedVariables              *bool                                `url:"restrict_user_defined_variables,omitempty" json:"restrict_user_defined_variables,omitempty"`
 	SecurityAndComplianceAccessLevel          *AccessControlValue                  `url:"security_and_compliance_access_level,omitempty" json:"security_and_compliance_access_level,omitempty"`
+	ServiceDeskEnabled                        *bool                                `url:"service_desk_enabled,omitempty" json:"service_desk_enabled,omitempty"`
 	SharedRunnersEnabled                      *bool                                `url:"shared_runners_enabled,omitempty" json:"shared_runners_enabled,omitempty"`
 	ShowDefaultAwardEmojis                    *bool                                `url:"show_default_award_emojis,omitempty" json:"show_default_award_emojis,omitempty"`
 	SnippetsAccessLevel                       *AccessControlValue                  `url:"snippets_access_level,omitempty" json:"snippets_access_level,omitempty"`
@@ -895,22 +899,14 @@ type EditProjectOptions struct {
 	Visibility                                *VisibilityValue                     `url:"visibility,omitempty" json:"visibility,omitempty"`
 	WikiAccessLevel                           *AccessControlValue                  `url:"wiki_access_level,omitempty" json:"wiki_access_level,omitempty"`
 
-	// Deprecated: Is it?
-	CIForwardDeploymentEnabled *bool `url:"ci_forward_deployment_enabled,omitempty" json:"ci_forward_deployment_enabled,omitempty"`
 	// Deprecated: Use ContainerRegistryAccessLevel instead.
 	ContainerRegistryEnabled *bool `url:"container_registry_enabled,omitempty" json:"container_registry_enabled,omitempty"`
 	// Deprecated: Use IssuesAccessLevel instead.
 	IssuesEnabled *bool `url:"issues_enabled,omitempty" json:"issues_enabled,omitempty"`
-	// Deprecated: Is it?
-	IssuesTemplate *string `url:"issues_template,omitempty" json:"issues_template,omitempty"`
 	// Deprecated: Use BuildsAccessLevel instead.
 	JobsEnabled *bool `url:"jobs_enabled,omitempty" json:"jobs_enabled,omitempty"`
 	// Deprecated: Use MergeRequestsAccessLevel instead.
 	MergeRequestsEnabled *bool `url:"merge_requests_enabled,omitempty" json:"merge_requests_enabled,omitempty"`
-	// Deprecated: Is it?
-	MergeRequestsTemplate *string `url:"merge_requests_template,omitempty" json:"merge_requests_template,omitempty"`
-	// Deprecated: Is it?
-	ServiceDeskEnabled *bool `url:"service_desk_enabled,omitempty" json:"service_desk_enabled,omitempty"`
 	// Deprecated: Use SnippetsAccessLevel instead.
 	SnippetsEnabled *bool `url:"snippets_enabled,omitempty" json:"snippets_enabled,omitempty"`
 	// Deprecated: Use Topics instead. (Deprecated in GitLab 14.0)

--- a/projects.go
+++ b/projects.go
@@ -151,7 +151,7 @@ type Project struct {
 	SecurityAndComplianceAccessLevel         AccessControlValue `json:"security_and_compliance_access_level"`
 	MergeRequestDefaultTargetSelf            bool               `json:"mr_default_target_self"`
 
-	// Deprecated members
+	// Deprecated: This parameter has been renamed to PublicJobs in GitLab 9.0.
 	PublicBuilds bool `json:"public_builds"`
 }
 
@@ -678,18 +678,28 @@ type CreateProjectOptions struct {
 	Visibility                                *VisibilityValue                     `url:"visibility,omitempty" json:"visibility,omitempty"`
 	WikiAccessLevel                           *AccessControlValue                  `url:"wiki_access_level,omitempty" json:"wiki_access_level,omitempty"`
 
-	// Deprecated members
-	CIForwardDeploymentEnabled *bool     `url:"ci_forward_deployment_enabled,omitempty" json:"ci_forward_deployment_enabled,omitempty"`
-	ContainerRegistryEnabled   *bool     `url:"container_registry_enabled,omitempty" json:"container_registry_enabled,omitempty"`
-	IssuesEnabled              *bool     `url:"issues_enabled,omitempty" json:"issues_enabled,omitempty"`
-	IssuesTemplate             *string   `url:"issues_template,omitempty" json:"issues_template,omitempty"`
-	JobsEnabled                *bool     `url:"jobs_enabled,omitempty" json:"jobs_enabled,omitempty"`
-	MergeRequestsEnabled       *bool     `url:"merge_requests_enabled,omitempty" json:"merge_requests_enabled,omitempty"`
-	MergeRequestsTemplate      *string   `url:"merge_requests_template,omitempty" json:"merge_requests_template,omitempty"`
-	ServiceDeskEnabled         *bool     `url:"service_desk_enabled,omitempty" json:"service_desk_enabled,omitempty"`
-	SnippetsEnabled            *bool     `url:"snippets_enabled,omitempty" json:"snippets_enabled,omitempty"`
-	TagList                    *[]string `url:"tag_list,omitempty" json:"tag_list,omitempty"`
-	WikiEnabled                *bool     `url:"wiki_enabled,omitempty" json:"wiki_enabled,omitempty"`
+	// Deprecated: Unknown reason.
+	CIForwardDeploymentEnabled *bool `url:"ci_forward_deployment_enabled,omitempty" json:"ci_forward_deployment_enabled,omitempty"`
+	// Deprecated: Use ContainerRegistryAccessLevel instead.
+	ContainerRegistryEnabled *bool `url:"container_registry_enabled,omitempty" json:"container_registry_enabled,omitempty"`
+	// Deprecated: Use IssuesAccessLevel instead.
+	IssuesEnabled *bool `url:"issues_enabled,omitempty" json:"issues_enabled,omitempty"`
+	// Deprecated: Unknown reason.
+	IssuesTemplate *string `url:"issues_template,omitempty" json:"issues_template,omitempty"`
+	// Deprecated: Use BuildsAccessLevel instead.
+	JobsEnabled *bool `url:"jobs_enabled,omitempty" json:"jobs_enabled,omitempty"`
+	// Deprecated: Use MergeRequestsAccessLevel instead.
+	MergeRequestsEnabled *bool `url:"merge_requests_enabled,omitempty" json:"merge_requests_enabled,omitempty"`
+	// Deprecated: Unknown reason.
+	MergeRequestsTemplate *string `url:"merge_requests_template,omitempty" json:"merge_requests_template,omitempty"`
+	// Deprecated: Unknown reason.
+	ServiceDeskEnabled *bool `url:"service_desk_enabled,omitempty" json:"service_desk_enabled,omitempty"`
+	// Deprecated: Use SnippetsAccessLevel instead.
+	SnippetsEnabled *bool `url:"snippets_enabled,omitempty" json:"snippets_enabled,omitempty"`
+	// Deprecated: Use Topics instead. (Deprecated in GitLab 14.0)
+	TagList *[]string `url:"tag_list,omitempty" json:"tag_list,omitempty"`
+	// Deprecated: Use WikiAccessLevel instead.
+	WikiEnabled *bool `url:"wiki_enabled,omitempty" json:"wiki_enabled,omitempty"`
 }
 
 // ContainerExpirationPolicyAttributes represents the available container
@@ -704,7 +714,7 @@ type ContainerExpirationPolicyAttributes struct {
 	NameRegexKeep   *string `url:"name_regex_keep,omitempty" json:"name_regex_keep,omitempty"`
 	Enabled         *bool   `url:"enabled,omitempty" json:"enabled,omitempty"`
 
-	// Deprecated members
+	// Deprecated: Is replaced by NameRegexDelete and is internally hardwired to its value.
 	NameRegex *string `url:"name_regex,omitempty" json:"name_regex,omitempty"`
 }
 
@@ -885,18 +895,28 @@ type EditProjectOptions struct {
 	Visibility                                *VisibilityValue                     `url:"visibility,omitempty" json:"visibility,omitempty"`
 	WikiAccessLevel                           *AccessControlValue                  `url:"wiki_access_level,omitempty" json:"wiki_access_level,omitempty"`
 
-	// Deprecated members
-	CIForwardDeploymentEnabled *bool     `url:"ci_forward_deployment_enabled,omitempty" json:"ci_forward_deployment_enabled,omitempty"`
-	ContainerRegistryEnabled   *bool     `url:"container_registry_enabled,omitempty" json:"container_registry_enabled,omitempty"`
-	IssuesEnabled              *bool     `url:"issues_enabled,omitempty" json:"issues_enabled,omitempty"`
-	IssuesTemplate             *string   `url:"issues_template,omitempty" json:"issues_template,omitempty"`
-	JobsEnabled                *bool     `url:"jobs_enabled,omitempty" json:"jobs_enabled,omitempty"`
-	MergeRequestsEnabled       *bool     `url:"merge_requests_enabled,omitempty" json:"merge_requests_enabled,omitempty"`
-	MergeRequestsTemplate      *string   `url:"merge_requests_template,omitempty" json:"merge_requests_template,omitempty"`
-	ServiceDeskEnabled         *bool     `url:"service_desk_enabled,omitempty" json:"service_desk_enabled,omitempty"`
-	SnippetsEnabled            *bool     `url:"snippets_enabled,omitempty" json:"snippets_enabled,omitempty"`
-	TagList                    *[]string `url:"tag_list,omitempty" json:"tag_list,omitempty"`
-	WikiEnabled                *bool     `url:"wiki_enabled,omitempty" json:"wiki_enabled,omitempty"`
+	// Deprecated: Is it?
+	CIForwardDeploymentEnabled *bool `url:"ci_forward_deployment_enabled,omitempty" json:"ci_forward_deployment_enabled,omitempty"`
+	// Deprecated: Use ContainerRegistryAccessLevel instead.
+	ContainerRegistryEnabled *bool `url:"container_registry_enabled,omitempty" json:"container_registry_enabled,omitempty"`
+	// Deprecated: Use IssuesAccessLevel instead.
+	IssuesEnabled *bool `url:"issues_enabled,omitempty" json:"issues_enabled,omitempty"`
+	// Deprecated: Is it?
+	IssuesTemplate *string `url:"issues_template,omitempty" json:"issues_template,omitempty"`
+	// Deprecated: Use BuildsAccessLevel instead.
+	JobsEnabled *bool `url:"jobs_enabled,omitempty" json:"jobs_enabled,omitempty"`
+	// Deprecated: Use MergeRequestsAccessLevel instead.
+	MergeRequestsEnabled *bool `url:"merge_requests_enabled,omitempty" json:"merge_requests_enabled,omitempty"`
+	// Deprecated: Is it?
+	MergeRequestsTemplate *string `url:"merge_requests_template,omitempty" json:"merge_requests_template,omitempty"`
+	// Deprecated: Is it?
+	ServiceDeskEnabled *bool `url:"service_desk_enabled,omitempty" json:"service_desk_enabled,omitempty"`
+	// Deprecated: Use SnippetsAccessLevel instead.
+	SnippetsEnabled *bool `url:"snippets_enabled,omitempty" json:"snippets_enabled,omitempty"`
+	// Deprecated: Use Topics instead. (Deprecated in GitLab 14.0)
+	TagList *[]string `url:"tag_list,omitempty" json:"tag_list,omitempty"`
+	// Deprecated: Use WikiAccessLevel instead.
+	WikiEnabled *bool `url:"wiki_enabled,omitempty" json:"wiki_enabled,omitempty"`
 }
 
 // EditProject updates an existing project.
@@ -956,7 +976,7 @@ type ForkProjectOptions struct {
 	Path                          *string          `url:"path,omitempty" json:"path,omitempty"`
 	Visibility                    *VisibilityValue `url:"visibility,omitempty" json:"visibility,omitempty"`
 
-	// Deprecated members
+	// Deprecated: This parameter has been split into NamespaceID and NamespacePath.
 	Namespace *string `url:"namespace,omitempty" json:"namespace,omitempty"`
 }
 

--- a/runners.go
+++ b/runners.go
@@ -85,7 +85,7 @@ type RunnerDetails struct {
 		WebURL string `json:"web_url"`
 	} `json:"groups"`
 
-	// Deprecated members
+	// Deprecated: Use Paused instead. (Deprecated in GitLab 14.8)
 	Active bool `json:"active"`
 }
 
@@ -100,7 +100,7 @@ type ListRunnersOptions struct {
 	Paused  *bool     `url:"paused,omitempty" json:"paused,omitempty"`
 	TagList *[]string `url:"tag_list,comma,omitempty" json:"tag_list,omitempty"`
 
-	// Deprecated members
+	// Deprecated: Use Type or Status instead.
 	Scope *string `url:"scope,omitempty" json:"scope,omitempty"`
 }
 
@@ -181,7 +181,7 @@ type UpdateRunnerDetailsOptions struct {
 	AccessLevel    *string   `url:"access_level,omitempty" json:"access_level,omitempty"`
 	MaximumTimeout *int      `url:"maximum_timeout,omitempty" json:"maximum_timeout,omitempty"`
 
-	// Deprecated members
+	// Deprecated: Use Paused instead. (Deprecated in GitLab 14.8)
 	Active *bool `url:"active,omitempty" json:"active,omitempty"`
 }
 

--- a/settings.go
+++ b/settings.go
@@ -342,7 +342,6 @@ type Settings struct {
 	ThrottleUnauthenticatedDeprecatedAPIEnabled           bool              `json:"throttle_unauthenticated_deprecated_api_enabled"`
 	ThrottleUnauthenticatedDeprecatedAPIPeriodInSeconds   int               `json:"throttle_unauthenticated_deprecated_api_period_in_seconds"`
 	ThrottleUnauthenticatedDeprecatedAPIRequestsPerPeriod int               `json:"throttle_unauthenticated_deprecated_api_requests_per_period"`
-	ThrottleUnauthenticatedEnabled                        bool              `json:"throttle_unauthenticated_enabled"`
 	ThrottleUnauthenticatedFilesAPIEnabled                bool              `json:"throttle_unauthenticated_files_api_enabled"`
 	ThrottleUnauthenticatedFilesAPIPeriodInSeconds        int               `json:"throttle_unauthenticated_files_api_period_in_seconds"`
 	ThrottleUnauthenticatedFilesAPIRequestsPerPeriod      int               `json:"throttle_unauthenticated_files_api_requests_per_period"`
@@ -352,8 +351,9 @@ type Settings struct {
 	ThrottleUnauthenticatedPackagesAPIEnabled             bool              `json:"throttle_unauthenticated_packages_api_enabled"`
 	ThrottleUnauthenticatedPackagesAPIPeriodInSeconds     int               `json:"throttle_unauthenticated_packages_api_period_in_seconds"`
 	ThrottleUnauthenticatedPackagesAPIRequestsPerPeriod   int               `json:"throttle_unauthenticated_packages_api_requests_per_period"`
-	ThrottleUnauthenticatedPeriodInSeconds                int               `json:"throttle_unauthenticated_period_in_seconds"`
-	ThrottleUnauthenticatedRequestsPerPeriod              int               `json:"throttle_unauthenticated_requests_per_period"`
+	ThrottleUnauthenticatedWebEnabled                     bool              `json:"throttle_unauthenticated_web_enabled"`
+	ThrottleUnauthenticatedWebPeriodInSeconds             int               `json:"throttle_unauthenticated_web_period_in_seconds"`
+	ThrottleUnauthenticatedWebRequestsPerPeriod           int               `json:"throttle_unauthenticated_web_requests_per_period"`
 	TimeTrackingLimitToHours                              bool              `json:"time_tracking_limit_to_hours"`
 	TwoFactorGracePeriod                                  int               `json:"two_factor_grace_period"`
 	UniqueIPsLimitEnabled                                 bool              `json:"unique_ips_limit_enabled"`
@@ -381,12 +381,12 @@ type Settings struct {
 	AllowLocalRequestsFromHooksAndServices bool `json:"allow_local_requests_from_hooks_and_services"`
 	// Deprecated: Use AssetProxyAllowlist instead.
 	AssetProxyWhitelist []string `json:"asset_proxy_whitelist"`
-	// Deprecated: Is it? Maybe ThrottleUnauthenticatedEnabled was meant instead?
-	ThrottleUnauthenticatedWebEnabled bool `json:"throttle_unauthenticated_web_enabled"`
-	// Deprecated: Is it? Maybe ThrottleUnauthenticatedPeriodInSeconds was meant instead?
-	ThrottleUnauthenticatedWebPeriodInSeconds int `json:"throttle_unauthenticated_web_period_in_seconds"`
-	// Deprecated: Is it? Maybe ThrottleUnauthenticatedRequestsPerPeriod was meant instead?
-	ThrottleUnauthenticatedWebRequestsPerPeriod int `json:"throttle_unauthenticated_web_requests_per_period"`
+	// Deprecated: Use ThrottleUnauthenticatedWebEnabled or ThrottleUnauthenticatedAPIEnabled instead. (Deprecated in GitLab 14.3)
+	ThrottleUnauthenticatedEnabled bool `json:"throttle_unauthenticated_enabled"`
+	// Deprecated: Use ThrottleUnauthenticatedWebPeriodInSeconds or ThrottleUnauthenticatedAPIPeriodInSeconds instead. (Deprecated in GitLab 14.3)
+	ThrottleUnauthenticatedPeriodInSeconds int `json:"throttle_unauthenticated_period_in_seconds"`
+	// Deprecated: Use ThrottleUnauthenticatedWebRequestsPerPeriod or ThrottleUnauthenticatedAPIRequestsPerPeriod instead. (Deprecated in GitLab 14.3)
+	ThrottleUnauthenticatedRequestsPerPeriod int `json:"throttle_unauthenticated_requests_per_period"`
 	// Deprecated: Replaced by SearchRateLimit in GitLab 14.9 (removed in 15.0).
 	UserEmailLookupLimit int `json:"user_email_lookup_limit"`
 }

--- a/settings.go
+++ b/settings.go
@@ -45,13 +45,11 @@ type Settings struct {
 	ID                                                    int               `json:"id"`
 	AbuseNotificationEmail                                string            `json:"abuse_notification_email"`
 	AdminMode                                             bool              `json:"admin_mode"`
-	AdminNotificationEmail                                string            `json:"admin_notification_email"` // deprecated
 	AfterSignOutPath                                      string            `json:"after_sign_out_path"`
 	AfterSignUpText                                       string            `json:"after_sign_up_text"`
 	AkismetAPIKey                                         string            `json:"akismet_api_key"`
 	AkismetEnabled                                        bool              `json:"akismet_enabled"`
 	AllowGroupOwnersToManageLDAP                          bool              `json:"allow_group_owners_to_manage_ldap"`
-	AllowLocalRequestsFromHooksAndServices                bool              `json:"allow_local_requests_from_hooks_and_services"` // deprecated
 	AllowLocalRequestsFromSystemHooks                     bool              `json:"allow_local_requests_from_system_hooks"`
 	AllowLocalRequestsFromWebHooksAndServices             bool              `json:"allow_local_requests_from_web_hooks_and_services"`
 	ArchiveBuildsInHumanReadable                          string            `json:"archive_builds_in_human_readable"`
@@ -59,7 +57,6 @@ type Settings struct {
 	AssetProxyEnabled                                     bool              `json:"asset_proxy_enabled"`
 	AssetProxyURL                                         string            `json:"asset_proxy_url"`
 	AssetProxySecretKey                                   string            `json:"asset_proxy_secret_key"`
-	AssetProxyWhitelist                                   []string          `json:"asset_proxy_whitelist"` // deprecated
 	AuthorizedKeysEnabled                                 bool              `json:"authorized_keys_enabled"`
 	AutoDevOpsDomain                                      string            `json:"auto_devops_domain"`
 	AutoDevOpsEnabled                                     bool              `json:"auto_devops_enabled"`
@@ -357,9 +354,6 @@ type Settings struct {
 	ThrottleUnauthenticatedPackagesAPIRequestsPerPeriod   int               `json:"throttle_unauthenticated_packages_api_requests_per_period"`
 	ThrottleUnauthenticatedPeriodInSeconds                int               `json:"throttle_unauthenticated_period_in_seconds"`
 	ThrottleUnauthenticatedRequestsPerPeriod              int               `json:"throttle_unauthenticated_requests_per_period"`
-	ThrottleUnauthenticatedWebEnabled                     bool              `json:"throttle_unauthenticated_web_enabled"`             // deprecated
-	ThrottleUnauthenticatedWebPeriodInSeconds             int               `json:"throttle_unauthenticated_web_period_in_seconds"`   // deprecated
-	ThrottleUnauthenticatedWebRequestsPerPeriod           int               `json:"throttle_unauthenticated_web_requests_per_period"` // deprecated
 	TimeTrackingLimitToHours                              bool              `json:"time_tracking_limit_to_hours"`
 	TwoFactorGracePeriod                                  int               `json:"two_factor_grace_period"`
 	UniqueIPsLimitEnabled                                 bool              `json:"unique_ips_limit_enabled"`
@@ -372,7 +366,6 @@ type Settings struct {
 	UserDeactivationEmailsEnabled                         bool              `json:"user_deactivation_emails_enabled"`
 	UserDefaultExternal                                   bool              `json:"user_default_external"`
 	UserDefaultInternalRegex                              string            `json:"user_default_internal_regex"`
-	UserEmailLookupLimit                                  int               `json:"user_email_lookup_limit"` // deprecated
 	UserOauthApplications                                 bool              `json:"user_oauth_applications"`
 	UserShowAddSSHKeyMessage                              bool              `json:"user_show_add_ssh_key_message"`
 	UsersGetByIDLimit                                     int               `json:"users_get_by_id_limit"`
@@ -381,6 +374,21 @@ type Settings struct {
 	WebIDEClientsidePreviewEnabled                        bool              `json:"web_ide_clientside_preview_enabled"`
 	WhatsNewVariant                                       string            `json:"whats_new_variant"`
 	WikiPageMaxContentBytes                               int               `json:"wiki_page_max_content_bytes"`
+
+	// Deprecated: Use AbuseNotificationEmail instead.
+	AdminNotificationEmail string `json:"admin_notification_email"`
+	// Deprecated: Use AllowLocalRequestsFromWebHooksAndServices instead.
+	AllowLocalRequestsFromHooksAndServices bool `json:"allow_local_requests_from_hooks_and_services"`
+	// Deprecated: Use AssetProxyAllowlist instead.
+	AssetProxyWhitelist []string `json:"asset_proxy_whitelist"`
+	// Deprecated: Is it? Maybe ThrottleUnauthenticatedEnabled was meant instead?
+	ThrottleUnauthenticatedWebEnabled bool `json:"throttle_unauthenticated_web_enabled"`
+	// Deprecated: Is it? Maybe ThrottleUnauthenticatedPeriodInSeconds was meant instead?
+	ThrottleUnauthenticatedWebPeriodInSeconds int `json:"throttle_unauthenticated_web_period_in_seconds"`
+	// Deprecated: Is it? Maybe ThrottleUnauthenticatedRequestsPerPeriod was meant instead?
+	ThrottleUnauthenticatedWebRequestsPerPeriod int `json:"throttle_unauthenticated_web_requests_per_period"`
+	// Deprecated: Replaced by SearchRateLimit in GitLab 14.9 (removed in 15.0).
+	UserEmailLookupLimit int `json:"user_email_lookup_limit"`
 }
 
 func (s Settings) String() string {

--- a/tags.go
+++ b/tags.go
@@ -126,7 +126,7 @@ type CreateTagOptions struct {
 	Ref     *string `url:"ref,omitempty" json:"ref,omitempty"`
 	Message *string `url:"message,omitempty" json:"message,omitempty"`
 
-	// Deprecated members
+	// Deprecated: Use the Releases API instead. (Deprecated in GitLab 11.7)
 	ReleaseDescription *string `url:"release_description:omitempty" json:"release_description,omitempty"`
 }
 

--- a/types.go
+++ b/types.go
@@ -67,9 +67,10 @@ const (
 	MaintainerPermissions    AccessLevelValue = 40
 	OwnerPermissions         AccessLevelValue = 50
 
-	// These are deprecated and should be removed in a future version
+	// Deprecated: Renamed to MaintainerPermissions in GitLab 11.0.
 	MasterPermissions AccessLevelValue = 40
-	OwnerPermission   AccessLevelValue = 50
+	// Deprecated: Renamed to OwnerPermissions.
+	OwnerPermission AccessLevelValue = 50
 )
 
 // AccessLevel is a helper routine that allocates a new AccessLevelValue


### PR DESCRIPTION
According to [Godoc](https://go.dev/blog/godoc), deprecating an identifier should be done with a doc comment starting with "Deprecated:".
When following this guideline, the generated documentation and any other tools can treat the code accordingly.

For some parameters I'm not sure why they are even deprecated and I commented them to maybe get some feedback on what to do with them.