### PR TITLE
Fix GitLab documentation links

### DIFF
--- a/access_requests.go
+++ b/access_requests.go
@@ -25,7 +25,7 @@ import (
 // AccessRequest represents a access request for a group or project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/access_requests.html
+// https://docs.gitlab.com/ee/api/access_requests.html
 type AccessRequest struct {
 	ID          int              `json:"id"`
 	Username    string           `json:"username"`
@@ -39,7 +39,7 @@ type AccessRequest struct {
 // AccessRequestsService handles communication with the project/group
 // access requests related methods of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/access_requests.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/access_requests.html
 type AccessRequestsService struct {
 	client *Client
 }
@@ -48,14 +48,14 @@ type AccessRequestsService struct {
 // ListProjectAccessRequests() or ListGroupAccessRequests() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/access_requests.html#list-access-requests-for-a-group-or-project
+// https://docs.gitlab.com/ee/api/access_requests.html#list-access-requests-for-a-group-or-project
 type ListAccessRequestsOptions ListOptions
 
 // ListProjectAccessRequests gets a list of access requests
 // viewable by the authenticated user.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/access_requests.html#list-access-requests-for-a-group-or-project
+// https://docs.gitlab.com/ee/api/access_requests.html#list-access-requests-for-a-group-or-project
 func (s *AccessRequestsService) ListProjectAccessRequests(pid interface{}, opt *ListAccessRequestsOptions, options ...RequestOptionFunc) ([]*AccessRequest, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -81,7 +81,7 @@ func (s *AccessRequestsService) ListProjectAccessRequests(pid interface{}, opt *
 // viewable by the authenticated user.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/access_requests.html#list-access-requests-for-a-group-or-project
+// https://docs.gitlab.com/ee/api/access_requests.html#list-access-requests-for-a-group-or-project
 func (s *AccessRequestsService) ListGroupAccessRequests(gid interface{}, opt *ListAccessRequestsOptions, options ...RequestOptionFunc) ([]*AccessRequest, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -107,7 +107,7 @@ func (s *AccessRequestsService) ListGroupAccessRequests(gid interface{}, opt *Li
 // to a group or project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/access_requests.html#request-access-to-a-group-or-project
+// https://docs.gitlab.com/ee/api/access_requests.html#request-access-to-a-group-or-project
 func (s *AccessRequestsService) RequestProjectAccess(pid interface{}, options ...RequestOptionFunc) (*AccessRequest, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -133,7 +133,7 @@ func (s *AccessRequestsService) RequestProjectAccess(pid interface{}, options ..
 // to a group or project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/access_requests.html#request-access-to-a-group-or-project
+// https://docs.gitlab.com/ee/api/access_requests.html#request-access-to-a-group-or-project
 func (s *AccessRequestsService) RequestGroupAccess(gid interface{}, options ...RequestOptionFunc) (*AccessRequest, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -159,7 +159,7 @@ func (s *AccessRequestsService) RequestGroupAccess(gid interface{}, options ...R
 // ApproveProjectAccessRequest() and ApproveGroupAccessRequest() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/access_requests.html#approve-an-access-request
+// https://docs.gitlab.com/ee/api/access_requests.html#approve-an-access-request
 type ApproveAccessRequestOptions struct {
 	AccessLevel *AccessLevelValue `url:"access_level,omitempty" json:"access_level,omitempty"`
 }
@@ -167,7 +167,7 @@ type ApproveAccessRequestOptions struct {
 // ApproveProjectAccessRequest approves an access request for the given user.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/access_requests.html#approve-an-access-request
+// https://docs.gitlab.com/ee/api/access_requests.html#approve-an-access-request
 func (s *AccessRequestsService) ApproveProjectAccessRequest(pid interface{}, user int, opt *ApproveAccessRequestOptions, options ...RequestOptionFunc) (*AccessRequest, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -192,7 +192,7 @@ func (s *AccessRequestsService) ApproveProjectAccessRequest(pid interface{}, use
 // ApproveGroupAccessRequest approves an access request for the given user.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/access_requests.html#approve-an-access-request
+// https://docs.gitlab.com/ee/api/access_requests.html#approve-an-access-request
 func (s *AccessRequestsService) ApproveGroupAccessRequest(gid interface{}, user int, opt *ApproveAccessRequestOptions, options ...RequestOptionFunc) (*AccessRequest, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -217,7 +217,7 @@ func (s *AccessRequestsService) ApproveGroupAccessRequest(gid interface{}, user 
 // DenyProjectAccessRequest denies an access request for the given user.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/access_requests.html#deny-an-access-request
+// https://docs.gitlab.com/ee/api/access_requests.html#deny-an-access-request
 func (s *AccessRequestsService) DenyProjectAccessRequest(pid interface{}, user int, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -236,7 +236,7 @@ func (s *AccessRequestsService) DenyProjectAccessRequest(pid interface{}, user i
 // DenyGroupAccessRequest denies an access request for the given user.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/access_requests.html#deny-an-access-request
+// https://docs.gitlab.com/ee/api/access_requests.html#deny-an-access-request
 func (s *AccessRequestsService) DenyGroupAccessRequest(gid interface{}, user int, options ...RequestOptionFunc) (*Response, error) {
 	group, err := parseID(gid)
 	if err != nil {

--- a/applications.go
+++ b/applications.go
@@ -42,7 +42,7 @@ type Application struct {
 // CreateApplicationOptions represents the available CreateApplication() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/applications.html#create-an-application
+// https://docs.gitlab.com/ee/api/applications.html#create-an-application
 type CreateApplicationOptions struct {
 	Name         *string `url:"name,omitempty" json:"name,omitempty"`
 	RedirectURI  *string `url:"redirect_uri,omitempty" json:"redirect_uri,omitempty"`
@@ -52,7 +52,7 @@ type CreateApplicationOptions struct {
 
 // CreateApplication creates a new application owned by the authenticated user.
 //
-// Gitlab API docs : https://docs.gitlab.com/ce/api/applications.html#create-an-application
+// Gitlab API docs : https://docs.gitlab.com/ee/api/applications.html#create-an-application
 func (s *ApplicationsService) CreateApplication(opt *CreateApplicationOptions, options ...RequestOptionFunc) (*Application, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodPost, "applications", opt, options)
 	if err != nil {
@@ -74,7 +74,7 @@ type ListApplicationsOptions ListOptions
 
 // ListApplications get a list of administrables applications by the authenticated user
 //
-// Gitlab API docs : https://docs.gitlab.com/ce/api/applications.html#list-all-applications
+// Gitlab API docs : https://docs.gitlab.com/ee/api/applications.html#list-all-applications
 func (s *ApplicationsService) ListApplications(opt *ListApplicationsOptions, options ...RequestOptionFunc) ([]*Application, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "applications", opt, options)
 	if err != nil {
@@ -93,7 +93,7 @@ func (s *ApplicationsService) ListApplications(opt *ListApplicationsOptions, opt
 // DeleteApplication removes a specific application.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/applications.html#delete-an-application
+// https://docs.gitlab.com/ee/api/applications.html#delete-an-application
 func (s *ApplicationsService) DeleteApplication(application int, options ...RequestOptionFunc) (*Response, error) {
 	u := fmt.Sprintf("applications/%d", application)
 

--- a/audit_events.go
+++ b/audit_events.go
@@ -62,7 +62,7 @@ type ListAuditEventsOptions struct {
 // ListInstanceAuditEvents gets a list of audit events for instance.
 // Authentication as Administrator is required.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/audit_events.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/audit_events.html#retrieve-all-instance-audit-events
 func (s *AuditEventsService) ListInstanceAuditEvents(opt *ListAuditEventsOptions, options ...RequestOptionFunc) ([]*AuditEvent, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "audit_events", opt, options)
 	if err != nil {
@@ -81,7 +81,7 @@ func (s *AuditEventsService) ListInstanceAuditEvents(opt *ListAuditEventsOptions
 // GetInstanceAuditEvent gets a specific instance audit event.
 // Authentication as Administrator is required.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/audit_events.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/audit_events.html#retrieve-single-instance-audit-event
 func (s *AuditEventsService) GetInstanceAuditEvent(event int, options ...RequestOptionFunc) (*AuditEvent, *Response, error) {
 	u := fmt.Sprintf("audit_events/%d", event)
 
@@ -102,7 +102,7 @@ func (s *AuditEventsService) GetInstanceAuditEvent(event int, options ...Request
 // ListGroupAuditEvents gets a list of audit events for the specified group
 // viewable by the authenticated user.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/audit_events.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/audit_events.html#retrieve-all-group-audit-events
 func (s *AuditEventsService) ListGroupAuditEvents(gid interface{}, opt *ListAuditEventsOptions, options ...RequestOptionFunc) ([]*AuditEvent, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -126,7 +126,7 @@ func (s *AuditEventsService) ListGroupAuditEvents(gid interface{}, opt *ListAudi
 
 // GetGroupAuditEvent gets a specific group audit event.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/audit_events.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/audit_events.html#retrieve-a-specific-group-audit-event
 func (s *AuditEventsService) GetGroupAuditEvent(gid interface{}, event int, options ...RequestOptionFunc) (*AuditEvent, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -151,7 +151,7 @@ func (s *AuditEventsService) GetGroupAuditEvent(gid interface{}, event int, opti
 // ListProjectAuditEvents gets a list of audit events for the specified project
 // viewable by the authenticated user.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/audit_events.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/audit_events.html#retrieve-all-project-audit-events
 func (s *AuditEventsService) ListProjectAuditEvents(pid interface{}, opt *ListAuditEventsOptions, options ...RequestOptionFunc) ([]*AuditEvent, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -176,7 +176,7 @@ func (s *AuditEventsService) ListProjectAuditEvents(pid interface{}, opt *ListAu
 // GetProjectAuditEvent gets a specific project audit event.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/audit_events.html
+// https://docs.gitlab.com/ee/api/audit_events.html#retrieve-a-specific-project-audit-event
 func (s *AuditEventsService) GetProjectAuditEvent(pid interface{}, event int, options ...RequestOptionFunc) (*AuditEvent, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/award_emojis.go
+++ b/award_emojis.go
@@ -25,14 +25,14 @@ import (
 // AwardEmojiService handles communication with the emoji awards related methods
 // of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/award_emoji.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/award_emoji.html
 type AwardEmojiService struct {
 	client *Client
 }
 
 // AwardEmoji represents a GitLab Award Emoji.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/award_emoji.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/award_emoji.html
 type AwardEmoji struct {
 	ID   int    `json:"id"`
 	Name string `json:"name"`
@@ -60,13 +60,13 @@ const (
 // for each resources
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/award_emoji.html
+// https://docs.gitlab.com/ee/api/award_emoji.html
 type ListAwardEmojiOptions ListOptions
 
 // ListMergeRequestAwardEmoji gets a list of all award emoji on the merge request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/award_emoji.html#list-an-awardable-39-s-award-emoji
+// https://docs.gitlab.com/ee/api/award_emoji.html#list-an-awardable-39-s-award-emoji
 func (s *AwardEmojiService) ListMergeRequestAwardEmoji(pid interface{}, mergeRequestIID int, opt *ListAwardEmojiOptions, options ...RequestOptionFunc) ([]*AwardEmoji, *Response, error) {
 	return s.listAwardEmoji(pid, awardMergeRequest, mergeRequestIID, opt, options...)
 }
@@ -74,7 +74,7 @@ func (s *AwardEmojiService) ListMergeRequestAwardEmoji(pid interface{}, mergeReq
 // ListIssueAwardEmoji gets a list of all award emoji on the issue.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/award_emoji.html#list-an-awardable-39-s-award-emoji
+// https://docs.gitlab.com/ee/api/award_emoji.html#list-an-awardable-39-s-award-emoji
 func (s *AwardEmojiService) ListIssueAwardEmoji(pid interface{}, issueIID int, opt *ListAwardEmojiOptions, options ...RequestOptionFunc) ([]*AwardEmoji, *Response, error) {
 	return s.listAwardEmoji(pid, awardIssue, issueIID, opt, options...)
 }
@@ -82,7 +82,7 @@ func (s *AwardEmojiService) ListIssueAwardEmoji(pid interface{}, issueIID int, o
 // ListSnippetAwardEmoji gets a list of all award emoji on the snippet.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/award_emoji.html#list-an-awardable-39-s-award-emoji
+// https://docs.gitlab.com/ee/api/award_emoji.html#list-an-awardable-39-s-award-emoji
 func (s *AwardEmojiService) ListSnippetAwardEmoji(pid interface{}, snippetID int, opt *ListAwardEmojiOptions, options ...RequestOptionFunc) ([]*AwardEmoji, *Response, error) {
 	return s.listAwardEmoji(pid, awardSnippets, snippetID, opt, options...)
 }
@@ -115,7 +115,7 @@ func (s *AwardEmojiService) listAwardEmoji(pid interface{}, resource string, res
 // GetMergeRequestAwardEmoji get an award emoji from merge request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/award_emoji.html#list-an-awardable-39-s-award-emoji
+// https://docs.gitlab.com/ee/api/award_emoji.html#list-an-awardable-39-s-award-emoji
 func (s *AwardEmojiService) GetMergeRequestAwardEmoji(pid interface{}, mergeRequestIID, awardID int, options ...RequestOptionFunc) (*AwardEmoji, *Response, error) {
 	return s.getAwardEmoji(pid, awardMergeRequest, mergeRequestIID, awardID, options...)
 }
@@ -123,7 +123,7 @@ func (s *AwardEmojiService) GetMergeRequestAwardEmoji(pid interface{}, mergeRequ
 // GetIssueAwardEmoji get an award emoji from issue.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/award_emoji.html#list-an-awardable-39-s-award-emoji
+// https://docs.gitlab.com/ee/api/award_emoji.html#list-an-awardable-39-s-award-emoji
 func (s *AwardEmojiService) GetIssueAwardEmoji(pid interface{}, issueIID, awardID int, options ...RequestOptionFunc) (*AwardEmoji, *Response, error) {
 	return s.getAwardEmoji(pid, awardIssue, issueIID, awardID, options...)
 }
@@ -131,7 +131,7 @@ func (s *AwardEmojiService) GetIssueAwardEmoji(pid interface{}, issueIID, awardI
 // GetSnippetAwardEmoji get an award emoji from snippet.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/award_emoji.html#list-an-awardable-39-s-award-emoji
+// https://docs.gitlab.com/ee/api/award_emoji.html#list-an-awardable-39-s-award-emoji
 func (s *AwardEmojiService) GetSnippetAwardEmoji(pid interface{}, snippetID, awardID int, options ...RequestOptionFunc) (*AwardEmoji, *Response, error) {
 	return s.getAwardEmoji(pid, awardSnippets, snippetID, awardID, options...)
 }
@@ -166,7 +166,7 @@ func (s *AwardEmojiService) getAwardEmoji(pid interface{}, resource string, reso
 // for a resource
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/award_emoji.html#award-a-new-emoji
+// https://docs.gitlab.com/ee/api/award_emoji.html#award-a-new-emoji
 type CreateAwardEmojiOptions struct {
 	Name string `json:"name"`
 }
@@ -174,7 +174,7 @@ type CreateAwardEmojiOptions struct {
 // CreateMergeRequestAwardEmoji get an award emoji from merge request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/award_emoji.html#award-a-new-emoji
+// https://docs.gitlab.com/ee/api/award_emoji.html#award-a-new-emoji
 func (s *AwardEmojiService) CreateMergeRequestAwardEmoji(pid interface{}, mergeRequestIID int, opt *CreateAwardEmojiOptions, options ...RequestOptionFunc) (*AwardEmoji, *Response, error) {
 	return s.createAwardEmoji(pid, awardMergeRequest, mergeRequestIID, opt, options...)
 }
@@ -182,7 +182,7 @@ func (s *AwardEmojiService) CreateMergeRequestAwardEmoji(pid interface{}, mergeR
 // CreateIssueAwardEmoji get an award emoji from issue.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/award_emoji.html#award-a-new-emoji
+// https://docs.gitlab.com/ee/api/award_emoji.html#award-a-new-emoji
 func (s *AwardEmojiService) CreateIssueAwardEmoji(pid interface{}, issueIID int, opt *CreateAwardEmojiOptions, options ...RequestOptionFunc) (*AwardEmoji, *Response, error) {
 	return s.createAwardEmoji(pid, awardIssue, issueIID, opt, options...)
 }
@@ -190,7 +190,7 @@ func (s *AwardEmojiService) CreateIssueAwardEmoji(pid interface{}, issueIID int,
 // CreateSnippetAwardEmoji get an award emoji from snippet.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/award_emoji.html#award-a-new-emoji
+// https://docs.gitlab.com/ee/api/award_emoji.html#award-a-new-emoji
 func (s *AwardEmojiService) CreateSnippetAwardEmoji(pid interface{}, snippetID int, opt *CreateAwardEmojiOptions, options ...RequestOptionFunc) (*AwardEmoji, *Response, error) {
 	return s.createAwardEmoji(pid, awardSnippets, snippetID, opt, options...)
 }
@@ -223,7 +223,7 @@ func (s *AwardEmojiService) createAwardEmoji(pid interface{}, resource string, r
 // DeleteIssueAwardEmoji delete award emoji on an issue.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/award_emoji.html#award-a-new-emoji-on-a-note
+// https://docs.gitlab.com/ee/api/award_emoji.html#award-a-new-emoji-on-a-note
 func (s *AwardEmojiService) DeleteIssueAwardEmoji(pid interface{}, issueIID, awardID int, options ...RequestOptionFunc) (*Response, error) {
 	return s.deleteAwardEmoji(pid, awardIssue, issueIID, awardID, options...)
 }
@@ -231,7 +231,7 @@ func (s *AwardEmojiService) DeleteIssueAwardEmoji(pid interface{}, issueIID, awa
 // DeleteMergeRequestAwardEmoji delete award emoji on a merge request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/award_emoji.html#award-a-new-emoji-on-a-note
+// https://docs.gitlab.com/ee/api/award_emoji.html#award-a-new-emoji-on-a-note
 func (s *AwardEmojiService) DeleteMergeRequestAwardEmoji(pid interface{}, mergeRequestIID, awardID int, options ...RequestOptionFunc) (*Response, error) {
 	return s.deleteAwardEmoji(pid, awardMergeRequest, mergeRequestIID, awardID, options...)
 }
@@ -239,7 +239,7 @@ func (s *AwardEmojiService) DeleteMergeRequestAwardEmoji(pid interface{}, mergeR
 // DeleteSnippetAwardEmoji delete award emoji on a snippet.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/award_emoji.html#award-a-new-emoji-on-a-note
+// https://docs.gitlab.com/ee/api/award_emoji.html#award-a-new-emoji-on-a-note
 func (s *AwardEmojiService) DeleteSnippetAwardEmoji(pid interface{}, snippetID, awardID int, options ...RequestOptionFunc) (*Response, error) {
 	return s.deleteAwardEmoji(pid, awardSnippets, snippetID, awardID, options...)
 }
@@ -247,7 +247,7 @@ func (s *AwardEmojiService) DeleteSnippetAwardEmoji(pid interface{}, snippetID, 
 // DeleteAwardEmoji Delete an award emoji on the specified resource.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/award_emoji.html#delete-an-award-emoji
+// https://docs.gitlab.com/ee/api/award_emoji.html#delete-an-award-emoji
 func (s *AwardEmojiService) deleteAwardEmoji(pid interface{}, resource string, resourceID, awardID int, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -267,7 +267,7 @@ func (s *AwardEmojiService) deleteAwardEmoji(pid interface{}, resource string, r
 // issue.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/award_emoji.html#award-emoji-on-notes
+// https://docs.gitlab.com/ee/api/award_emoji.html#award-emoji-on-notes
 func (s *AwardEmojiService) ListIssuesAwardEmojiOnNote(pid interface{}, issueID, noteID int, opt *ListAwardEmojiOptions, options ...RequestOptionFunc) ([]*AwardEmoji, *Response, error) {
 	return s.listAwardEmojiOnNote(pid, awardIssue, issueID, noteID, opt, options...)
 }
@@ -276,7 +276,7 @@ func (s *AwardEmojiService) ListIssuesAwardEmojiOnNote(pid interface{}, issueID,
 // from the merge request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/award_emoji.html#award-emoji-on-notes
+// https://docs.gitlab.com/ee/api/award_emoji.html#award-emoji-on-notes
 func (s *AwardEmojiService) ListMergeRequestAwardEmojiOnNote(pid interface{}, mergeRequestIID, noteID int, opt *ListAwardEmojiOptions, options ...RequestOptionFunc) ([]*AwardEmoji, *Response, error) {
 	return s.listAwardEmojiOnNote(pid, awardMergeRequest, mergeRequestIID, noteID, opt, options...)
 }
@@ -285,7 +285,7 @@ func (s *AwardEmojiService) ListMergeRequestAwardEmojiOnNote(pid interface{}, me
 // snippet.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/award_emoji.html#award-emoji-on-notes
+// https://docs.gitlab.com/ee/api/award_emoji.html#award-emoji-on-notes
 func (s *AwardEmojiService) ListSnippetAwardEmojiOnNote(pid interface{}, snippetIID, noteID int, opt *ListAwardEmojiOptions, options ...RequestOptionFunc) ([]*AwardEmoji, *Response, error) {
 	return s.listAwardEmojiOnNote(pid, awardSnippets, snippetIID, noteID, opt, options...)
 }
@@ -315,7 +315,7 @@ func (s *AwardEmojiService) listAwardEmojiOnNote(pid interface{}, resources stri
 // GetIssuesAwardEmojiOnNote gets an award emoji on a note from an issue.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/award_emoji.html#award-emoji-on-notes
+// https://docs.gitlab.com/ee/api/award_emoji.html#award-emoji-on-notes
 func (s *AwardEmojiService) GetIssuesAwardEmojiOnNote(pid interface{}, issueID, noteID, awardID int, options ...RequestOptionFunc) (*AwardEmoji, *Response, error) {
 	return s.getSingleNoteAwardEmoji(pid, awardIssue, issueID, noteID, awardID, options...)
 }
@@ -324,7 +324,7 @@ func (s *AwardEmojiService) GetIssuesAwardEmojiOnNote(pid interface{}, issueID, 
 // merge request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/award_emoji.html#award-emoji-on-notes
+// https://docs.gitlab.com/ee/api/award_emoji.html#award-emoji-on-notes
 func (s *AwardEmojiService) GetMergeRequestAwardEmojiOnNote(pid interface{}, mergeRequestIID, noteID, awardID int, options ...RequestOptionFunc) (*AwardEmoji, *Response, error) {
 	return s.getSingleNoteAwardEmoji(pid, awardMergeRequest, mergeRequestIID, noteID, awardID,
 		options...)
@@ -333,7 +333,7 @@ func (s *AwardEmojiService) GetMergeRequestAwardEmojiOnNote(pid interface{}, mer
 // GetSnippetAwardEmojiOnNote gets an award emoji on a note from a snippet.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/award_emoji.html#award-emoji-on-notes
+// https://docs.gitlab.com/ee/api/award_emoji.html#award-emoji-on-notes
 func (s *AwardEmojiService) GetSnippetAwardEmojiOnNote(pid interface{}, snippetIID, noteID, awardID int, options ...RequestOptionFunc) (*AwardEmoji, *Response, error) {
 	return s.getSingleNoteAwardEmoji(pid, awardSnippets, snippetIID, noteID, awardID, options...)
 }
@@ -368,7 +368,7 @@ func (s *AwardEmojiService) getSingleNoteAwardEmoji(pid interface{}, ressource s
 // CreateIssuesAwardEmojiOnNote gets an award emoji on a note from an issue.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/award_emoji.html#award-emoji-on-notes
+// https://docs.gitlab.com/ee/api/award_emoji.html#award-emoji-on-notes
 func (s *AwardEmojiService) CreateIssuesAwardEmojiOnNote(pid interface{}, issueID, noteID int, opt *CreateAwardEmojiOptions, options ...RequestOptionFunc) (*AwardEmoji, *Response, error) {
 	return s.createAwardEmojiOnNote(pid, awardIssue, issueID, noteID, opt, options...)
 }
@@ -377,7 +377,7 @@ func (s *AwardEmojiService) CreateIssuesAwardEmojiOnNote(pid interface{}, issueI
 // merge request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/award_emoji.html#award-emoji-on-notes
+// https://docs.gitlab.com/ee/api/award_emoji.html#award-emoji-on-notes
 func (s *AwardEmojiService) CreateMergeRequestAwardEmojiOnNote(pid interface{}, mergeRequestIID, noteID int, opt *CreateAwardEmojiOptions, options ...RequestOptionFunc) (*AwardEmoji, *Response, error) {
 	return s.createAwardEmojiOnNote(pid, awardMergeRequest, mergeRequestIID, noteID, opt, options...)
 }
@@ -385,7 +385,7 @@ func (s *AwardEmojiService) CreateMergeRequestAwardEmojiOnNote(pid interface{}, 
 // CreateSnippetAwardEmojiOnNote gets an award emoji on a note from a snippet.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/award_emoji.html#award-emoji-on-notes
+// https://docs.gitlab.com/ee/api/award_emoji.html#award-emoji-on-notes
 func (s *AwardEmojiService) CreateSnippetAwardEmojiOnNote(pid interface{}, snippetIID, noteID int, opt *CreateAwardEmojiOptions, options ...RequestOptionFunc) (*AwardEmoji, *Response, error) {
 	return s.createAwardEmojiOnNote(pid, awardSnippets, snippetIID, noteID, opt, options...)
 }
@@ -393,7 +393,7 @@ func (s *AwardEmojiService) CreateSnippetAwardEmojiOnNote(pid interface{}, snipp
 // CreateAwardEmojiOnNote award emoji on a note.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/award_emoji.html#award-a-new-emoji-on-a-note
+// https://docs.gitlab.com/ee/api/award_emoji.html#award-a-new-emoji-on-a-note
 func (s *AwardEmojiService) createAwardEmojiOnNote(pid interface{}, resource string, resourceID, noteID int, opt *CreateAwardEmojiOptions, options ...RequestOptionFunc) (*AwardEmoji, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -423,7 +423,7 @@ func (s *AwardEmojiService) createAwardEmojiOnNote(pid interface{}, resource str
 // DeleteIssuesAwardEmojiOnNote deletes an award emoji on a note from an issue.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/award_emoji.html#award-emoji-on-notes
+// https://docs.gitlab.com/ee/api/award_emoji.html#award-emoji-on-notes
 func (s *AwardEmojiService) DeleteIssuesAwardEmojiOnNote(pid interface{}, issueID, noteID, awardID int, options ...RequestOptionFunc) (*Response, error) {
 	return s.deleteAwardEmojiOnNote(pid, awardIssue, issueID, noteID, awardID, options...)
 }
@@ -432,7 +432,7 @@ func (s *AwardEmojiService) DeleteIssuesAwardEmojiOnNote(pid interface{}, issueI
 // merge request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/award_emoji.html#award-emoji-on-notes
+// https://docs.gitlab.com/ee/api/award_emoji.html#award-emoji-on-notes
 func (s *AwardEmojiService) DeleteMergeRequestAwardEmojiOnNote(pid interface{}, mergeRequestIID, noteID, awardID int, options ...RequestOptionFunc) (*Response, error) {
 	return s.deleteAwardEmojiOnNote(pid, awardMergeRequest, mergeRequestIID, noteID, awardID,
 		options...)
@@ -441,7 +441,7 @@ func (s *AwardEmojiService) DeleteMergeRequestAwardEmojiOnNote(pid interface{}, 
 // DeleteSnippetAwardEmojiOnNote deletes an award emoji on a note from a snippet.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/award_emoji.html#award-emoji-on-notes
+// https://docs.gitlab.com/ee/api/award_emoji.html#award-emoji-on-notes
 func (s *AwardEmojiService) DeleteSnippetAwardEmojiOnNote(pid interface{}, snippetIID, noteID, awardID int, options ...RequestOptionFunc) (*Response, error) {
 	return s.deleteAwardEmojiOnNote(pid, awardSnippets, snippetIID, noteID, awardID, options...)
 }

--- a/award_emojis.go
+++ b/award_emojis.go
@@ -66,7 +66,7 @@ type ListAwardEmojiOptions ListOptions
 // ListMergeRequestAwardEmoji gets a list of all award emoji on the merge request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/award_emoji.html#list-an-awardable-39-s-award-emoji
+// https://docs.gitlab.com/ee/api/award_emoji.html#list-an-awardables-award-emojis
 func (s *AwardEmojiService) ListMergeRequestAwardEmoji(pid interface{}, mergeRequestIID int, opt *ListAwardEmojiOptions, options ...RequestOptionFunc) ([]*AwardEmoji, *Response, error) {
 	return s.listAwardEmoji(pid, awardMergeRequest, mergeRequestIID, opt, options...)
 }
@@ -74,7 +74,7 @@ func (s *AwardEmojiService) ListMergeRequestAwardEmoji(pid interface{}, mergeReq
 // ListIssueAwardEmoji gets a list of all award emoji on the issue.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/award_emoji.html#list-an-awardable-39-s-award-emoji
+// https://docs.gitlab.com/ee/api/award_emoji.html#list-an-awardables-award-emojis
 func (s *AwardEmojiService) ListIssueAwardEmoji(pid interface{}, issueIID int, opt *ListAwardEmojiOptions, options ...RequestOptionFunc) ([]*AwardEmoji, *Response, error) {
 	return s.listAwardEmoji(pid, awardIssue, issueIID, opt, options...)
 }
@@ -82,7 +82,7 @@ func (s *AwardEmojiService) ListIssueAwardEmoji(pid interface{}, issueIID int, o
 // ListSnippetAwardEmoji gets a list of all award emoji on the snippet.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/award_emoji.html#list-an-awardable-39-s-award-emoji
+// https://docs.gitlab.com/ee/api/award_emoji.html#list-an-awardables-award-emojis
 func (s *AwardEmojiService) ListSnippetAwardEmoji(pid interface{}, snippetID int, opt *ListAwardEmojiOptions, options ...RequestOptionFunc) ([]*AwardEmoji, *Response, error) {
 	return s.listAwardEmoji(pid, awardSnippets, snippetID, opt, options...)
 }
@@ -115,7 +115,7 @@ func (s *AwardEmojiService) listAwardEmoji(pid interface{}, resource string, res
 // GetMergeRequestAwardEmoji get an award emoji from merge request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/award_emoji.html#list-an-awardable-39-s-award-emoji
+// https://docs.gitlab.com/ee/api/award_emoji.html#get-single-award-emoji
 func (s *AwardEmojiService) GetMergeRequestAwardEmoji(pid interface{}, mergeRequestIID, awardID int, options ...RequestOptionFunc) (*AwardEmoji, *Response, error) {
 	return s.getAwardEmoji(pid, awardMergeRequest, mergeRequestIID, awardID, options...)
 }
@@ -123,7 +123,7 @@ func (s *AwardEmojiService) GetMergeRequestAwardEmoji(pid interface{}, mergeRequ
 // GetIssueAwardEmoji get an award emoji from issue.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/award_emoji.html#list-an-awardable-39-s-award-emoji
+// https://docs.gitlab.com/ee/api/award_emoji.html#get-single-award-emoji
 func (s *AwardEmojiService) GetIssueAwardEmoji(pid interface{}, issueIID, awardID int, options ...RequestOptionFunc) (*AwardEmoji, *Response, error) {
 	return s.getAwardEmoji(pid, awardIssue, issueIID, awardID, options...)
 }
@@ -131,7 +131,7 @@ func (s *AwardEmojiService) GetIssueAwardEmoji(pid interface{}, issueIID, awardI
 // GetSnippetAwardEmoji get an award emoji from snippet.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/award_emoji.html#list-an-awardable-39-s-award-emoji
+// https://docs.gitlab.com/ee/api/award_emoji.html#get-single-award-emoji
 func (s *AwardEmojiService) GetSnippetAwardEmoji(pid interface{}, snippetID, awardID int, options ...RequestOptionFunc) (*AwardEmoji, *Response, error) {
 	return s.getAwardEmoji(pid, awardSnippets, snippetID, awardID, options...)
 }
@@ -223,7 +223,7 @@ func (s *AwardEmojiService) createAwardEmoji(pid interface{}, resource string, r
 // DeleteIssueAwardEmoji delete award emoji on an issue.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/award_emoji.html#award-a-new-emoji-on-a-note
+// https://docs.gitlab.com/ee/api/award_emoji.html#delete-an-award-emoji
 func (s *AwardEmojiService) DeleteIssueAwardEmoji(pid interface{}, issueIID, awardID int, options ...RequestOptionFunc) (*Response, error) {
 	return s.deleteAwardEmoji(pid, awardIssue, issueIID, awardID, options...)
 }
@@ -231,7 +231,7 @@ func (s *AwardEmojiService) DeleteIssueAwardEmoji(pid interface{}, issueIID, awa
 // DeleteMergeRequestAwardEmoji delete award emoji on a merge request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/award_emoji.html#award-a-new-emoji-on-a-note
+// https://docs.gitlab.com/ee/api/award_emoji.html#delete-an-award-emoji
 func (s *AwardEmojiService) DeleteMergeRequestAwardEmoji(pid interface{}, mergeRequestIID, awardID int, options ...RequestOptionFunc) (*Response, error) {
 	return s.deleteAwardEmoji(pid, awardMergeRequest, mergeRequestIID, awardID, options...)
 }
@@ -239,7 +239,7 @@ func (s *AwardEmojiService) DeleteMergeRequestAwardEmoji(pid interface{}, mergeR
 // DeleteSnippetAwardEmoji delete award emoji on a snippet.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/award_emoji.html#award-a-new-emoji-on-a-note
+// https://docs.gitlab.com/ee/api/award_emoji.html#delete-an-award-emoji
 func (s *AwardEmojiService) DeleteSnippetAwardEmoji(pid interface{}, snippetID, awardID int, options ...RequestOptionFunc) (*Response, error) {
 	return s.deleteAwardEmoji(pid, awardSnippets, snippetID, awardID, options...)
 }
@@ -267,7 +267,7 @@ func (s *AwardEmojiService) deleteAwardEmoji(pid interface{}, resource string, r
 // issue.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/award_emoji.html#award-emoji-on-notes
+// https://docs.gitlab.com/ee/api/award_emoji.html#list-a-comments-award-emojis
 func (s *AwardEmojiService) ListIssuesAwardEmojiOnNote(pid interface{}, issueID, noteID int, opt *ListAwardEmojiOptions, options ...RequestOptionFunc) ([]*AwardEmoji, *Response, error) {
 	return s.listAwardEmojiOnNote(pid, awardIssue, issueID, noteID, opt, options...)
 }
@@ -276,7 +276,7 @@ func (s *AwardEmojiService) ListIssuesAwardEmojiOnNote(pid interface{}, issueID,
 // from the merge request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/award_emoji.html#award-emoji-on-notes
+// https://docs.gitlab.com/ee/api/award_emoji.html#list-a-comments-award-emojis
 func (s *AwardEmojiService) ListMergeRequestAwardEmojiOnNote(pid interface{}, mergeRequestIID, noteID int, opt *ListAwardEmojiOptions, options ...RequestOptionFunc) ([]*AwardEmoji, *Response, error) {
 	return s.listAwardEmojiOnNote(pid, awardMergeRequest, mergeRequestIID, noteID, opt, options...)
 }
@@ -285,7 +285,7 @@ func (s *AwardEmojiService) ListMergeRequestAwardEmojiOnNote(pid interface{}, me
 // snippet.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/award_emoji.html#award-emoji-on-notes
+// https://docs.gitlab.com/ee/api/award_emoji.html#list-a-comments-award-emojis
 func (s *AwardEmojiService) ListSnippetAwardEmojiOnNote(pid interface{}, snippetIID, noteID int, opt *ListAwardEmojiOptions, options ...RequestOptionFunc) ([]*AwardEmoji, *Response, error) {
 	return s.listAwardEmojiOnNote(pid, awardSnippets, snippetIID, noteID, opt, options...)
 }
@@ -315,7 +315,7 @@ func (s *AwardEmojiService) listAwardEmojiOnNote(pid interface{}, resources stri
 // GetIssuesAwardEmojiOnNote gets an award emoji on a note from an issue.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/award_emoji.html#award-emoji-on-notes
+// https://docs.gitlab.com/ee/api/award_emoji.html#get-an-award-emoji-for-a-comment
 func (s *AwardEmojiService) GetIssuesAwardEmojiOnNote(pid interface{}, issueID, noteID, awardID int, options ...RequestOptionFunc) (*AwardEmoji, *Response, error) {
 	return s.getSingleNoteAwardEmoji(pid, awardIssue, issueID, noteID, awardID, options...)
 }
@@ -324,7 +324,7 @@ func (s *AwardEmojiService) GetIssuesAwardEmojiOnNote(pid interface{}, issueID, 
 // merge request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/award_emoji.html#award-emoji-on-notes
+// https://docs.gitlab.com/ee/api/award_emoji.html#get-an-award-emoji-for-a-comment
 func (s *AwardEmojiService) GetMergeRequestAwardEmojiOnNote(pid interface{}, mergeRequestIID, noteID, awardID int, options ...RequestOptionFunc) (*AwardEmoji, *Response, error) {
 	return s.getSingleNoteAwardEmoji(pid, awardMergeRequest, mergeRequestIID, noteID, awardID,
 		options...)
@@ -333,7 +333,7 @@ func (s *AwardEmojiService) GetMergeRequestAwardEmojiOnNote(pid interface{}, mer
 // GetSnippetAwardEmojiOnNote gets an award emoji on a note from a snippet.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/award_emoji.html#award-emoji-on-notes
+// https://docs.gitlab.com/ee/api/award_emoji.html#get-an-award-emoji-for-a-comment
 func (s *AwardEmojiService) GetSnippetAwardEmojiOnNote(pid interface{}, snippetIID, noteID, awardID int, options ...RequestOptionFunc) (*AwardEmoji, *Response, error) {
 	return s.getSingleNoteAwardEmoji(pid, awardSnippets, snippetIID, noteID, awardID, options...)
 }
@@ -368,7 +368,7 @@ func (s *AwardEmojiService) getSingleNoteAwardEmoji(pid interface{}, ressource s
 // CreateIssuesAwardEmojiOnNote gets an award emoji on a note from an issue.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/award_emoji.html#award-emoji-on-notes
+// https://docs.gitlab.com/ee/api/award_emoji.html#award-a-new-emoji-on-a-comment
 func (s *AwardEmojiService) CreateIssuesAwardEmojiOnNote(pid interface{}, issueID, noteID int, opt *CreateAwardEmojiOptions, options ...RequestOptionFunc) (*AwardEmoji, *Response, error) {
 	return s.createAwardEmojiOnNote(pid, awardIssue, issueID, noteID, opt, options...)
 }
@@ -377,7 +377,7 @@ func (s *AwardEmojiService) CreateIssuesAwardEmojiOnNote(pid interface{}, issueI
 // merge request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/award_emoji.html#award-emoji-on-notes
+// https://docs.gitlab.com/ee/api/award_emoji.html#award-a-new-emoji-on-a-comment
 func (s *AwardEmojiService) CreateMergeRequestAwardEmojiOnNote(pid interface{}, mergeRequestIID, noteID int, opt *CreateAwardEmojiOptions, options ...RequestOptionFunc) (*AwardEmoji, *Response, error) {
 	return s.createAwardEmojiOnNote(pid, awardMergeRequest, mergeRequestIID, noteID, opt, options...)
 }
@@ -385,7 +385,7 @@ func (s *AwardEmojiService) CreateMergeRequestAwardEmojiOnNote(pid interface{}, 
 // CreateSnippetAwardEmojiOnNote gets an award emoji on a note from a snippet.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/award_emoji.html#award-emoji-on-notes
+// https://docs.gitlab.com/ee/api/award_emoji.html#award-a-new-emoji-on-a-comment
 func (s *AwardEmojiService) CreateSnippetAwardEmojiOnNote(pid interface{}, snippetIID, noteID int, opt *CreateAwardEmojiOptions, options ...RequestOptionFunc) (*AwardEmoji, *Response, error) {
 	return s.createAwardEmojiOnNote(pid, awardSnippets, snippetIID, noteID, opt, options...)
 }
@@ -393,7 +393,7 @@ func (s *AwardEmojiService) CreateSnippetAwardEmojiOnNote(pid interface{}, snipp
 // CreateAwardEmojiOnNote award emoji on a note.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/award_emoji.html#award-a-new-emoji-on-a-note
+// https://docs.gitlab.com/ee/api/award_emoji.html#award-a-new-emoji-on-a-comment
 func (s *AwardEmojiService) createAwardEmojiOnNote(pid interface{}, resource string, resourceID, noteID int, opt *CreateAwardEmojiOptions, options ...RequestOptionFunc) (*AwardEmoji, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -423,7 +423,7 @@ func (s *AwardEmojiService) createAwardEmojiOnNote(pid interface{}, resource str
 // DeleteIssuesAwardEmojiOnNote deletes an award emoji on a note from an issue.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/award_emoji.html#award-emoji-on-notes
+// https://docs.gitlab.com/ee/api/award_emoji.html#delete-an-award-emoji-from-a-comment
 func (s *AwardEmojiService) DeleteIssuesAwardEmojiOnNote(pid interface{}, issueID, noteID, awardID int, options ...RequestOptionFunc) (*Response, error) {
 	return s.deleteAwardEmojiOnNote(pid, awardIssue, issueID, noteID, awardID, options...)
 }
@@ -432,7 +432,7 @@ func (s *AwardEmojiService) DeleteIssuesAwardEmojiOnNote(pid interface{}, issueI
 // merge request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/award_emoji.html#award-emoji-on-notes
+// https://docs.gitlab.com/ee/api/award_emoji.html#delete-an-award-emoji-from-a-comment
 func (s *AwardEmojiService) DeleteMergeRequestAwardEmojiOnNote(pid interface{}, mergeRequestIID, noteID, awardID int, options ...RequestOptionFunc) (*Response, error) {
 	return s.deleteAwardEmojiOnNote(pid, awardMergeRequest, mergeRequestIID, noteID, awardID,
 		options...)
@@ -441,7 +441,7 @@ func (s *AwardEmojiService) DeleteMergeRequestAwardEmojiOnNote(pid interface{}, 
 // DeleteSnippetAwardEmojiOnNote deletes an award emoji on a note from a snippet.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/award_emoji.html#award-emoji-on-notes
+// https://docs.gitlab.com/ee/api/award_emoji.html#delete-an-award-emoji-from-a-comment
 func (s *AwardEmojiService) DeleteSnippetAwardEmojiOnNote(pid interface{}, snippetIID, noteID, awardID int, options ...RequestOptionFunc) (*Response, error) {
 	return s.deleteAwardEmojiOnNote(pid, awardSnippets, snippetIID, noteID, awardID, options...)
 }

--- a/boards.go
+++ b/boards.go
@@ -78,14 +78,14 @@ func (b BoardList) String() string {
 
 // CreateIssueBoardOptions represents the available CreateIssueBoard() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/boards.html#create-a-board-starter
+// GitLab API docs: https://docs.gitlab.com/ee/api/boards.html#create-an-issue-board
 type CreateIssueBoardOptions struct {
 	Name *string `url:"name,omitempty" json:"name,omitempty"`
 }
 
 // CreateIssueBoard creates a new issue board.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/boards.html#create-a-board-starter
+// GitLab API docs: https://docs.gitlab.com/ee/api/boards.html#create-an-issue-board
 func (s *IssueBoardsService) CreateIssueBoard(pid interface{}, opt *CreateIssueBoardOptions, options ...RequestOptionFunc) (*IssueBoard, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -109,7 +109,7 @@ func (s *IssueBoardsService) CreateIssueBoard(pid interface{}, opt *CreateIssueB
 
 // UpdateIssueBoardOptions represents the available UpdateIssueBoard() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/boards.html#update-a-board-starter
+// GitLab API docs: https://docs.gitlab.com/ee/api/boards.html#update-an-issue-board
 type UpdateIssueBoardOptions struct {
 	Name        *string `url:"name,omitempty" json:"name,omitempty"`
 	AssigneeID  *int    `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
@@ -120,7 +120,7 @@ type UpdateIssueBoardOptions struct {
 
 // UpdateIssueBoard update an issue board.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/boards.html#create-a-board-starter
+// GitLab API docs: https://docs.gitlab.com/ee/api/boards.html#update-an-issue-board
 func (s *IssueBoardsService) UpdateIssueBoard(pid interface{}, board int, opt *UpdateIssueBoardOptions, options ...RequestOptionFunc) (*IssueBoard, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -144,7 +144,7 @@ func (s *IssueBoardsService) UpdateIssueBoard(pid interface{}, board int, opt *U
 
 // DeleteIssueBoard deletes an issue board.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/boards.html#delete-a-board-starter
+// GitLab API docs: https://docs.gitlab.com/ee/api/boards.html#delete-an-issue-board
 func (s *IssueBoardsService) DeleteIssueBoard(pid interface{}, board int, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -162,12 +162,12 @@ func (s *IssueBoardsService) DeleteIssueBoard(pid interface{}, board int, option
 
 // ListIssueBoardsOptions represents the available ListIssueBoards() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/boards.html#project-board
+// GitLab API docs: https://docs.gitlab.com/ee/api/boards.html#list-project-issue-boards
 type ListIssueBoardsOptions ListOptions
 
 // ListIssueBoards gets a list of all issue boards in a project.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/boards.html#project-board
+// GitLab API docs: https://docs.gitlab.com/ee/api/boards.html#list-project-issue-boards
 func (s *IssueBoardsService) ListIssueBoards(pid interface{}, opt *ListIssueBoardsOptions, options ...RequestOptionFunc) ([]*IssueBoard, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -191,7 +191,7 @@ func (s *IssueBoardsService) ListIssueBoards(pid interface{}, opt *ListIssueBoar
 
 // GetIssueBoard gets a single issue board of a project.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/boards.html#single-board
+// GitLab API docs: https://docs.gitlab.com/ee/api/boards.html#show-a-single-issue-board
 func (s *IssueBoardsService) GetIssueBoard(pid interface{}, board int, options ...RequestOptionFunc) (*IssueBoard, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -215,13 +215,13 @@ func (s *IssueBoardsService) GetIssueBoard(pid interface{}, board int, options .
 
 // GetIssueBoardListsOptions represents the available GetIssueBoardLists() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/boards.html#list-board-lists
+// GitLab API docs: https://docs.gitlab.com/ee/api/boards.html#list-board-lists-in-a-project-issue-board
 type GetIssueBoardListsOptions ListOptions
 
 // GetIssueBoardLists gets a list of the issue board's lists. Does not include
 // backlog and closed lists.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/boards.html#list-board-lists
+// GitLab API docs: https://docs.gitlab.com/ee/api/boards.html#list-board-lists-in-a-project-issue-board
 func (s *IssueBoardsService) GetIssueBoardLists(pid interface{}, board int, opt *GetIssueBoardListsOptions, options ...RequestOptionFunc) ([]*BoardList, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -245,7 +245,7 @@ func (s *IssueBoardsService) GetIssueBoardLists(pid interface{}, board int, opt 
 
 // GetIssueBoardList gets a single issue board list.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/boards.html#single-board-list
+// GitLab API docs: https://docs.gitlab.com/ee/api/boards.html#show-a-single-board-list
 func (s *IssueBoardsService) GetIssueBoardList(pid interface{}, board, list int, options ...RequestOptionFunc) (*BoardList, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -274,7 +274,7 @@ func (s *IssueBoardsService) GetIssueBoardList(pid interface{}, board, list int,
 // CreateIssueBoardListOptions represents the available CreateIssueBoardList()
 // options.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/boards.html#new-board-list
+// GitLab API docs: https://docs.gitlab.com/ee/api/boards.html#create-a-board-list
 type CreateIssueBoardListOptions struct {
 	LabelID     *int `url:"label_id,omitempty" json:"label_id,omitempty"`
 	AssigneeID  *int `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
@@ -284,7 +284,7 @@ type CreateIssueBoardListOptions struct {
 
 // CreateIssueBoardList creates a new issue board list.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/boards.html#new-board-list
+// GitLab API docs: https://docs.gitlab.com/ee/api/boards.html#create-a-board-list
 func (s *IssueBoardsService) CreateIssueBoardList(pid interface{}, board int, opt *CreateIssueBoardListOptions, options ...RequestOptionFunc) (*BoardList, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -309,14 +309,14 @@ func (s *IssueBoardsService) CreateIssueBoardList(pid interface{}, board int, op
 // UpdateIssueBoardListOptions represents the available UpdateIssueBoardList()
 // options.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/boards.html#edit-board-list
+// GitLab API docs: https://docs.gitlab.com/ee/api/boards.html#reorder-a-list-in-a-board
 type UpdateIssueBoardListOptions struct {
 	Position *int `url:"position" json:"position"`
 }
 
 // UpdateIssueBoardList updates the position of an existing issue board list.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/boards.html#edit-board-list
+// GitLab API docs: https://docs.gitlab.com/ee/api/boards.html#reorder-a-list-in-a-board
 func (s *IssueBoardsService) UpdateIssueBoardList(pid interface{}, board, list int, opt *UpdateIssueBoardListOptions, options ...RequestOptionFunc) (*BoardList, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -346,7 +346,7 @@ func (s *IssueBoardsService) UpdateIssueBoardList(pid interface{}, board, list i
 // project owners.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/boards.html#delete-a-board-list
+// https://docs.gitlab.com/ee/api/boards.html#delete-a-board-list-from-a-board
 func (s *IssueBoardsService) DeleteIssueBoardList(pid interface{}, board, list int, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/boards.go
+++ b/boards.go
@@ -24,14 +24,14 @@ import (
 // IssueBoardsService handles communication with the issue board related
 // methods of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/boards.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/boards.html
 type IssueBoardsService struct {
 	client *Client
 }
 
 // IssueBoard represents a GitLab issue board.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/boards.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/boards.html
 type IssueBoard struct {
 	ID        int        `json:"id"`
 	Name      string     `json:"name"`
@@ -56,7 +56,7 @@ func (b IssueBoard) String() string {
 
 // BoardList represents a GitLab board list.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/boards.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/boards.html
 type BoardList struct {
 	ID       int `json:"id"`
 	Assignee *struct {
@@ -162,12 +162,12 @@ func (s *IssueBoardsService) DeleteIssueBoard(pid interface{}, board int, option
 
 // ListIssueBoardsOptions represents the available ListIssueBoards() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/boards.html#project-board
+// GitLab API docs: https://docs.gitlab.com/ee/api/boards.html#project-board
 type ListIssueBoardsOptions ListOptions
 
 // ListIssueBoards gets a list of all issue boards in a project.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/boards.html#project-board
+// GitLab API docs: https://docs.gitlab.com/ee/api/boards.html#project-board
 func (s *IssueBoardsService) ListIssueBoards(pid interface{}, opt *ListIssueBoardsOptions, options ...RequestOptionFunc) ([]*IssueBoard, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -191,7 +191,7 @@ func (s *IssueBoardsService) ListIssueBoards(pid interface{}, opt *ListIssueBoar
 
 // GetIssueBoard gets a single issue board of a project.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/boards.html#single-board
+// GitLab API docs: https://docs.gitlab.com/ee/api/boards.html#single-board
 func (s *IssueBoardsService) GetIssueBoard(pid interface{}, board int, options ...RequestOptionFunc) (*IssueBoard, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -215,13 +215,13 @@ func (s *IssueBoardsService) GetIssueBoard(pid interface{}, board int, options .
 
 // GetIssueBoardListsOptions represents the available GetIssueBoardLists() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/boards.html#list-board-lists
+// GitLab API docs: https://docs.gitlab.com/ee/api/boards.html#list-board-lists
 type GetIssueBoardListsOptions ListOptions
 
 // GetIssueBoardLists gets a list of the issue board's lists. Does not include
 // backlog and closed lists.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/boards.html#list-board-lists
+// GitLab API docs: https://docs.gitlab.com/ee/api/boards.html#list-board-lists
 func (s *IssueBoardsService) GetIssueBoardLists(pid interface{}, board int, opt *GetIssueBoardListsOptions, options ...RequestOptionFunc) ([]*BoardList, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -245,7 +245,7 @@ func (s *IssueBoardsService) GetIssueBoardLists(pid interface{}, board int, opt 
 
 // GetIssueBoardList gets a single issue board list.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/boards.html#single-board-list
+// GitLab API docs: https://docs.gitlab.com/ee/api/boards.html#single-board-list
 func (s *IssueBoardsService) GetIssueBoardList(pid interface{}, board, list int, options ...RequestOptionFunc) (*BoardList, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -274,7 +274,7 @@ func (s *IssueBoardsService) GetIssueBoardList(pid interface{}, board, list int,
 // CreateIssueBoardListOptions represents the available CreateIssueBoardList()
 // options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/boards.html#new-board-list
+// GitLab API docs: https://docs.gitlab.com/ee/api/boards.html#new-board-list
 type CreateIssueBoardListOptions struct {
 	LabelID     *int `url:"label_id,omitempty" json:"label_id,omitempty"`
 	AssigneeID  *int `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
@@ -284,7 +284,7 @@ type CreateIssueBoardListOptions struct {
 
 // CreateIssueBoardList creates a new issue board list.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/boards.html#new-board-list
+// GitLab API docs: https://docs.gitlab.com/ee/api/boards.html#new-board-list
 func (s *IssueBoardsService) CreateIssueBoardList(pid interface{}, board int, opt *CreateIssueBoardListOptions, options ...RequestOptionFunc) (*BoardList, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -309,14 +309,14 @@ func (s *IssueBoardsService) CreateIssueBoardList(pid interface{}, board int, op
 // UpdateIssueBoardListOptions represents the available UpdateIssueBoardList()
 // options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/boards.html#edit-board-list
+// GitLab API docs: https://docs.gitlab.com/ee/api/boards.html#edit-board-list
 type UpdateIssueBoardListOptions struct {
 	Position *int `url:"position" json:"position"`
 }
 
 // UpdateIssueBoardList updates the position of an existing issue board list.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/boards.html#edit-board-list
+// GitLab API docs: https://docs.gitlab.com/ee/api/boards.html#edit-board-list
 func (s *IssueBoardsService) UpdateIssueBoardList(pid interface{}, board, list int, opt *UpdateIssueBoardListOptions, options ...RequestOptionFunc) (*BoardList, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -346,7 +346,7 @@ func (s *IssueBoardsService) UpdateIssueBoardList(pid interface{}, board, list i
 // project owners.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/boards.html#delete-a-board-list
+// https://docs.gitlab.com/ee/api/boards.html#delete-a-board-list
 func (s *IssueBoardsService) DeleteIssueBoardList(pid interface{}, board, list int, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/branches.go
+++ b/branches.go
@@ -25,14 +25,14 @@ import (
 // BranchesService handles communication with the branch related methods
 // of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/branches.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/branches.html
 type BranchesService struct {
 	client *Client
 }
 
 // Branch represents a GitLab branch.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/branches.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/branches.html
 type Branch struct {
 	Commit             *Commit `json:"commit"`
 	Name               string  `json:"name"`
@@ -52,7 +52,7 @@ func (b Branch) String() string {
 // ListBranchesOptions represents the available ListBranches() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/branches.html#list-repository-branches
+// https://docs.gitlab.com/ee/api/branches.html#list-repository-branches
 type ListBranchesOptions struct {
 	ListOptions
 	Search *string `url:"search,omitempty" json:"search,omitempty"`
@@ -62,7 +62,7 @@ type ListBranchesOptions struct {
 // name alphabetically.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/branches.html#list-repository-branches
+// https://docs.gitlab.com/ee/api/branches.html#list-repository-branches
 func (s *BranchesService) ListBranches(pid interface{}, opts *ListBranchesOptions, options ...RequestOptionFunc) ([]*Branch, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -87,7 +87,7 @@ func (s *BranchesService) ListBranches(pid interface{}, opts *ListBranchesOption
 // GetBranch gets a single project repository branch.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/branches.html#get-single-repository-branch
+// https://docs.gitlab.com/ee/api/branches.html#get-single-repository-branch
 func (s *BranchesService) GetBranch(pid interface{}, branch string, options ...RequestOptionFunc) (*Branch, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -112,7 +112,7 @@ func (s *BranchesService) GetBranch(pid interface{}, branch string, options ...R
 // ProtectBranchOptions represents the available ProtectBranch() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/branches.html#protect-repository-branch
+// https://docs.gitlab.com/ee/api/branches.html#protect-repository-branch
 type ProtectBranchOptions struct {
 	DevelopersCanPush  *bool `url:"developers_can_push,omitempty" json:"developers_can_push,omitempty"`
 	DevelopersCanMerge *bool `url:"developers_can_merge,omitempty" json:"developers_can_merge,omitempty"`
@@ -123,7 +123,7 @@ type ProtectBranchOptions struct {
 // still returns a 200 OK status code.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/branches.html#protect-repository-branch
+// https://docs.gitlab.com/ee/api/branches.html#protect-repository-branch
 func (s *BranchesService) ProtectBranch(pid interface{}, branch string, opts *ProtectBranchOptions, options ...RequestOptionFunc) (*Branch, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -150,7 +150,7 @@ func (s *BranchesService) ProtectBranch(pid interface{}, branch string, opts *Pr
 // still returns a 200 OK status code.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/branches.html#unprotect-repository-branch
+// https://docs.gitlab.com/ee/api/branches.html#unprotect-repository-branch
 func (s *BranchesService) UnprotectBranch(pid interface{}, branch string, options ...RequestOptionFunc) (*Branch, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -175,7 +175,7 @@ func (s *BranchesService) UnprotectBranch(pid interface{}, branch string, option
 // CreateBranchOptions represents the available CreateBranch() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/branches.html#create-repository-branch
+// https://docs.gitlab.com/ee/api/branches.html#create-repository-branch
 type CreateBranchOptions struct {
 	Branch *string `url:"branch,omitempty" json:"branch,omitempty"`
 	Ref    *string `url:"ref,omitempty" json:"ref,omitempty"`
@@ -184,7 +184,7 @@ type CreateBranchOptions struct {
 // CreateBranch creates branch from commit SHA or existing branch.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/branches.html#create-repository-branch
+// https://docs.gitlab.com/ee/api/branches.html#create-repository-branch
 func (s *BranchesService) CreateBranch(pid interface{}, opt *CreateBranchOptions, options ...RequestOptionFunc) (*Branch, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -209,7 +209,7 @@ func (s *BranchesService) CreateBranch(pid interface{}, opt *CreateBranchOptions
 // DeleteBranch deletes an existing branch.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/branches.html#delete-repository-branch
+// https://docs.gitlab.com/ee/api/branches.html#delete-repository-branch
 func (s *BranchesService) DeleteBranch(pid interface{}, branch string, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -228,7 +228,7 @@ func (s *BranchesService) DeleteBranch(pid interface{}, branch string, options .
 // DeleteMergedBranches deletes all branches that are merged into the project's default branch.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/branches.html#delete-merged-branches
+// https://docs.gitlab.com/ee/api/branches.html#delete-merged-branches
 func (s *BranchesService) DeleteMergedBranches(pid interface{}, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/broadcast_messages.go
+++ b/broadcast_messages.go
@@ -25,7 +25,7 @@ import (
 // BroadcastMessagesService handles communication with the broadcast
 // messages methods of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/broadcast_messages.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/broadcast_messages.html
 type BroadcastMessagesService struct {
 	client *Client
 }
@@ -33,7 +33,7 @@ type BroadcastMessagesService struct {
 // BroadcastMessage represents a GitLab issue board.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/broadcast_messages.html#get-all-broadcast-messages
+// https://docs.gitlab.com/ee/api/broadcast_messages.html#get-all-broadcast-messages
 type BroadcastMessage struct {
 	Message            string             `json:"message"`
 	StartsAt           *time.Time         `json:"starts_at"`
@@ -54,13 +54,13 @@ type BroadcastMessage struct {
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/broadcast_messages.html#get-all-broadcast-messages
+// https://docs.gitlab.com/ee/api/broadcast_messages.html#get-all-broadcast-messages
 type ListBroadcastMessagesOptions ListOptions
 
 // ListBroadcastMessages gets a list of all broadcasted messages.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/broadcast_messages.html#get-all-broadcast-messages
+// https://docs.gitlab.com/ee/api/broadcast_messages.html#get-all-broadcast-messages
 func (s *BroadcastMessagesService) ListBroadcastMessages(opt *ListBroadcastMessagesOptions, options ...RequestOptionFunc) ([]*BroadcastMessage, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "broadcast_messages", opt, options)
 	if err != nil {
@@ -79,7 +79,7 @@ func (s *BroadcastMessagesService) ListBroadcastMessages(opt *ListBroadcastMessa
 // GetBroadcastMessage gets a single broadcast message.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/broadcast_messages.html#get-a-specific-broadcast-message
+// https://docs.gitlab.com/ee/api/broadcast_messages.html#get-a-specific-broadcast-message
 func (s *BroadcastMessagesService) GetBroadcastMessage(broadcast int, options ...RequestOptionFunc) (*BroadcastMessage, *Response, error) {
 	u := fmt.Sprintf("broadcast_messages/%d", broadcast)
 
@@ -101,7 +101,7 @@ func (s *BroadcastMessagesService) GetBroadcastMessage(broadcast int, options ..
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/broadcast_messages.html#create-a-broadcast-message
+// https://docs.gitlab.com/ee/api/broadcast_messages.html#create-a-broadcast-message
 type CreateBroadcastMessageOptions struct {
 	Message            *string            `url:"message" json:"message"`
 	StartsAt           *time.Time         `url:"starts_at,omitempty" json:"starts_at,omitempty"`
@@ -119,7 +119,7 @@ type CreateBroadcastMessageOptions struct {
 // CreateBroadcastMessage creates a message to broadcast.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/broadcast_messages.html#create-a-broadcast-message
+// https://docs.gitlab.com/ee/api/broadcast_messages.html#create-a-broadcast-message
 func (s *BroadcastMessagesService) CreateBroadcastMessage(opt *CreateBroadcastMessageOptions, options ...RequestOptionFunc) (*BroadcastMessage, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodPost, "broadcast_messages", opt, options)
 	if err != nil {
@@ -139,7 +139,7 @@ func (s *BroadcastMessagesService) CreateBroadcastMessage(opt *CreateBroadcastMe
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/broadcast_messages.html#update-a-broadcast-message
+// https://docs.gitlab.com/ee/api/broadcast_messages.html#update-a-broadcast-message
 type UpdateBroadcastMessageOptions struct {
 	Message            *string            `url:"message,omitempty" json:"message,omitempty"`
 	StartsAt           *time.Time         `url:"starts_at,omitempty" json:"starts_at,omitempty"`
@@ -157,7 +157,7 @@ type UpdateBroadcastMessageOptions struct {
 // UpdateBroadcastMessage update a broadcasted message.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/broadcast_messages.html#update-a-broadcast-message
+// https://docs.gitlab.com/ee/api/broadcast_messages.html#update-a-broadcast-message
 func (s *BroadcastMessagesService) UpdateBroadcastMessage(broadcast int, opt *UpdateBroadcastMessageOptions, options ...RequestOptionFunc) (*BroadcastMessage, *Response, error) {
 	u := fmt.Sprintf("broadcast_messages/%d", broadcast)
 
@@ -178,7 +178,7 @@ func (s *BroadcastMessagesService) UpdateBroadcastMessage(broadcast int, opt *Up
 // DeleteBroadcastMessage deletes a broadcasted message.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/broadcast_messages.html#delete-a-broadcast-message
+// https://docs.gitlab.com/ee/api/broadcast_messages.html#delete-a-broadcast-message
 func (s *BroadcastMessagesService) DeleteBroadcastMessage(broadcast int, options ...RequestOptionFunc) (*Response, error) {
 	u := fmt.Sprintf("broadcast_messages/%d", broadcast)
 

--- a/ci_yml_templates.go
+++ b/ci_yml_templates.go
@@ -25,7 +25,7 @@ import (
 // CI YML templates related methods of the GitLab API.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/templates/gitlab_ci_ymls.html
+// https://docs.gitlab.com/ee/api/templates/gitlab_ci_ymls.html
 type CIYMLTemplatesService struct {
 	client *Client
 }
@@ -33,7 +33,7 @@ type CIYMLTemplatesService struct {
 // CIYMLTemplate represents a GitLab CI YML template.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/templates/gitlab_ci_ymls.html
+// https://docs.gitlab.com/ee/api/templates/gitlab_ci_ymls.html
 type CIYMLTemplate struct {
 	Name    string `json:"name"`
 	Content string `json:"content"`
@@ -42,7 +42,7 @@ type CIYMLTemplate struct {
 // CIYMLTemplateListItem represents a GitLab CI YML template from the list.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/templates/gitlab_ci_ymls.html
+// https://docs.gitlab.com/ee/api/templates/gitlab_ci_ymls.html
 type CIYMLTemplateListItem struct {
 	Key  string `json:"key"`
 	Name string `json:"name"`
@@ -51,13 +51,13 @@ type CIYMLTemplateListItem struct {
 // ListCIYMLTemplatesOptions represents the available ListAllTemplates() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/templates/gitignores.html#list-gitignore-templates
+// https://docs.gitlab.com/ee/api/templates/gitignores.html#list-gitignore-templates
 type ListCIYMLTemplatesOptions ListOptions
 
 // ListAllTemplates get all GitLab CI YML templates.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/templates/gitlab_ci_ymls.html#list-gitlab-ci-yml-templates
+// https://docs.gitlab.com/ee/api/templates/gitlab_ci_ymls.html#list-gitlab-ci-yml-templates
 func (s *CIYMLTemplatesService) ListAllTemplates(opt *ListCIYMLTemplatesOptions, options ...RequestOptionFunc) ([]*CIYMLTemplateListItem, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "templates/gitlab_ci_ymls", opt, options)
 	if err != nil {
@@ -76,7 +76,7 @@ func (s *CIYMLTemplatesService) ListAllTemplates(opt *ListCIYMLTemplatesOptions,
 // GetTemplate get a single GitLab CI YML template.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/templates/gitlab_ci_ymls.html#single-gitlab-ci-yml-template
+// https://docs.gitlab.com/ee/api/templates/gitlab_ci_ymls.html#single-gitlab-ci-yml-template
 func (s *CIYMLTemplatesService) GetTemplate(key string, options ...RequestOptionFunc) (*CIYMLTemplate, *Response, error) {
 	u := fmt.Sprintf("templates/gitlab_ci_ymls/%s", PathEscape(key))
 

--- a/ci_yml_templates.go
+++ b/ci_yml_templates.go
@@ -51,13 +51,13 @@ type CIYMLTemplateListItem struct {
 // ListCIYMLTemplatesOptions represents the available ListAllTemplates() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/templates/gitignores.html#list-gitignore-templates
+// https://docs.gitlab.com/ee/api/templates/gitlab_ci_ymls.html#list-gitlab-ci-yaml-templates
 type ListCIYMLTemplatesOptions ListOptions
 
 // ListAllTemplates get all GitLab CI YML templates.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/templates/gitlab_ci_ymls.html#list-gitlab-ci-yml-templates
+// https://docs.gitlab.com/ee/api/templates/gitlab_ci_ymls.html#list-gitlab-ci-yaml-templates
 func (s *CIYMLTemplatesService) ListAllTemplates(opt *ListCIYMLTemplatesOptions, options ...RequestOptionFunc) ([]*CIYMLTemplateListItem, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "templates/gitlab_ci_ymls", opt, options)
 	if err != nil {
@@ -76,7 +76,7 @@ func (s *CIYMLTemplatesService) ListAllTemplates(opt *ListCIYMLTemplatesOptions,
 // GetTemplate get a single GitLab CI YML template.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/templates/gitlab_ci_ymls.html#single-gitlab-ci-yml-template
+// https://docs.gitlab.com/ee/api/templates/gitlab_ci_ymls.html#single-gitlab-ci-yaml-template
 func (s *CIYMLTemplatesService) GetTemplate(key string, options ...RequestOptionFunc) (*CIYMLTemplate, *Response, error) {
 	u := fmt.Sprintf("templates/gitlab_ci_ymls/%s", PathEscape(key))
 

--- a/commits.go
+++ b/commits.go
@@ -26,14 +26,14 @@ import (
 // CommitsService handles communication with the commit related methods
 // of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/commits.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/commits.html
 type CommitsService struct {
 	client *Client
 }
 
 // Commit represents a GitLab commit.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/commits.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/commits.html
 type Commit struct {
 	ID             string            `json:"id"`
 	ShortID        string            `json:"short_id"`
@@ -57,7 +57,7 @@ type Commit struct {
 
 // CommitStats represents the number of added and deleted files in a commit.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/commits.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/commits.html
 type CommitStats struct {
 	Additions int `json:"additions"`
 	Deletions int `json:"deletions"`
@@ -70,7 +70,7 @@ func (c Commit) String() string {
 
 // ListCommitsOptions represents the available ListCommits() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/commits.html#list-repository-commits
+// GitLab API docs: https://docs.gitlab.com/ee/api/commits.html#list-repository-commits
 type ListCommitsOptions struct {
 	ListOptions
 	RefName     *string    `url:"ref_name,omitempty" json:"ref_name,omitempty"`
@@ -85,7 +85,7 @@ type ListCommitsOptions struct {
 
 // ListCommits gets a list of repository commits in a project.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/commits.html#list-commits
+// GitLab API docs: https://docs.gitlab.com/ee/api/commits.html#list-commits
 func (s *CommitsService) ListCommits(pid interface{}, opt *ListCommitsOptions, options ...RequestOptionFunc) ([]*Commit, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -110,7 +110,7 @@ func (s *CommitsService) ListCommits(pid interface{}, opt *ListCommitsOptions, o
 // CommitRef represents the reference of branches/tags in a commit.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/commits.html#get-references-a-commit-is-pushed-to
+// https://docs.gitlab.com/ee/api/commits.html#get-references-a-commit-is-pushed-to
 type CommitRef struct {
 	Type string `json:"type"`
 	Name string `json:"name"`
@@ -119,7 +119,7 @@ type CommitRef struct {
 // GetCommitRefsOptions represents the available GetCommitRefs() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/commits.html#get-references-a-commit-is-pushed-to
+// https://docs.gitlab.com/ee/api/commits.html#get-references-a-commit-is-pushed-to
 type GetCommitRefsOptions struct {
 	ListOptions
 	Type *string `url:"type,omitempty" json:"type,omitempty"`
@@ -128,7 +128,7 @@ type GetCommitRefsOptions struct {
 // GetCommitRefs gets all references (from branches or tags) a commit is pushed to
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/commits.html#get-references-a-commit-is-pushed-to
+// https://docs.gitlab.com/ee/api/commits.html#get-references-a-commit-is-pushed-to
 func (s *CommitsService) GetCommitRefs(pid interface{}, sha string, opt *GetCommitRefsOptions, options ...RequestOptionFunc) ([]*CommitRef, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -153,7 +153,7 @@ func (s *CommitsService) GetCommitRefs(pid interface{}, sha string, opt *GetComm
 // GetCommit gets a specific commit identified by the commit hash or name of a
 // branch or tag.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/commits.html#get-a-single-commit
+// GitLab API docs: https://docs.gitlab.com/ee/api/commits.html#get-a-single-commit
 func (s *CommitsService) GetCommit(pid interface{}, sha string, options ...RequestOptionFunc) (*Commit, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -180,7 +180,7 @@ func (s *CommitsService) GetCommit(pid interface{}, sha string, options ...Reque
 
 // CreateCommitOptions represents the available options for a new commit.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/commits.html#create-a-commit-with-multiple-files-and-actions
+// GitLab API docs: https://docs.gitlab.com/ee/api/commits.html#create-a-commit-with-multiple-files-and-actions
 type CreateCommitOptions struct {
 	Branch        *string                `url:"branch,omitempty" json:"branch,omitempty"`
 	CommitMessage *string                `url:"commit_message,omitempty" json:"commit_message,omitempty"`
@@ -197,7 +197,7 @@ type CreateCommitOptions struct {
 // CommitActionOptions represents the available options for a new single
 // file action.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/commits.html#create-a-commit-with-multiple-files-and-actions
+// GitLab API docs: https://docs.gitlab.com/ee/api/commits.html#create-a-commit-with-multiple-files-and-actions
 type CommitActionOptions struct {
 	Action          *FileActionValue `url:"action,omitempty" json:"action,omitempty"`
 	FilePath        *string          `url:"file_path,omitempty" json:"file_path,omitempty"`
@@ -210,7 +210,7 @@ type CommitActionOptions struct {
 
 // CreateCommit creates a commit with multiple files and actions.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/commits.html#create-a-commit-with-multiple-files-and-actions
+// GitLab API docs: https://docs.gitlab.com/ee/api/commits.html#create-a-commit-with-multiple-files-and-actions
 func (s *CommitsService) CreateCommit(pid interface{}, opt *CreateCommitOptions, options ...RequestOptionFunc) (*Commit, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -234,7 +234,7 @@ func (s *CommitsService) CreateCommit(pid interface{}, opt *CreateCommitOptions,
 
 // Diff represents a GitLab diff.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/commits.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/commits.html
 type Diff struct {
 	Diff        string `json:"diff"`
 	NewPath     string `json:"new_path"`
@@ -253,13 +253,13 @@ func (d Diff) String() string {
 // GetCommitDiffOptions represents the available GetCommitDiff() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/commits.html#get-the-diff-of-a-commit
+// https://docs.gitlab.com/ee/api/commits.html#get-the-diff-of-a-commit
 type GetCommitDiffOptions ListOptions
 
 // GetCommitDiff gets the diff of a commit in a project..
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/commits.html#get-the-diff-of-a-commit
+// https://docs.gitlab.com/ee/api/commits.html#get-the-diff-of-a-commit
 func (s *CommitsService) GetCommitDiff(pid interface{}, sha string, opt *GetCommitDiffOptions, options ...RequestOptionFunc) ([]*Diff, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -283,7 +283,7 @@ func (s *CommitsService) GetCommitDiff(pid interface{}, sha string, opt *GetComm
 
 // CommitComment represents a GitLab commit comment.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/commits.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/commits.html
 type CommitComment struct {
 	Note     string `json:"note"`
 	Path     string `json:"path"`
@@ -310,13 +310,13 @@ func (c CommitComment) String() string {
 // GetCommitCommentsOptions represents the available GetCommitComments() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/commits.html#get-the-comments-of-a-commit
+// https://docs.gitlab.com/ee/api/commits.html#get-the-comments-of-a-commit
 type GetCommitCommentsOptions ListOptions
 
 // GetCommitComments gets the comments of a commit in a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/commits.html#get-the-comments-of-a-commit
+// https://docs.gitlab.com/ee/api/commits.html#get-the-comments-of-a-commit
 func (s *CommitsService) GetCommitComments(pid interface{}, sha string, opt *GetCommitCommentsOptions, options ...RequestOptionFunc) ([]*CommitComment, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -342,7 +342,7 @@ func (s *CommitsService) GetCommitComments(pid interface{}, sha string, opt *Get
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/commits.html#post-comment-to-commit
+// https://docs.gitlab.com/ee/api/commits.html#post-comment-to-commit
 type PostCommitCommentOptions struct {
 	Note     *string `url:"note,omitempty" json:"note,omitempty"`
 	Path     *string `url:"path" json:"path"`
@@ -355,7 +355,7 @@ type PostCommitCommentOptions struct {
 // line_old are required.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/commits.html#post-comment-to-commit
+// https://docs.gitlab.com/ee/api/commits.html#post-comment-to-commit
 func (s *CommitsService) PostCommitComment(pid interface{}, sha string, opt *PostCommitCommentOptions, options ...RequestOptionFunc) (*CommitComment, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -379,7 +379,7 @@ func (s *CommitsService) PostCommitComment(pid interface{}, sha string, opt *Pos
 
 // GetCommitStatusesOptions represents the available GetCommitStatuses() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/commits.html#get-the-status-of-a-commit
+// GitLab API docs: https://docs.gitlab.com/ee/api/commits.html#get-the-status-of-a-commit
 type GetCommitStatusesOptions struct {
 	ListOptions
 	Ref   *string `url:"ref,omitempty" json:"ref,omitempty"`
@@ -390,7 +390,7 @@ type GetCommitStatusesOptions struct {
 
 // CommitStatus represents a GitLab commit status.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/commits.html#get-the-status-of-a-commit
+// GitLab API docs: https://docs.gitlab.com/ee/api/commits.html#get-the-status-of-a-commit
 type CommitStatus struct {
 	ID           int        `json:"id"`
 	SHA          string     `json:"sha"`
@@ -409,7 +409,7 @@ type CommitStatus struct {
 
 // GetCommitStatuses gets the statuses of a commit in a project.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/commits.html#get-the-status-of-a-commit
+// GitLab API docs: https://docs.gitlab.com/ee/api/commits.html#get-the-status-of-a-commit
 func (s *CommitsService) GetCommitStatuses(pid interface{}, sha string, opt *GetCommitStatusesOptions, options ...RequestOptionFunc) ([]*CommitStatus, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -433,7 +433,7 @@ func (s *CommitsService) GetCommitStatuses(pid interface{}, sha string, opt *Get
 
 // SetCommitStatusOptions represents the available SetCommitStatus() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/commits.html#post-the-status-to-commit
+// GitLab API docs: https://docs.gitlab.com/ee/api/commits.html#post-the-status-to-commit
 type SetCommitStatusOptions struct {
 	State       BuildStateValue `url:"state" json:"state"`
 	Ref         *string         `url:"ref,omitempty" json:"ref,omitempty"`
@@ -447,7 +447,7 @@ type SetCommitStatusOptions struct {
 
 // SetCommitStatus sets the status of a commit in a project.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/commits.html#post-the-status-to-commit
+// GitLab API docs: https://docs.gitlab.com/ee/api/commits.html#post-the-status-to-commit
 func (s *CommitsService) SetCommitStatus(pid interface{}, sha string, opt *SetCommitStatusOptions, options ...RequestOptionFunc) (*CommitStatus, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -472,7 +472,7 @@ func (s *CommitsService) SetCommitStatus(pid interface{}, sha string, opt *SetCo
 // ListMergeRequestsByCommit gets merge request associated with a commit.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/commits.html#list-merge-requests-associated-with-a-commit
+// https://docs.gitlab.com/ee/api/commits.html#list-merge-requests-associated-with-a-commit
 func (s *CommitsService) ListMergeRequestsByCommit(pid interface{}, sha string, options ...RequestOptionFunc) ([]*MergeRequest, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -496,7 +496,7 @@ func (s *CommitsService) ListMergeRequestsByCommit(pid interface{}, sha string, 
 
 // CherryPickCommitOptions represents the available CherryPickCommit() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/commits.html#cherry-pick-a-commit
+// GitLab API docs: https://docs.gitlab.com/ee/api/commits.html#cherry-pick-a-commit
 type CherryPickCommitOptions struct {
 	Branch  *string `url:"branch,omitempty" json:"branch,omitempty"`
 	DryRun  *bool   `url:"dry_run,omitempty" json:"dry_run,omitempty"`
@@ -505,7 +505,7 @@ type CherryPickCommitOptions struct {
 
 // CherryPickCommit cherry picks a commit to a given branch.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/commits.html#cherry-pick-a-commit
+// GitLab API docs: https://docs.gitlab.com/ee/api/commits.html#cherry-pick-a-commit
 func (s *CommitsService) CherryPickCommit(pid interface{}, sha string, opt *CherryPickCommitOptions, options ...RequestOptionFunc) (*Commit, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/commits.go
+++ b/commits.go
@@ -85,7 +85,7 @@ type ListCommitsOptions struct {
 
 // ListCommits gets a list of repository commits in a project.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/commits.html#list-commits
+// GitLab API docs: https://docs.gitlab.com/ee/api/commits.html#list-repository-commits
 func (s *CommitsService) ListCommits(pid interface{}, opt *ListCommitsOptions, options ...RequestOptionFunc) ([]*Commit, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -379,7 +379,7 @@ func (s *CommitsService) PostCommitComment(pid interface{}, sha string, opt *Pos
 
 // GetCommitStatusesOptions represents the available GetCommitStatuses() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/commits.html#get-the-status-of-a-commit
+// GitLab API docs: https://docs.gitlab.com/ee/api/commits.html#list-the-statuses-of-a-commit
 type GetCommitStatusesOptions struct {
 	ListOptions
 	Ref   *string `url:"ref,omitempty" json:"ref,omitempty"`
@@ -390,7 +390,7 @@ type GetCommitStatusesOptions struct {
 
 // CommitStatus represents a GitLab commit status.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/commits.html#get-the-status-of-a-commit
+// GitLab API docs: https://docs.gitlab.com/ee/api/commits.html#commit-status
 type CommitStatus struct {
 	ID           int        `json:"id"`
 	SHA          string     `json:"sha"`
@@ -409,7 +409,7 @@ type CommitStatus struct {
 
 // GetCommitStatuses gets the statuses of a commit in a project.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/commits.html#get-the-status-of-a-commit
+// GitLab API docs: https://docs.gitlab.com/ee/api/commits.html#list-the-statuses-of-a-commit
 func (s *CommitsService) GetCommitStatuses(pid interface{}, sha string, opt *GetCommitStatusesOptions, options ...RequestOptionFunc) ([]*CommitStatus, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -433,7 +433,7 @@ func (s *CommitsService) GetCommitStatuses(pid interface{}, sha string, opt *Get
 
 // SetCommitStatusOptions represents the available SetCommitStatus() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/commits.html#post-the-status-to-commit
+// GitLab API docs: https://docs.gitlab.com/ee/api/commits.html#set-the-pipeline-status-of-a-commit
 type SetCommitStatusOptions struct {
 	State       BuildStateValue `url:"state" json:"state"`
 	Ref         *string         `url:"ref,omitempty" json:"ref,omitempty"`
@@ -447,7 +447,7 @@ type SetCommitStatusOptions struct {
 
 // SetCommitStatus sets the status of a commit in a project.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/commits.html#post-the-status-to-commit
+// GitLab API docs: https://docs.gitlab.com/ee/api/commits.html#set-the-pipeline-status-of-a-commit
 func (s *CommitsService) SetCommitStatus(pid interface{}, sha string, opt *SetCommitStatusOptions, options ...RequestOptionFunc) (*CommitStatus, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/container_registry.go
+++ b/container_registry.go
@@ -80,7 +80,7 @@ type ListRegistryRepositoriesOptions struct {
 // ListProjectRegistryRepositories gets a list of registry repositories in a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/container_registry.html#list-registry-repositories
+// https://docs.gitlab.com/ee/api/container_registry.html#within-a-project
 func (s *ContainerRegistryService) ListProjectRegistryRepositories(pid interface{}, opt *ListRegistryRepositoriesOptions, options ...RequestOptionFunc) ([]*RegistryRepository, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -272,7 +272,7 @@ func (s *ContainerRegistryService) DeleteRegistryRepositoryTag(pid interface{}, 
 // DeleteRegistryRepositoryTags() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/container_registry.html#delete-repository-tags-in-bulk
+// https://docs.gitlab.com/ee/api/container_registry.html#delete-registry-repository-tags-in-bulk
 type DeleteRegistryRepositoryTagsOptions struct {
 	NameRegexpDelete *string `url:"name_regex_delete,omitempty" json:"name_regex_delete,omitempty"`
 	NameRegexpKeep   *string `url:"name_regex_keep,omitempty" json:"name_regex_keep,omitempty"`
@@ -287,7 +287,7 @@ type DeleteRegistryRepositoryTagsOptions struct {
 // given criteria.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/container_registry.html#delete-repository-tags-in-bulk
+// https://docs.gitlab.com/ee/api/container_registry.html#delete-registry-repository-tags-in-bulk
 func (s *ContainerRegistryService) DeleteRegistryRepositoryTags(pid interface{}, repository int, opt *DeleteRegistryRepositoryTagsOptions, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/custom_attributes.go
+++ b/custom_attributes.go
@@ -24,14 +24,14 @@ import (
 // CustomAttributesService handles communication with the group, project and
 // user custom attributes related methods of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/custom_attributes.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/custom_attributes.html
 type CustomAttributesService struct {
 	client *Client
 }
 
 // CustomAttribute struct is used to unmarshal response to api calls.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/custom_attributes.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/custom_attributes.html
 type CustomAttribute struct {
 	Key   string `json:"key"`
 	Value string `json:"value"`
@@ -40,7 +40,7 @@ type CustomAttribute struct {
 // ListCustomUserAttributes lists the custom attributes of the specified user.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/custom_attributes.html#list-custom-attributes
+// https://docs.gitlab.com/ee/api/custom_attributes.html#list-custom-attributes
 func (s *CustomAttributesService) ListCustomUserAttributes(user int, options ...RequestOptionFunc) ([]*CustomAttribute, *Response, error) {
 	return s.listCustomAttributes("users", user, options...)
 }
@@ -48,7 +48,7 @@ func (s *CustomAttributesService) ListCustomUserAttributes(user int, options ...
 // ListCustomGroupAttributes lists the custom attributes of the specified group.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/custom_attributes.html#list-custom-attributes
+// https://docs.gitlab.com/ee/api/custom_attributes.html#list-custom-attributes
 func (s *CustomAttributesService) ListCustomGroupAttributes(group int, options ...RequestOptionFunc) ([]*CustomAttribute, *Response, error) {
 	return s.listCustomAttributes("groups", group, options...)
 }
@@ -56,7 +56,7 @@ func (s *CustomAttributesService) ListCustomGroupAttributes(group int, options .
 // ListCustomProjectAttributes lists the custom attributes of the specified project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/custom_attributes.html#list-custom-attributes
+// https://docs.gitlab.com/ee/api/custom_attributes.html#list-custom-attributes
 func (s *CustomAttributesService) ListCustomProjectAttributes(project int, options ...RequestOptionFunc) ([]*CustomAttribute, *Response, error) {
 	return s.listCustomAttributes("projects", project, options...)
 }
@@ -79,7 +79,7 @@ func (s *CustomAttributesService) listCustomAttributes(resource string, id int, 
 // GetCustomUserAttribute returns the user attribute with a speciifc key.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/custom_attributes.html#single-custom-attribute
+// https://docs.gitlab.com/ee/api/custom_attributes.html#single-custom-attribute
 func (s *CustomAttributesService) GetCustomUserAttribute(user int, key string, options ...RequestOptionFunc) (*CustomAttribute, *Response, error) {
 	return s.getCustomAttribute("users", user, key, options...)
 }
@@ -87,7 +87,7 @@ func (s *CustomAttributesService) GetCustomUserAttribute(user int, key string, o
 // GetCustomGroupAttribute returns the group attribute with a speciifc key.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/custom_attributes.html#single-custom-attribute
+// https://docs.gitlab.com/ee/api/custom_attributes.html#single-custom-attribute
 func (s *CustomAttributesService) GetCustomGroupAttribute(group int, key string, options ...RequestOptionFunc) (*CustomAttribute, *Response, error) {
 	return s.getCustomAttribute("groups", group, key, options...)
 }
@@ -95,7 +95,7 @@ func (s *CustomAttributesService) GetCustomGroupAttribute(group int, key string,
 // GetCustomProjectAttribute returns the project attribute with a speciifc key.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/custom_attributes.html#single-custom-attribute
+// https://docs.gitlab.com/ee/api/custom_attributes.html#single-custom-attribute
 func (s *CustomAttributesService) GetCustomProjectAttribute(project int, key string, options ...RequestOptionFunc) (*CustomAttribute, *Response, error) {
 	return s.getCustomAttribute("projects", project, key, options...)
 }
@@ -118,7 +118,7 @@ func (s *CustomAttributesService) getCustomAttribute(resource string, id int, ke
 // SetCustomUserAttribute sets the custom attributes of the specified user.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/custom_attributes.html#set-custom-attribute
+// https://docs.gitlab.com/ee/api/custom_attributes.html#set-custom-attribute
 func (s *CustomAttributesService) SetCustomUserAttribute(user int, c CustomAttribute, options ...RequestOptionFunc) (*CustomAttribute, *Response, error) {
 	return s.setCustomAttribute("users", user, c, options...)
 }
@@ -126,7 +126,7 @@ func (s *CustomAttributesService) SetCustomUserAttribute(user int, c CustomAttri
 // SetCustomGroupAttribute sets the custom attributes of the specified group.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/custom_attributes.html#set-custom-attribute
+// https://docs.gitlab.com/ee/api/custom_attributes.html#set-custom-attribute
 func (s *CustomAttributesService) SetCustomGroupAttribute(group int, c CustomAttribute, options ...RequestOptionFunc) (*CustomAttribute, *Response, error) {
 	return s.setCustomAttribute("groups", group, c, options...)
 }
@@ -134,7 +134,7 @@ func (s *CustomAttributesService) SetCustomGroupAttribute(group int, c CustomAtt
 // SetCustomProjectAttribute sets the custom attributes of the specified project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/custom_attributes.html#set-custom-attribute
+// https://docs.gitlab.com/ee/api/custom_attributes.html#set-custom-attribute
 func (s *CustomAttributesService) SetCustomProjectAttribute(project int, c CustomAttribute, options ...RequestOptionFunc) (*CustomAttribute, *Response, error) {
 	return s.setCustomAttribute("projects", project, c, options...)
 }
@@ -157,7 +157,7 @@ func (s *CustomAttributesService) setCustomAttribute(resource string, id int, c 
 // DeleteCustomUserAttribute removes the custom attribute of the specified user.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/custom_attributes.html#delete-custom-attribute
+// https://docs.gitlab.com/ee/api/custom_attributes.html#delete-custom-attribute
 func (s *CustomAttributesService) DeleteCustomUserAttribute(user int, key string, options ...RequestOptionFunc) (*Response, error) {
 	return s.deleteCustomAttribute("users", user, key, options...)
 }
@@ -165,7 +165,7 @@ func (s *CustomAttributesService) DeleteCustomUserAttribute(user int, key string
 // DeleteCustomGroupAttribute removes the custom attribute of the specified group.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/custom_attributes.html#delete-custom-attribute
+// https://docs.gitlab.com/ee/api/custom_attributes.html#delete-custom-attribute
 func (s *CustomAttributesService) DeleteCustomGroupAttribute(group int, key string, options ...RequestOptionFunc) (*Response, error) {
 	return s.deleteCustomAttribute("groups", group, key, options...)
 }
@@ -173,7 +173,7 @@ func (s *CustomAttributesService) DeleteCustomGroupAttribute(group int, key stri
 // DeleteCustomProjectAttribute removes the custom attribute of the specified project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/custom_attributes.html#delete-custom-attribute
+// https://docs.gitlab.com/ee/api/custom_attributes.html#delete-custom-attribute
 func (s *CustomAttributesService) DeleteCustomProjectAttribute(project int, key string, options ...RequestOptionFunc) (*Response, error) {
 	return s.deleteCustomAttribute("projects", project, key, options...)
 }

--- a/deploy_keys.go
+++ b/deploy_keys.go
@@ -25,7 +25,7 @@ import (
 // DeployKeysService handles communication with the keys related methods
 // of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/deploy_keys.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/deploy_keys.html
 type DeployKeysService struct {
 	client *Client
 }
@@ -77,7 +77,7 @@ func (k ProjectDeployKey) String() string {
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/deploy_keys.html#list-all-deploy-keys
+// https://docs.gitlab.com/ee/api/deploy_keys.html#list-all-deploy-keys
 type ListInstanceDeployKeysOptions struct {
 	ListOptions
 	Public *bool `url:"public,omitempty" json:"public,omitempty"`
@@ -86,7 +86,7 @@ type ListInstanceDeployKeysOptions struct {
 // ListAllDeployKeys gets a list of all deploy keys
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/deploy_keys.html#list-all-deploy-keys
+// https://docs.gitlab.com/ee/api/deploy_keys.html#list-all-deploy-keys
 func (s *DeployKeysService) ListAllDeployKeys(opt *ListInstanceDeployKeysOptions, options ...RequestOptionFunc) ([]*InstanceDeployKey, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "deploy_keys", opt, options)
 	if err != nil {
@@ -106,13 +106,13 @@ func (s *DeployKeysService) ListAllDeployKeys(opt *ListInstanceDeployKeysOptions
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/deploy_keys.html#list-project-deploy-keys
+// https://docs.gitlab.com/ee/api/deploy_keys.html#list-project-deploy-keys
 type ListProjectDeployKeysOptions ListOptions
 
 // ListProjectDeployKeys gets a list of a project's deploy keys
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/deploy_keys.html#list-project-deploy-keys
+// https://docs.gitlab.com/ee/api/deploy_keys.html#list-project-deploy-keys
 func (s *DeployKeysService) ListProjectDeployKeys(pid interface{}, opt *ListProjectDeployKeysOptions, options ...RequestOptionFunc) ([]*ProjectDeployKey, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -137,7 +137,7 @@ func (s *DeployKeysService) ListProjectDeployKeys(pid interface{}, opt *ListProj
 // GetDeployKey gets a single deploy key.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/deploy_keys.html#single-deploy-key
+// https://docs.gitlab.com/ee/api/deploy_keys.html#single-deploy-key
 func (s *DeployKeysService) GetDeployKey(pid interface{}, deployKey int, options ...RequestOptionFunc) (*ProjectDeployKey, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -162,7 +162,7 @@ func (s *DeployKeysService) GetDeployKey(pid interface{}, deployKey int, options
 // AddDeployKeyOptions represents the available ADDDeployKey() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/deploy_keys.html#add-deploy-key
+// https://docs.gitlab.com/ee/api/deploy_keys.html#add-deploy-key
 type AddDeployKeyOptions struct {
 	Title   *string `url:"title,omitempty" json:"title,omitempty"`
 	Key     *string `url:"key,omitempty" json:"key,omitempty"`
@@ -174,7 +174,7 @@ type AddDeployKeyOptions struct {
 // original one was is accessible by same user.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/deploy_keys.html#add-deploy-key
+// https://docs.gitlab.com/ee/api/deploy_keys.html#add-deploy-key
 func (s *DeployKeysService) AddDeployKey(pid interface{}, opt *AddDeployKeyOptions, options ...RequestOptionFunc) (*ProjectDeployKey, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -199,7 +199,7 @@ func (s *DeployKeysService) AddDeployKey(pid interface{}, opt *AddDeployKeyOptio
 // DeleteDeployKey deletes a deploy key from a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/deploy_keys.html#delete-deploy-key
+// https://docs.gitlab.com/ee/api/deploy_keys.html#delete-deploy-key
 func (s *DeployKeysService) DeleteDeployKey(pid interface{}, deployKey int, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -218,7 +218,7 @@ func (s *DeployKeysService) DeleteDeployKey(pid interface{}, deployKey int, opti
 // EnableDeployKey enables a deploy key.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/deploy_keys.html#enable-a-deploy-key
+// https://docs.gitlab.com/ee/api/deploy_keys.html#enable-a-deploy-key
 func (s *DeployKeysService) EnableDeployKey(pid interface{}, deployKey int, options ...RequestOptionFunc) (*ProjectDeployKey, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -243,7 +243,7 @@ func (s *DeployKeysService) EnableDeployKey(pid interface{}, deployKey int, opti
 // UpdateDeployKeyOptions represents the available UpdateDeployKey() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/deploy_keys.html#update-deploy-key
+// https://docs.gitlab.com/ee/api/deploy_keys.html#update-deploy-key
 type UpdateDeployKeyOptions struct {
 	Title   *string `url:"title,omitempty" json:"title,omitempty"`
 	CanPush *bool   `url:"can_push,omitempty" json:"can_push,omitempty"`
@@ -252,7 +252,7 @@ type UpdateDeployKeyOptions struct {
 // UpdateDeployKey updates a deploy key for a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/deploy_keys.html#update-deploy-key
+// https://docs.gitlab.com/ee/api/deploy_keys.html#update-deploy-key
 func (s *DeployKeysService) UpdateDeployKey(pid interface{}, deployKey int, opt *UpdateDeployKeyOptions, options ...RequestOptionFunc) (*ProjectDeployKey, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/deploy_keys.go
+++ b/deploy_keys.go
@@ -106,13 +106,13 @@ func (s *DeployKeysService) ListAllDeployKeys(opt *ListInstanceDeployKeysOptions
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/deploy_keys.html#list-project-deploy-keys
+// https://docs.gitlab.com/ee/api/deploy_keys.html#list-deploy-keys-for-project
 type ListProjectDeployKeysOptions ListOptions
 
 // ListProjectDeployKeys gets a list of a project's deploy keys
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/deploy_keys.html#list-project-deploy-keys
+// https://docs.gitlab.com/ee/api/deploy_keys.html#list-deploy-keys-for-project
 func (s *DeployKeysService) ListProjectDeployKeys(pid interface{}, opt *ListProjectDeployKeysOptions, options ...RequestOptionFunc) ([]*ProjectDeployKey, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -137,7 +137,7 @@ func (s *DeployKeysService) ListProjectDeployKeys(pid interface{}, opt *ListProj
 // GetDeployKey gets a single deploy key.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/deploy_keys.html#single-deploy-key
+// https://docs.gitlab.com/ee/api/deploy_keys.html#get-a-single-deploy-key
 func (s *DeployKeysService) GetDeployKey(pid interface{}, deployKey int, options ...RequestOptionFunc) (*ProjectDeployKey, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/deploy_tokens.go
+++ b/deploy_tokens.go
@@ -25,7 +25,7 @@ import (
 // DeployTokensService handles communication with the deploy tokens related methods
 // of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/deploy_tokens.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/deploy_tokens.html
 type DeployTokensService struct {
 	client *Client
 }
@@ -47,7 +47,7 @@ func (k DeployToken) String() string {
 // ListAllDeployTokens gets a list of all deploy tokens.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/deploy_tokens.html#list-all-deploy-tokens
+// https://docs.gitlab.com/ee/api/deploy_tokens.html#list-all-deploy-tokens
 func (s *DeployTokensService) ListAllDeployTokens(options ...RequestOptionFunc) ([]*DeployToken, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "deploy_tokens", nil, options)
 	if err != nil {
@@ -67,13 +67,13 @@ func (s *DeployTokensService) ListAllDeployTokens(options ...RequestOptionFunc) 
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/deploy_tokens.html#list-project-deploy-tokens
+// https://docs.gitlab.com/ee/api/deploy_tokens.html#list-project-deploy-tokens
 type ListProjectDeployTokensOptions ListOptions
 
 // ListProjectDeployTokens gets a list of a project's deploy tokens.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/deploy_tokens.html#list-project-deploy-tokens
+// https://docs.gitlab.com/ee/api/deploy_tokens.html#list-project-deploy-tokens
 func (s *DeployTokensService) ListProjectDeployTokens(pid interface{}, opt *ListProjectDeployTokensOptions, options ...RequestOptionFunc) ([]*DeployToken, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -123,7 +123,7 @@ func (s *DeployTokensService) GetProjectDeployToken(pid interface{}, deployToken
 // CreateProjectDeployTokenOptions represents the available CreateProjectDeployToken() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/deploy_tokens.html#create-a-project-deploy-token
+// https://docs.gitlab.com/ee/api/deploy_tokens.html#create-a-project-deploy-token
 type CreateProjectDeployTokenOptions struct {
 	Name      *string    `url:"name,omitempty" json:"name,omitempty"`
 	ExpiresAt *time.Time `url:"expires_at,omitempty" json:"expires_at,omitempty"`
@@ -134,7 +134,7 @@ type CreateProjectDeployTokenOptions struct {
 // CreateProjectDeployToken creates a new deploy token for a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/deploy_tokens.html#create-a-project-deploy-token
+// https://docs.gitlab.com/ee/api/deploy_tokens.html#create-a-project-deploy-token
 func (s *DeployTokensService) CreateProjectDeployToken(pid interface{}, opt *CreateProjectDeployTokenOptions, options ...RequestOptionFunc) (*DeployToken, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -159,7 +159,7 @@ func (s *DeployTokensService) CreateProjectDeployToken(pid interface{}, opt *Cre
 // DeleteProjectDeployToken removes a deploy token from the project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/deploy_tokens.html#delete-a-project-deploy-token
+// https://docs.gitlab.com/ee/api/deploy_tokens.html#delete-a-project-deploy-token
 func (s *DeployTokensService) DeleteProjectDeployToken(pid interface{}, deployToken int, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -179,13 +179,13 @@ func (s *DeployTokensService) DeleteProjectDeployToken(pid interface{}, deployTo
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/deploy_tokens.html#list-group-deploy-deploy-tokens
+// https://docs.gitlab.com/ee/api/deploy_tokens.html#list-group-deploy-deploy-tokens
 type ListGroupDeployTokensOptions ListOptions
 
 // ListGroupDeployTokens gets a list of a group’s deploy tokens.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/deploy_tokens.html#list-project-deploy-tokens
+// https://docs.gitlab.com/ee/api/deploy_tokens.html#list-project-deploy-tokens
 func (s *DeployTokensService) ListGroupDeployTokens(gid interface{}, opt *ListGroupDeployTokensOptions, options ...RequestOptionFunc) ([]*DeployToken, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -235,7 +235,7 @@ func (s *DeployTokensService) GetGroupDeployToken(gid interface{}, deployToken i
 // CreateGroupDeployTokenOptions represents the available CreateGroupDeployToken() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/deploy_tokens.html#create-a-group-deploy-token
+// https://docs.gitlab.com/ee/api/deploy_tokens.html#create-a-group-deploy-token
 type CreateGroupDeployTokenOptions struct {
 	Name      *string    `url:"name,omitempty" json:"name,omitempty"`
 	ExpiresAt *time.Time `url:"expires_at,omitempty" json:"expires_at,omitempty"`
@@ -246,7 +246,7 @@ type CreateGroupDeployTokenOptions struct {
 // CreateGroupDeployToken creates a new deploy token for a group.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/deploy_tokens.html#create-a-group-deploy-token
+// https://docs.gitlab.com/ee/api/deploy_tokens.html#create-a-group-deploy-token
 func (s *DeployTokensService) CreateGroupDeployToken(gid interface{}, opt *CreateGroupDeployTokenOptions, options ...RequestOptionFunc) (*DeployToken, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -271,7 +271,7 @@ func (s *DeployTokensService) CreateGroupDeployToken(gid interface{}, opt *Creat
 // DeleteGroupDeployToken removes a deploy token from the group.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/deploy_tokens.html#delete-a-group-deploy-token
+// https://docs.gitlab.com/ee/api/deploy_tokens.html#delete-a-group-deploy-token
 func (s *DeployTokensService) DeleteGroupDeployToken(gid interface{}, deployToken int, options ...RequestOptionFunc) (*Response, error) {
 	group, err := parseID(gid)
 	if err != nil {

--- a/deploy_tokens.go
+++ b/deploy_tokens.go
@@ -179,13 +179,13 @@ func (s *DeployTokensService) DeleteProjectDeployToken(pid interface{}, deployTo
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/deploy_tokens.html#list-group-deploy-deploy-tokens
+// https://docs.gitlab.com/ee/api/deploy_tokens.html#list-group-deploy-tokens
 type ListGroupDeployTokensOptions ListOptions
 
 // ListGroupDeployTokens gets a list of a group’s deploy tokens.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/deploy_tokens.html#list-project-deploy-tokens
+// https://docs.gitlab.com/ee/api/deploy_tokens.html#list-group-deploy-tokens
 func (s *DeployTokensService) ListGroupDeployTokens(gid interface{}, opt *ListGroupDeployTokensOptions, options ...RequestOptionFunc) ([]*DeployToken, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {

--- a/deployments.go
+++ b/deployments.go
@@ -24,7 +24,7 @@ import (
 // DeploymentsService handles communication with the deployment related methods
 // of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/deployments.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/deployments.html
 type DeploymentsService struct {
 	client *Client
 }
@@ -69,7 +69,7 @@ type Deployment struct {
 // ListProjectDeploymentsOptions represents the available ListProjectDeployments() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/deployments.html#list-project-deployments
+// https://docs.gitlab.com/ee/api/deployments.html#list-project-deployments
 type ListProjectDeploymentsOptions struct {
 	ListOptions
 	OrderBy     *string `url:"order_by,omitempty" json:"order_by,omitempty"`
@@ -88,7 +88,7 @@ type ListProjectDeploymentsOptions struct {
 
 // ListProjectDeployments gets a list of deployments in a project.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/deployments.html#list-project-deployments
+// GitLab API docs: https://docs.gitlab.com/ee/api/deployments.html#list-project-deployments
 func (s *DeploymentsService) ListProjectDeployments(pid interface{}, opts *ListProjectDeploymentsOptions, options ...RequestOptionFunc) ([]*Deployment, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -112,7 +112,7 @@ func (s *DeploymentsService) ListProjectDeployments(pid interface{}, opts *ListP
 
 // GetProjectDeployment get a deployment for a project.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/deployments.html#get-a-specific-deployment
+// GitLab API docs: https://docs.gitlab.com/ee/api/deployments.html#get-a-specific-deployment
 func (s *DeploymentsService) GetProjectDeployment(pid interface{}, deployment int, options ...RequestOptionFunc) (*Deployment, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/deployments.go
+++ b/deployments.go
@@ -173,14 +173,14 @@ func (s *DeploymentsService) CreateProjectDeployment(pid interface{}, opt *Creat
 // UpdateProjectDeploymentOptions represents the available
 // UpdateProjectDeployment() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/deployments.html#updating-a-deployment
+// GitLab API docs: https://docs.gitlab.com/ee/api/deployments.html#update-a-deployment
 type UpdateProjectDeploymentOptions struct {
 	Status *DeploymentStatusValue `url:"status,omitempty" json:"status,omitempty"`
 }
 
 // UpdateProjectDeployment updates a project deployment.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/deployments.html#updating-a-deployment
+// GitLab API docs: https://docs.gitlab.com/ee/api/deployments.html#update-a-deployment
 func (s *DeploymentsService) UpdateProjectDeployment(pid interface{}, deployment int, opt *UpdateProjectDeploymentOptions, options ...RequestOptionFunc) (*Deployment, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/discussions.go
+++ b/discussions.go
@@ -514,7 +514,7 @@ func (s *DiscussionsService) GetEpicDiscussion(gid interface{}, epic int, discus
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/discussions.html#add-note-to-existing-epic-thread
+// https://docs.gitlab.com/ee/api/discussions.html#create-new-epic-thread
 type CreateEpicDiscussionOptions struct {
 	Body      *string    `url:"body,omitempty" json:"body,omitempty"`
 	CreatedAt *time.Time `url:"created_at,omitempty" json:"created_at,omitempty"`
@@ -524,7 +524,7 @@ type CreateEpicDiscussionOptions struct {
 // discussions are comments users can post to a epic.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/discussions.html#add-note-to-existing-epic-thread
+// https://docs.gitlab.com/ee/api/discussions.html#create-new-epic-thread
 func (s *DiscussionsService) CreateEpicDiscussion(gid interface{}, epic int, opt *CreateEpicDiscussionOptions, options ...RequestOptionFunc) (*Discussion, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -802,7 +802,7 @@ func (s *DiscussionsService) ResolveMergeRequestDiscussion(pid interface{}, merg
 // AddMergeRequestDiscussionNote() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/discussions.html#add-note-to-existing-merge-request-discussion
+// https://docs.gitlab.com/ee/api/discussions.html#add-note-to-existing-merge-request-thread
 type AddMergeRequestDiscussionNoteOptions struct {
 	Body      *string    `url:"body,omitempty" json:"body,omitempty"`
 	CreatedAt *time.Time `url:"created_at,omitempty" json:"created_at,omitempty"`
@@ -812,7 +812,7 @@ type AddMergeRequestDiscussionNoteOptions struct {
 // merge request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/discussions.html#add-note-to-existing-merge-request-discussion
+// https://docs.gitlab.com/ee/api/discussions.html#add-note-to-existing-merge-request-thread
 func (s *DiscussionsService) AddMergeRequestDiscussionNote(pid interface{}, mergeRequest int, discussion string, opt *AddMergeRequestDiscussionNoteOptions, options ...RequestOptionFunc) (*Note, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -842,7 +842,7 @@ func (s *DiscussionsService) AddMergeRequestDiscussionNote(pid interface{}, merg
 // UpdateMergeRequestDiscussion() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/discussions.html#modify-existing-merge-request-discussion-note
+// https://docs.gitlab.com/ee/api/discussions.html#modify-an-existing-merge-request-thread-note
 type UpdateMergeRequestDiscussionNoteOptions struct {
 	Body      *string    `url:"body,omitempty" json:"body,omitempty"`
 	CreatedAt *time.Time `url:"created_at,omitempty" json:"created_at,omitempty"`
@@ -853,7 +853,7 @@ type UpdateMergeRequestDiscussionNoteOptions struct {
 // request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/discussions.html#modify-existing-merge-request-discussion-note
+// https://docs.gitlab.com/ee/api/discussions.html#modify-an-existing-merge-request-thread-note
 func (s *DiscussionsService) UpdateMergeRequestDiscussionNote(pid interface{}, mergeRequest int, discussion string, note int, opt *UpdateMergeRequestDiscussionNoteOptions, options ...RequestOptionFunc) (*Note, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -884,7 +884,7 @@ func (s *DiscussionsService) UpdateMergeRequestDiscussionNote(pid interface{}, m
 // request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/discussions.html#delete-a-merge-request-discussion-note
+// https://docs.gitlab.com/ee/api/discussions.html#delete-a-merge-request-thread-note
 func (s *DiscussionsService) DeleteMergeRequestDiscussionNote(pid interface{}, mergeRequest int, discussion string, note int, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/discussions.go
+++ b/discussions.go
@@ -25,14 +25,14 @@ import (
 // DiscussionsService handles communication with the discussions related
 // methods of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/discussions.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/discussions.html
 type DiscussionsService struct {
 	client *Client
 }
 
 // Discussion represents a GitLab discussion.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/discussions.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/discussions.html
 type Discussion struct {
 	ID             string  `json:"id"`
 	IndividualNote bool    `json:"individual_note"`
@@ -47,14 +47,14 @@ func (d Discussion) String() string {
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#list-project-issue-discussion-items
+// https://docs.gitlab.com/ee/api/discussions.html#list-project-issue-discussion-items
 type ListIssueDiscussionsOptions ListOptions
 
 // ListIssueDiscussions gets a list of all discussions for a single
 // issue.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#list-project-issue-discussion-items
+// https://docs.gitlab.com/ee/api/discussions.html#list-project-issue-discussion-items
 func (s *DiscussionsService) ListIssueDiscussions(pid interface{}, issue int, opt *ListIssueDiscussionsOptions, options ...RequestOptionFunc) ([]*Discussion, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -79,7 +79,7 @@ func (s *DiscussionsService) ListIssueDiscussions(pid interface{}, issue int, op
 // GetIssueDiscussion returns a single discussion for a specific project issue.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#get-single-issue-discussion-item
+// https://docs.gitlab.com/ee/api/discussions.html#get-single-issue-discussion-item
 func (s *DiscussionsService) GetIssueDiscussion(pid interface{}, issue int, discussion string, options ...RequestOptionFunc) (*Discussion, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -109,7 +109,7 @@ func (s *DiscussionsService) GetIssueDiscussion(pid interface{}, issue int, disc
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#create-new-issue-thread
+// https://docs.gitlab.com/ee/api/discussions.html#create-new-issue-thread
 type CreateIssueDiscussionOptions struct {
 	Body      *string    `url:"body,omitempty" json:"body,omitempty"`
 	CreatedAt *time.Time `url:"created_at,omitempty" json:"created_at,omitempty"`
@@ -118,7 +118,7 @@ type CreateIssueDiscussionOptions struct {
 // CreateIssueDiscussion creates a new discussion to a single project issue.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#create-new-issue-thread
+// https://docs.gitlab.com/ee/api/discussions.html#create-new-issue-thread
 func (s *DiscussionsService) CreateIssueDiscussion(pid interface{}, issue int, opt *CreateIssueDiscussionOptions, options ...RequestOptionFunc) (*Discussion, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -144,7 +144,7 @@ func (s *DiscussionsService) CreateIssueDiscussion(pid interface{}, issue int, o
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#add-note-to-existing-issue-thread
+// https://docs.gitlab.com/ee/api/discussions.html#add-note-to-existing-issue-thread
 type AddIssueDiscussionNoteOptions struct {
 	Body      *string    `url:"body,omitempty" json:"body,omitempty"`
 	CreatedAt *time.Time `url:"created_at,omitempty" json:"created_at,omitempty"`
@@ -153,7 +153,7 @@ type AddIssueDiscussionNoteOptions struct {
 // AddIssueDiscussionNote creates a new discussion to a single project issue.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#add-note-to-existing-issue-thread
+// https://docs.gitlab.com/ee/api/discussions.html#add-note-to-existing-issue-thread
 func (s *DiscussionsService) AddIssueDiscussionNote(pid interface{}, issue int, discussion string, opt *AddIssueDiscussionNoteOptions, options ...RequestOptionFunc) (*Note, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -183,7 +183,7 @@ func (s *DiscussionsService) AddIssueDiscussionNote(pid interface{}, issue int, 
 // UpdateIssueDiscussion() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#modify-existing-issue-thread-note
+// https://docs.gitlab.com/ee/api/discussions.html#modify-existing-issue-thread-note
 type UpdateIssueDiscussionNoteOptions struct {
 	Body      *string    `url:"body,omitempty" json:"body,omitempty"`
 	CreatedAt *time.Time `url:"created_at,omitempty" json:"created_at,omitempty"`
@@ -192,7 +192,7 @@ type UpdateIssueDiscussionNoteOptions struct {
 // UpdateIssueDiscussionNote modifies existing discussion of an issue.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#modify-existing-issue-thread-note
+// https://docs.gitlab.com/ee/api/discussions.html#modify-existing-issue-thread-note
 func (s *DiscussionsService) UpdateIssueDiscussionNote(pid interface{}, issue int, discussion string, note int, opt *UpdateIssueDiscussionNoteOptions, options ...RequestOptionFunc) (*Note, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -222,7 +222,7 @@ func (s *DiscussionsService) UpdateIssueDiscussionNote(pid interface{}, issue in
 // DeleteIssueDiscussionNote deletes an existing discussion of an issue.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#delete-an-issue-thread-note
+// https://docs.gitlab.com/ee/api/discussions.html#delete-an-issue-thread-note
 func (s *DiscussionsService) DeleteIssueDiscussionNote(pid interface{}, issue int, discussion string, note int, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -247,14 +247,14 @@ func (s *DiscussionsService) DeleteIssueDiscussionNote(pid interface{}, issue in
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#list-project-snippet-discussion-items
+// https://docs.gitlab.com/ee/api/discussions.html#list-project-snippet-discussion-items
 type ListSnippetDiscussionsOptions ListOptions
 
 // ListSnippetDiscussions gets a list of all discussions for a single
 // snippet. Snippet discussions are comments users can post to a snippet.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#list-project-snippet-discussion-items
+// https://docs.gitlab.com/ee/api/discussions.html#list-project-snippet-discussion-items
 func (s *DiscussionsService) ListSnippetDiscussions(pid interface{}, snippet int, opt *ListSnippetDiscussionsOptions, options ...RequestOptionFunc) ([]*Discussion, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -279,7 +279,7 @@ func (s *DiscussionsService) ListSnippetDiscussions(pid interface{}, snippet int
 // GetSnippetDiscussion returns a single discussion for a given snippet.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#get-single-snippet-discussion-item
+// https://docs.gitlab.com/ee/api/discussions.html#get-single-snippet-discussion-item
 func (s *DiscussionsService) GetSnippetDiscussion(pid interface{}, snippet int, discussion string, options ...RequestOptionFunc) (*Discussion, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -309,7 +309,7 @@ func (s *DiscussionsService) GetSnippetDiscussion(pid interface{}, snippet int, 
 // CreateSnippetDiscussion() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#create-new-snippet-thread
+// https://docs.gitlab.com/ee/api/discussions.html#create-new-snippet-thread
 type CreateSnippetDiscussionOptions struct {
 	Body      *string    `url:"body,omitempty" json:"body,omitempty"`
 	CreatedAt *time.Time `url:"created_at,omitempty" json:"created_at,omitempty"`
@@ -319,7 +319,7 @@ type CreateSnippetDiscussionOptions struct {
 // Snippet discussions are comments users can post to a snippet.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#create-new-snippet-thread
+// https://docs.gitlab.com/ee/api/discussions.html#create-new-snippet-thread
 func (s *DiscussionsService) CreateSnippetDiscussion(pid interface{}, snippet int, opt *CreateSnippetDiscussionOptions, options ...RequestOptionFunc) (*Discussion, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -345,7 +345,7 @@ func (s *DiscussionsService) CreateSnippetDiscussion(pid interface{}, snippet in
 // AddSnippetDiscussionNote() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#add-note-to-existing-snippet-thread
+// https://docs.gitlab.com/ee/api/discussions.html#add-note-to-existing-snippet-thread
 type AddSnippetDiscussionNoteOptions struct {
 	Body      *string    `url:"body,omitempty" json:"body,omitempty"`
 	CreatedAt *time.Time `url:"created_at,omitempty" json:"created_at,omitempty"`
@@ -355,7 +355,7 @@ type AddSnippetDiscussionNoteOptions struct {
 // snippet.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#add-note-to-existing-snippet-thread
+// https://docs.gitlab.com/ee/api/discussions.html#add-note-to-existing-snippet-thread
 func (s *DiscussionsService) AddSnippetDiscussionNote(pid interface{}, snippet int, discussion string, opt *AddSnippetDiscussionNoteOptions, options ...RequestOptionFunc) (*Note, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -385,7 +385,7 @@ func (s *DiscussionsService) AddSnippetDiscussionNote(pid interface{}, snippet i
 // UpdateSnippetDiscussion() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#modify-existing-snippet-thread-note
+// https://docs.gitlab.com/ee/api/discussions.html#modify-existing-snippet-thread-note
 type UpdateSnippetDiscussionNoteOptions struct {
 	Body      *string    `url:"body,omitempty" json:"body,omitempty"`
 	CreatedAt *time.Time `url:"created_at,omitempty" json:"created_at,omitempty"`
@@ -394,7 +394,7 @@ type UpdateSnippetDiscussionNoteOptions struct {
 // UpdateSnippetDiscussionNote modifies existing discussion of a snippet.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#modify-existing-snippet-thread-note
+// https://docs.gitlab.com/ee/api/discussions.html#modify-existing-snippet-thread-note
 func (s *DiscussionsService) UpdateSnippetDiscussionNote(pid interface{}, snippet int, discussion string, note int, opt *UpdateSnippetDiscussionNoteOptions, options ...RequestOptionFunc) (*Note, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -424,7 +424,7 @@ func (s *DiscussionsService) UpdateSnippetDiscussionNote(pid interface{}, snippe
 // DeleteSnippetDiscussionNote deletes an existing discussion of a snippet.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#delete-a-snippet-thread-note
+// https://docs.gitlab.com/ee/api/discussions.html#delete-a-snippet-thread-note
 func (s *DiscussionsService) DeleteSnippetDiscussionNote(pid interface{}, snippet int, discussion string, note int, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -449,14 +449,14 @@ func (s *DiscussionsService) DeleteSnippetDiscussionNote(pid interface{}, snippe
 // ListEpicDiscussions() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#list-group-epic-discussion-items
+// https://docs.gitlab.com/ee/api/discussions.html#list-group-epic-discussion-items
 type ListGroupEpicDiscussionsOptions ListOptions
 
 // ListGroupEpicDiscussions gets a list of all discussions for a single
 // epic. Epic discussions are comments users can post to a epic.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#list-group-epic-discussion-items
+// https://docs.gitlab.com/ee/api/discussions.html#list-group-epic-discussion-items
 func (s *DiscussionsService) ListGroupEpicDiscussions(gid interface{}, epic int, opt *ListGroupEpicDiscussionsOptions, options ...RequestOptionFunc) ([]*Discussion, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -484,7 +484,7 @@ func (s *DiscussionsService) ListGroupEpicDiscussions(gid interface{}, epic int,
 // GetEpicDiscussion returns a single discussion for a given epic.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#get-single-epic-discussion-item
+// https://docs.gitlab.com/ee/api/discussions.html#get-single-epic-discussion-item
 func (s *DiscussionsService) GetEpicDiscussion(gid interface{}, epic int, discussion string, options ...RequestOptionFunc) (*Discussion, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -514,7 +514,7 @@ func (s *DiscussionsService) GetEpicDiscussion(gid interface{}, epic int, discus
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#add-note-to-existing-epic-thread
+// https://docs.gitlab.com/ee/api/discussions.html#add-note-to-existing-epic-thread
 type CreateEpicDiscussionOptions struct {
 	Body      *string    `url:"body,omitempty" json:"body,omitempty"`
 	CreatedAt *time.Time `url:"created_at,omitempty" json:"created_at,omitempty"`
@@ -524,7 +524,7 @@ type CreateEpicDiscussionOptions struct {
 // discussions are comments users can post to a epic.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#add-note-to-existing-epic-thread
+// https://docs.gitlab.com/ee/api/discussions.html#add-note-to-existing-epic-thread
 func (s *DiscussionsService) CreateEpicDiscussion(gid interface{}, epic int, opt *CreateEpicDiscussionOptions, options ...RequestOptionFunc) (*Discussion, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -553,7 +553,7 @@ func (s *DiscussionsService) CreateEpicDiscussion(gid interface{}, epic int, opt
 // AddEpicDiscussionNote() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#add-note-to-existing-epic-thread
+// https://docs.gitlab.com/ee/api/discussions.html#add-note-to-existing-epic-thread
 type AddEpicDiscussionNoteOptions struct {
 	Body      *string    `url:"body,omitempty" json:"body,omitempty"`
 	CreatedAt *time.Time `url:"created_at,omitempty" json:"created_at,omitempty"`
@@ -562,7 +562,7 @@ type AddEpicDiscussionNoteOptions struct {
 // AddEpicDiscussionNote creates a new discussion to a single project epic.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#add-note-to-existing-epic-thread
+// https://docs.gitlab.com/ee/api/discussions.html#add-note-to-existing-epic-thread
 func (s *DiscussionsService) AddEpicDiscussionNote(gid interface{}, epic int, discussion string, opt *AddEpicDiscussionNoteOptions, options ...RequestOptionFunc) (*Note, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -592,7 +592,7 @@ func (s *DiscussionsService) AddEpicDiscussionNote(gid interface{}, epic int, di
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#modify-existing-epic-thread-note
+// https://docs.gitlab.com/ee/api/discussions.html#modify-existing-epic-thread-note
 type UpdateEpicDiscussionNoteOptions struct {
 	Body      *string    `url:"body,omitempty" json:"body,omitempty"`
 	CreatedAt *time.Time `url:"created_at,omitempty" json:"created_at,omitempty"`
@@ -601,7 +601,7 @@ type UpdateEpicDiscussionNoteOptions struct {
 // UpdateEpicDiscussionNote modifies existing discussion of a epic.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#modify-existing-epic-thread-note
+// https://docs.gitlab.com/ee/api/discussions.html#modify-existing-epic-thread-note
 func (s *DiscussionsService) UpdateEpicDiscussionNote(gid interface{}, epic int, discussion string, note int, opt *UpdateEpicDiscussionNoteOptions, options ...RequestOptionFunc) (*Note, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -631,7 +631,7 @@ func (s *DiscussionsService) UpdateEpicDiscussionNote(gid interface{}, epic int,
 // DeleteEpicDiscussionNote deletes an existing discussion of a epic.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#delete-an-epic-thread-note
+// https://docs.gitlab.com/ee/api/discussions.html#delete-an-epic-thread-note
 func (s *DiscussionsService) DeleteEpicDiscussionNote(gid interface{}, epic int, discussion string, note int, options ...RequestOptionFunc) (*Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -656,14 +656,14 @@ func (s *DiscussionsService) DeleteEpicDiscussionNote(gid interface{}, epic int,
 // ListMergeRequestDiscussions() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#list-project-merge-request-discussion-items
+// https://docs.gitlab.com/ee/api/discussions.html#list-project-merge-request-discussion-items
 type ListMergeRequestDiscussionsOptions ListOptions
 
 // ListMergeRequestDiscussions gets a list of all discussions for a single
 // merge request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#list-project-merge-request-discussion-items
+// https://docs.gitlab.com/ee/api/discussions.html#list-project-merge-request-discussion-items
 func (s *DiscussionsService) ListMergeRequestDiscussions(pid interface{}, mergeRequest int, opt *ListMergeRequestDiscussionsOptions, options ...RequestOptionFunc) ([]*Discussion, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -692,7 +692,7 @@ func (s *DiscussionsService) ListMergeRequestDiscussions(pid interface{}, mergeR
 // request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#get-single-merge-request-discussion-item
+// https://docs.gitlab.com/ee/api/discussions.html#get-single-merge-request-discussion-item
 func (s *DiscussionsService) GetMergeRequestDiscussion(pid interface{}, mergeRequest int, discussion string, options ...RequestOptionFunc) (*Discussion, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -722,7 +722,7 @@ func (s *DiscussionsService) GetMergeRequestDiscussion(pid interface{}, mergeReq
 // CreateMergeRequestDiscussion() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#create-new-merge-request-thread
+// https://docs.gitlab.com/ee/api/discussions.html#create-new-merge-request-thread
 type CreateMergeRequestDiscussionOptions struct {
 	Body      *string       `url:"body,omitempty" json:"body,omitempty"`
 	CommitID  *string       `url:"commit_id,omitempty" json:"commit_id,omitempty"`
@@ -734,7 +734,7 @@ type CreateMergeRequestDiscussionOptions struct {
 // request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#create-new-merge-request-thread
+// https://docs.gitlab.com/ee/api/discussions.html#create-new-merge-request-thread
 func (s *DiscussionsService) CreateMergeRequestDiscussion(pid interface{}, mergeRequest int, opt *CreateMergeRequestDiscussionOptions, options ...RequestOptionFunc) (*Discussion, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -763,7 +763,7 @@ func (s *DiscussionsService) CreateMergeRequestDiscussion(pid interface{}, merge
 // ResolveMergeRequestDiscussion() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#resolve-a-merge-request-thread
+// https://docs.gitlab.com/ee/api/discussions.html#resolve-a-merge-request-thread
 type ResolveMergeRequestDiscussionOptions struct {
 	Resolved *bool `url:"resolved,omitempty" json:"resolved,omitempty"`
 }
@@ -772,7 +772,7 @@ type ResolveMergeRequestDiscussionOptions struct {
 // request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#resolve-a-merge-request-thread
+// https://docs.gitlab.com/ee/api/discussions.html#resolve-a-merge-request-thread
 func (s *DiscussionsService) ResolveMergeRequestDiscussion(pid interface{}, mergeRequest int, discussion string, opt *ResolveMergeRequestDiscussionOptions, options ...RequestOptionFunc) (*Discussion, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -802,7 +802,7 @@ func (s *DiscussionsService) ResolveMergeRequestDiscussion(pid interface{}, merg
 // AddMergeRequestDiscussionNote() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#add-note-to-existing-merge-request-discussion
+// https://docs.gitlab.com/ee/api/discussions.html#add-note-to-existing-merge-request-discussion
 type AddMergeRequestDiscussionNoteOptions struct {
 	Body      *string    `url:"body,omitempty" json:"body,omitempty"`
 	CreatedAt *time.Time `url:"created_at,omitempty" json:"created_at,omitempty"`
@@ -812,7 +812,7 @@ type AddMergeRequestDiscussionNoteOptions struct {
 // merge request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#add-note-to-existing-merge-request-discussion
+// https://docs.gitlab.com/ee/api/discussions.html#add-note-to-existing-merge-request-discussion
 func (s *DiscussionsService) AddMergeRequestDiscussionNote(pid interface{}, mergeRequest int, discussion string, opt *AddMergeRequestDiscussionNoteOptions, options ...RequestOptionFunc) (*Note, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -842,7 +842,7 @@ func (s *DiscussionsService) AddMergeRequestDiscussionNote(pid interface{}, merg
 // UpdateMergeRequestDiscussion() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#modify-existing-merge-request-discussion-note
+// https://docs.gitlab.com/ee/api/discussions.html#modify-existing-merge-request-discussion-note
 type UpdateMergeRequestDiscussionNoteOptions struct {
 	Body      *string    `url:"body,omitempty" json:"body,omitempty"`
 	CreatedAt *time.Time `url:"created_at,omitempty" json:"created_at,omitempty"`
@@ -853,7 +853,7 @@ type UpdateMergeRequestDiscussionNoteOptions struct {
 // request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#modify-existing-merge-request-discussion-note
+// https://docs.gitlab.com/ee/api/discussions.html#modify-existing-merge-request-discussion-note
 func (s *DiscussionsService) UpdateMergeRequestDiscussionNote(pid interface{}, mergeRequest int, discussion string, note int, opt *UpdateMergeRequestDiscussionNoteOptions, options ...RequestOptionFunc) (*Note, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -884,7 +884,7 @@ func (s *DiscussionsService) UpdateMergeRequestDiscussionNote(pid interface{}, m
 // request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#delete-a-merge-request-discussion-note
+// https://docs.gitlab.com/ee/api/discussions.html#delete-a-merge-request-discussion-note
 func (s *DiscussionsService) DeleteMergeRequestDiscussionNote(pid interface{}, mergeRequest int, discussion string, note int, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -909,14 +909,14 @@ func (s *DiscussionsService) DeleteMergeRequestDiscussionNote(pid interface{}, m
 // ListCommitDiscussions() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#list-project-commit-discussion-items
+// https://docs.gitlab.com/ee/api/discussions.html#list-project-commit-discussion-items
 type ListCommitDiscussionsOptions ListOptions
 
 // ListCommitDiscussions gets a list of all discussions for a single
 // commit.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#list-project-commit-discussion-items
+// https://docs.gitlab.com/ee/api/discussions.html#list-project-commit-discussion-items
 func (s *DiscussionsService) ListCommitDiscussions(pid interface{}, commit string, opt *ListCommitDiscussionsOptions, options ...RequestOptionFunc) ([]*Discussion, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -945,7 +945,7 @@ func (s *DiscussionsService) ListCommitDiscussions(pid interface{}, commit strin
 // commit.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#get-single-commit-discussion-item
+// https://docs.gitlab.com/ee/api/discussions.html#get-single-commit-discussion-item
 func (s *DiscussionsService) GetCommitDiscussion(pid interface{}, commit string, discussion string, options ...RequestOptionFunc) (*Discussion, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -975,7 +975,7 @@ func (s *DiscussionsService) GetCommitDiscussion(pid interface{}, commit string,
 // CreateCommitDiscussion() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#create-new-commit-thread
+// https://docs.gitlab.com/ee/api/discussions.html#create-new-commit-thread
 type CreateCommitDiscussionOptions struct {
 	Body      *string       `url:"body,omitempty" json:"body,omitempty"`
 	CreatedAt *time.Time    `url:"created_at,omitempty" json:"created_at,omitempty"`
@@ -985,7 +985,7 @@ type CreateCommitDiscussionOptions struct {
 // CreateCommitDiscussion creates a new discussion to a single project commit.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#create-new-commit-thread
+// https://docs.gitlab.com/ee/api/discussions.html#create-new-commit-thread
 func (s *DiscussionsService) CreateCommitDiscussion(pid interface{}, commit string, opt *CreateCommitDiscussionOptions, options ...RequestOptionFunc) (*Discussion, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -1014,7 +1014,7 @@ func (s *DiscussionsService) CreateCommitDiscussion(pid interface{}, commit stri
 // AddCommitDiscussionNote() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#add-note-to-existing-commit-thread
+// https://docs.gitlab.com/ee/api/discussions.html#add-note-to-existing-commit-thread
 type AddCommitDiscussionNoteOptions struct {
 	Body      *string    `url:"body,omitempty" json:"body,omitempty"`
 	CreatedAt *time.Time `url:"created_at,omitempty" json:"created_at,omitempty"`
@@ -1023,7 +1023,7 @@ type AddCommitDiscussionNoteOptions struct {
 // AddCommitDiscussionNote creates a new discussion to a single project commit.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#add-note-to-existing-commit-thread
+// https://docs.gitlab.com/ee/api/discussions.html#add-note-to-existing-commit-thread
 func (s *DiscussionsService) AddCommitDiscussionNote(pid interface{}, commit string, discussion string, opt *AddCommitDiscussionNoteOptions, options ...RequestOptionFunc) (*Note, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -1053,7 +1053,7 @@ func (s *DiscussionsService) AddCommitDiscussionNote(pid interface{}, commit str
 // UpdateCommitDiscussion() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#modify-an-existing-commit-thread-note
+// https://docs.gitlab.com/ee/api/discussions.html#modify-an-existing-commit-thread-note
 type UpdateCommitDiscussionNoteOptions struct {
 	Body      *string    `url:"body,omitempty" json:"body,omitempty"`
 	CreatedAt *time.Time `url:"created_at,omitempty" json:"created_at,omitempty"`
@@ -1062,7 +1062,7 @@ type UpdateCommitDiscussionNoteOptions struct {
 // UpdateCommitDiscussionNote modifies existing discussion of an commit.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#modify-an-existing-commit-thread-note
+// https://docs.gitlab.com/ee/api/discussions.html#modify-an-existing-commit-thread-note
 func (s *DiscussionsService) UpdateCommitDiscussionNote(pid interface{}, commit string, discussion string, note int, opt *UpdateCommitDiscussionNoteOptions, options ...RequestOptionFunc) (*Note, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -1092,7 +1092,7 @@ func (s *DiscussionsService) UpdateCommitDiscussionNote(pid interface{}, commit 
 // DeleteCommitDiscussionNote deletes an existing discussion of an commit.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/discussions.html#delete-a-commit-thread-note
+// https://docs.gitlab.com/ee/api/discussions.html#delete-a-commit-thread-note
 func (s *DiscussionsService) DeleteCommitDiscussionNote(pid interface{}, commit string, discussion string, note int, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/dockerfile_templates.go
+++ b/dockerfile_templates.go
@@ -25,14 +25,14 @@ import (
 // DockerfileTemplatesService handles communication with the Dockerfile
 // templates related methods of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/templates/dockerfiles.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/templates/dockerfiles.html
 type DockerfileTemplatesService struct {
 	client *Client
 }
 
 // DockerfileTemplate represents a GitLab Dockerfile template.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/templates/dockerfiles.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/templates/dockerfiles.html
 type DockerfileTemplate struct {
 	Name    string `json:"name"`
 	Content string `json:"content"`
@@ -40,7 +40,7 @@ type DockerfileTemplate struct {
 
 // DockerfileTemplateListItem represents a GitLab Dockerfile template from the list.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/templates/dockerfiles.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/templates/dockerfiles.html
 type DockerfileTemplateListItem struct {
 	Key  string `json:"key"`
 	Name string `json:"name"`

--- a/environments.go
+++ b/environments.go
@@ -25,14 +25,14 @@ import (
 // EnvironmentsService handles communication with the environment related methods
 // of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/environments.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/environments.html
 type EnvironmentsService struct {
 	client *Client
 }
 
 // Environment represents a GitLab environment.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/environments.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/environments.html
 type Environment struct {
 	ID             int         `json:"id"`
 	Name           string      `json:"name"`
@@ -188,7 +188,7 @@ func (s *EnvironmentsService) EditEnvironment(pid interface{}, environment int, 
 // DeleteEnvironment removes an environment from a project team.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/environments.html#remove-a-environment-from-a-group-or-project
+// https://docs.gitlab.com/ee/api/environments.html#remove-a-environment-from-a-group-or-project
 func (s *EnvironmentsService) DeleteEnvironment(pid interface{}, environment int, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -207,7 +207,7 @@ func (s *EnvironmentsService) DeleteEnvironment(pid interface{}, environment int
 // StopEnvironment stop an environment from a project team.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/environments.html#stop-an-environment
+// https://docs.gitlab.com/ee/api/environments.html#stop-an-environment
 func (s *EnvironmentsService) StopEnvironment(pid interface{}, environmentID int, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/environments.go
+++ b/environments.go
@@ -153,7 +153,7 @@ func (s *EnvironmentsService) CreateEnvironment(pid interface{}, opt *CreateEnvi
 // EditEnvironmentOptions represents the available EditEnvironment() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/environments.html#edit-an-existing-environment
+// https://docs.gitlab.com/ee/api/environments.html#update-an-existing-environment
 type EditEnvironmentOptions struct {
 	Name        *string `url:"name,omitempty" json:"name,omitempty"`
 	ExternalURL *string `url:"external_url,omitempty" json:"external_url,omitempty"`
@@ -163,7 +163,7 @@ type EditEnvironmentOptions struct {
 // EditEnvironment updates a project team environment to a specified access level..
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/environments.html#edit-an-existing-environment
+// https://docs.gitlab.com/ee/api/environments.html#update-an-existing-environment
 func (s *EnvironmentsService) EditEnvironment(pid interface{}, environment int, opt *EditEnvironmentOptions, options ...RequestOptionFunc) (*Environment, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -188,7 +188,7 @@ func (s *EnvironmentsService) EditEnvironment(pid interface{}, environment int, 
 // DeleteEnvironment removes an environment from a project team.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/environments.html#remove-a-environment-from-a-group-or-project
+// https://docs.gitlab.com/ee/api/environments.html#delete-an-environment
 func (s *EnvironmentsService) DeleteEnvironment(pid interface{}, environment int, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/error_tracking.go
+++ b/error_tracking.go
@@ -46,7 +46,7 @@ func (p ErrorTrackingClientKey) String() string {
 
 // ErrorTrackingSettings represents error tracking settings for a GitLab project.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/error_tracking.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/error_tracking.html#error-tracking-project-settings
 type ErrorTrackingSettings struct {
 	Active            bool   `json:"active"`
 	ProjectName       string `json:"project_name"`

--- a/event_systemhook_types.go
+++ b/event_systemhook_types.go
@@ -28,7 +28,7 @@ type systemHookEvent struct {
 // BaseSystemEvent contains system hook's common properties.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/system_hooks/system_hooks.html
+// https://docs.gitlab.com/ee/administration/system_hooks.html
 type BaseSystemEvent struct {
 	EventName string `json:"event_name"`
 	CreatedAt string `json:"created_at"`
@@ -38,7 +38,7 @@ type BaseSystemEvent struct {
 // ProjectSystemEvent represents a project system event.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/system_hooks/system_hooks.html
+// https://docs.gitlab.com/ee/administration/system_hooks.html
 type ProjectSystemEvent struct {
 	BaseSystemEvent
 	Name                 string `json:"name"`
@@ -54,7 +54,7 @@ type ProjectSystemEvent struct {
 // GroupSystemEvent represents a group system event.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/system_hooks/system_hooks.html
+// https://docs.gitlab.com/ee/administration/system_hooks.html
 type GroupSystemEvent struct {
 	BaseSystemEvent
 	Name                 string `json:"name"`
@@ -71,7 +71,7 @@ type GroupSystemEvent struct {
 // KeySystemEvent represents a key system event.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/system_hooks/system_hooks.html
+// https://docs.gitlab.com/ee/administration/system_hooks.html
 type KeySystemEvent struct {
 	BaseSystemEvent
 	ID       int    `json:"id"`
@@ -82,7 +82,7 @@ type KeySystemEvent struct {
 // UserSystemEvent represents a user system event.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/system_hooks/system_hooks.html
+// https://docs.gitlab.com/ee/administration/system_hooks.html
 type UserSystemEvent struct {
 	BaseSystemEvent
 	ID          int    `json:"user_id"`
@@ -95,7 +95,7 @@ type UserSystemEvent struct {
 // UserGroupSystemEvent represents a user group system event.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/system_hooks/system_hooks.html
+// https://docs.gitlab.com/ee/administration/system_hooks.html
 type UserGroupSystemEvent struct {
 	BaseSystemEvent
 	ID          int    `json:"user_id"`
@@ -111,7 +111,7 @@ type UserGroupSystemEvent struct {
 // UserTeamSystemEvent represents a user team system event.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/system_hooks/system_hooks.html
+// https://docs.gitlab.com/ee/administration/system_hooks.html
 type UserTeamSystemEvent struct {
 	BaseSystemEvent
 	ID                       int    `json:"user_id"`
@@ -129,7 +129,7 @@ type UserTeamSystemEvent struct {
 // PushSystemEvent represents a push system event.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/system_hooks/system_hooks.html
+// https://docs.gitlab.com/ee/administration/system_hooks.html#push-events
 type PushSystemEvent struct {
 	BaseSystemEvent
 	Before       string `json:"before"`
@@ -172,7 +172,7 @@ type PushSystemEvent struct {
 // TagPushSystemEvent represents a tag push system event.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/system_hooks/system_hooks.html
+// https://docs.gitlab.com/ee/administration/system_hooks.html#tag-events
 type TagPushSystemEvent struct {
 	BaseSystemEvent
 	Before       string `json:"before"`
@@ -215,7 +215,7 @@ type TagPushSystemEvent struct {
 // RepositoryUpdateSystemEvent represents a repository updated system event.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/system_hooks/system_hooks.html
+// https://docs.gitlab.com/ee/administration/system_hooks.html#repository-update-events
 type RepositoryUpdateSystemEvent struct {
 	BaseSystemEvent
 	UserID     int    `json:"user_id"`

--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -41,7 +41,7 @@ const (
 // BuildEvent represents a build event.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/user/project/integrations/webhooks.html#build-events
+// https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#build-events
 type BuildEvent struct {
 	ObjectKind        string     `json:"object_kind"`
 	Ref               string     `json:"ref"`
@@ -77,7 +77,7 @@ type BuildEvent struct {
 // CommitCommentEvent represents a comment on a commit event.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/user/project/integrations/webhook_events.html#comment-on-a-commit
+// https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#comment-on-a-commit
 type CommitCommentEvent struct {
 	ObjectKind string `json:"object_kind"`
 	User       *User  `json:"user"`
@@ -141,7 +141,7 @@ type CommitCommentEvent struct {
 // DeploymentEvent represents a deployment event
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/user/project/integrations/webhook_events.html#deployment-events
+// https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#deployment-events
 type DeploymentEvent struct {
 	ObjectKind    string `json:"object_kind"`
 	Status        string `json:"status"`
@@ -177,7 +177,7 @@ type DeploymentEvent struct {
 // IssueCommentEvent represents a comment on an issue event.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/user/project/integrations/webhook_events.html#comment-on-an-issue
+// https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#comment-on-an-issue
 type IssueCommentEvent struct {
 	ObjectKind string `json:"object_kind"`
 	User       *User  `json:"user"`
@@ -248,7 +248,7 @@ type IssueCommentEvent struct {
 // IssueEvent represents a issue event.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/user/project/integrations/webhook_events.html#issue-events
+// https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#issue-events
 type IssueEvent struct {
 	ObjectKind string     `json:"object_kind"`
 	User       *EventUser `json:"user"`
@@ -501,7 +501,7 @@ type MergeCommentEvent struct {
 // MergeEvent represents a merge event.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/user/project/integrations/webhook_events.html#merge-request-events
+// https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#merge-request-events
 type MergeEvent struct {
 	ObjectKind string     `json:"object_kind"`
 	User       *EventUser `json:"user"`
@@ -688,7 +688,7 @@ func (p *MergeParams) UnmarshalJSON(b []byte) error {
 // PipelineEvent represents a pipeline event.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/user/project/integrations/webhook_events.html#pipeline-events
+// https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#pipeline-events
 type PipelineEvent struct {
 	ObjectKind       string `json:"object_kind"`
 	ObjectAttributes struct {
@@ -787,7 +787,7 @@ type PipelineEvent struct {
 // PushEvent represents a push event.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/user/project/integrations/webhook_events.html#push-events
+// https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#push-events
 type PushEvent struct {
 	ObjectKind   string `json:"object_kind"`
 	Before       string `json:"before"`
@@ -837,7 +837,7 @@ type PushEvent struct {
 // ReleaseEvent represents a release event
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/user/project/integrations/webhook_events.html#release-events
+// https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#release-events
 type ReleaseEvent struct {
 	ID          int    `json:"id"`
 	CreatedAt   string `json:"created_at"` // Should be *time.Time (see Gitlab issue #21468)
@@ -974,7 +974,7 @@ type SubGroupEvent struct {
 // TagEvent represents a tag event.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/user/project/integrations/webhook_events.html#tag-events
+// https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#tag-events
 type TagEvent struct {
 	ObjectKind   string `json:"object_kind"`
 	Before       string `json:"before"`
@@ -1025,7 +1025,7 @@ type TagEvent struct {
 // WikiPageEvent represents a wiki page event.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/user/project/integrations/webhook_events.html#wiki-page-events
+// https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#wiki-page-events
 type WikiPageEvent struct {
 	ObjectKind string     `json:"object_kind"`
 	User       *EventUser `json:"user"`

--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -41,7 +41,7 @@ const (
 // BuildEvent represents a build event.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#build-events
+// https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#job-events
 type BuildEvent struct {
 	ObjectKind        string     `json:"object_kind"`
 	Ref               string     `json:"ref"`

--- a/events.go
+++ b/events.go
@@ -25,7 +25,7 @@ import (
 // EventsService handles communication with the event related methods of
 // the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/events.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/events.html
 type EventsService struct {
 	client *Client
 }
@@ -33,7 +33,7 @@ type EventsService struct {
 // ContributionEvent represents a user's contribution
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/events.html#get-user-contribution-events
+// https://docs.gitlab.com/ee/api/events.html#get-user-contribution-events
 type ContributionEvent struct {
 	ID          int        `json:"id"`
 	Title       string     `json:"title"`
@@ -69,7 +69,7 @@ type ContributionEvent struct {
 // ListContributionEventsOptions represents the options for GetUserContributionEvents
 //
 // GitLap API docs:
-// https://docs.gitlab.com/ce/api/events.html#get-user-contribution-events
+// https://docs.gitlab.com/ee/api/events.html#get-user-contribution-events
 type ListContributionEventsOptions struct {
 	ListOptions
 	Action     *EventTypeValue       `url:"action,omitempty" json:"action,omitempty"`
@@ -83,7 +83,7 @@ type ListContributionEventsOptions struct {
 // for the specified user, sorted from newest to oldest.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/events.html#get-user-contribution-events
+// https://docs.gitlab.com/ee/api/events.html#get-user-contribution-events
 func (s *UsersService) ListUserContributionEvents(uid interface{}, opt *ListContributionEventsOptions, options ...RequestOptionFunc) ([]*ContributionEvent, *Response, error) {
 	user, err := parseID(uid)
 	if err != nil {
@@ -107,7 +107,7 @@ func (s *UsersService) ListUserContributionEvents(uid interface{}, opt *ListCont
 
 // ListCurrentUserContributionEvents gets a list currently authenticated user's events
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/events.html#list-currently-authenticated-user-39-s-events
+// GitLab API docs: https://docs.gitlab.com/ee/api/events.html#list-currently-authenticated-user-39-s-events
 func (s *EventsService) ListCurrentUserContributionEvents(opt *ListContributionEventsOptions, options ...RequestOptionFunc) ([]*ContributionEvent, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "events", opt, options)
 	if err != nil {

--- a/events.go
+++ b/events.go
@@ -107,7 +107,7 @@ func (s *UsersService) ListUserContributionEvents(uid interface{}, opt *ListCont
 
 // ListCurrentUserContributionEvents gets a list currently authenticated user's events
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/events.html#list-currently-authenticated-user-39-s-events
+// GitLab API docs: https://docs.gitlab.com/ee/api/events.html#list-currently-authenticated-users-events
 func (s *EventsService) ListCurrentUserContributionEvents(opt *ListContributionEventsOptions, options ...RequestOptionFunc) ([]*ContributionEvent, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "events", opt, options)
 	if err != nil {
@@ -125,7 +125,7 @@ func (s *EventsService) ListCurrentUserContributionEvents(opt *ListContributionE
 
 // ListProjectVisibleEvents gets a list of visible events for a particular project
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/events.html#list-a-project-s-visible-events
+// GitLab API docs: https://docs.gitlab.com/ee/api/events.html#list-a-projects-visible-events
 func (s *EventsService) ListProjectVisibleEvents(pid interface{}, opt *ListContributionEventsOptions, options ...RequestOptionFunc) ([]*ContributionEvent, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/feature_flags.go
+++ b/feature_flags.go
@@ -25,14 +25,14 @@ import (
 // FeaturesService handles the communication with the application FeaturesService
 // related methods of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/features.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/features.html
 type FeaturesService struct {
 	client *Client
 }
 
 // Feature represents a GitLab feature flag.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/features.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/features.html
 type Feature struct {
 	Name  string `json:"name"`
 	State string `json:"state"`
@@ -41,7 +41,7 @@ type Feature struct {
 
 // Gate represents a gate of a GitLab feature flag.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/features.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/features.html
 type Gate struct {
 	Key   string      `json:"key"`
 	Value interface{} `json:"value"`
@@ -54,7 +54,7 @@ func (f Feature) String() string {
 // ListFeatures gets a list of feature flags
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/features.html#list-all-features
+// https://docs.gitlab.com/ee/api/features.html#list-all-features
 func (s *FeaturesService) ListFeatures(options ...RequestOptionFunc) ([]*Feature, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "features", nil, options)
 	if err != nil {
@@ -72,7 +72,7 @@ func (s *FeaturesService) ListFeatures(options ...RequestOptionFunc) ([]*Feature
 // SetFeatureFlag sets or creates a feature flag gate
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/features.html#set-or-create-a-feature
+// https://docs.gitlab.com/ee/api/features.html#set-or-create-a-feature
 func (s *FeaturesService) SetFeatureFlag(name string, value interface{}, options ...RequestOptionFunc) (*Feature, *Response, error) {
 	u := fmt.Sprintf("features/%s", url.PathEscape(name))
 

--- a/freeze_periods.go
+++ b/freeze_periods.go
@@ -25,7 +25,7 @@ import (
 // FreezePeriodsService handles the communication with the freeze periods
 // related methods of the GitLab API.
 //
-// https://docs.gitlab.com/ce/api/freeze_periods.html
+// https://docs.gitlab.com/ee/api/freeze_periods.html
 type FreezePeriodsService struct {
 	client *Client
 }
@@ -33,7 +33,7 @@ type FreezePeriodsService struct {
 // FreezePeriod represents a freeze period object.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/freeze_periods.html#list-freeze-periods
+// https://docs.gitlab.com/ee/api/freeze_periods.html#list-freeze-periods
 type FreezePeriod struct {
 	ID           int        `json:"id"`
 	FreezeStart  string     `json:"freeze_start"`
@@ -47,13 +47,13 @@ type FreezePeriod struct {
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/freeze_periods.html#list-freeze-periods
+// https://docs.gitlab.com/ee/api/freeze_periods.html#list-freeze-periods
 type ListFreezePeriodsOptions ListOptions
 
 // ListFreezePeriods gets a list of project project freeze periods.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/freeze_periods.html#list-freeze-periods
+// https://docs.gitlab.com/ee/api/freeze_periods.html#list-freeze-periods
 func (s *FreezePeriodsService) ListFreezePeriods(pid interface{}, opt *ListFreezePeriodsOptions, options ...RequestOptionFunc) ([]*FreezePeriod, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -78,7 +78,7 @@ func (s *FreezePeriodsService) ListFreezePeriods(pid interface{}, opt *ListFreez
 // GetFreezePeriod gets a specific freeze period for a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/freeze_periods.html#get-a-freeze-period-by-a-freeze_period_id
+// https://docs.gitlab.com/ee/api/freeze_periods.html#get-a-freeze-period-by-a-freeze_period_id
 func (s *FreezePeriodsService) GetFreezePeriod(pid interface{}, freezePeriod int, options ...RequestOptionFunc) (*FreezePeriod, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -104,7 +104,7 @@ func (s *FreezePeriodsService) GetFreezePeriod(pid interface{}, freezePeriod int
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/freeze_periods.html#create-a-freeze-period
+// https://docs.gitlab.com/ee/api/freeze_periods.html#create-a-freeze-period
 type CreateFreezePeriodOptions struct {
 	FreezeStart  *string `url:"freeze_start,omitempty" json:"freeze_start,omitempty"`
 	FreezeEnd    *string `url:"freeze_end,omitempty" json:"freeze_end,omitempty"`
@@ -114,7 +114,7 @@ type CreateFreezePeriodOptions struct {
 // CreateFreezePeriodOptions adds a freeze period to a specified project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/freeze_periods.html#create-a-freeze-period
+// https://docs.gitlab.com/ee/api/freeze_periods.html#create-a-freeze-period
 func (s *FreezePeriodsService) CreateFreezePeriodOptions(pid interface{}, opt *CreateFreezePeriodOptions, options ...RequestOptionFunc) (*FreezePeriod, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -140,7 +140,7 @@ func (s *FreezePeriodsService) CreateFreezePeriodOptions(pid interface{}, opt *C
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/freeze_periods.html#update-a-freeze-period
+// https://docs.gitlab.com/ee/api/freeze_periods.html#update-a-freeze-period
 type UpdateFreezePeriodOptions struct {
 	FreezeStart  *string `url:"freeze_start,omitempty" json:"freeze_start,omitempty"`
 	FreezeEnd    *string `url:"freeze_end,omitempty" json:"freeze_end,omitempty"`
@@ -150,7 +150,7 @@ type UpdateFreezePeriodOptions struct {
 // UpdateFreezePeriodOptions edits a freeze period for a specified project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/freeze_periods.html#update-a-freeze-period
+// https://docs.gitlab.com/ee/api/freeze_periods.html#update-a-freeze-period
 func (s *FreezePeriodsService) UpdateFreezePeriodOptions(pid interface{}, freezePeriod int, opt *UpdateFreezePeriodOptions, options ...RequestOptionFunc) (*FreezePeriod, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -177,7 +177,7 @@ func (s *FreezePeriodsService) UpdateFreezePeriodOptions(pid interface{}, freeze
 // available or not.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/freeze_periods.html#delete-a-freeze-period
+// https://docs.gitlab.com/ee/api/freeze_periods.html#delete-a-freeze-period
 func (s *FreezePeriodsService) DeleteFreezePeriod(pid interface{}, freezePeriod int, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/gitignore_templates.go
+++ b/gitignore_templates.go
@@ -49,13 +49,13 @@ type GitIgnoreTemplateListItem struct {
 // ListTemplatesOptions represents the available ListAllTemplates() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/templates/gitignores.html#list-gitignore-templates
+// https://docs.gitlab.com/ee/api/templates/gitignores.html#get-all-gitignore-templates
 type ListTemplatesOptions ListOptions
 
 // ListTemplates get a list of available git ignore templates
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/templates/gitignores.html#list-gitignore-templates
+// https://docs.gitlab.com/ee/api/templates/gitignores.html#get-all-gitignore-templates
 func (s *GitIgnoreTemplatesService) ListTemplates(opt *ListTemplatesOptions, options ...RequestOptionFunc) ([]*GitIgnoreTemplateListItem, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "templates/gitignores", opt, options)
 	if err != nil {

--- a/gitignore_templates.go
+++ b/gitignore_templates.go
@@ -25,14 +25,14 @@ import (
 // GitIgnoreTemplatesService handles communication with the gitignore
 // templates related methods of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/templates/gitignores.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/templates/gitignores.html
 type GitIgnoreTemplatesService struct {
 	client *Client
 }
 
 // GitIgnoreTemplate represents a GitLab gitignore template.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/templates/gitignores.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/templates/gitignores.html
 type GitIgnoreTemplate struct {
 	Name    string `json:"name"`
 	Content string `json:"content"`
@@ -40,7 +40,7 @@ type GitIgnoreTemplate struct {
 
 // GitIgnoreTemplateListItem represents a GitLab gitignore template from the list.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/templates/gitignores.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/templates/gitignores.html
 type GitIgnoreTemplateListItem struct {
 	Key  string `json:"key"`
 	Name string `json:"name"`
@@ -49,13 +49,13 @@ type GitIgnoreTemplateListItem struct {
 // ListTemplatesOptions represents the available ListAllTemplates() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/templates/gitignores.html#list-gitignore-templates
+// https://docs.gitlab.com/ee/api/templates/gitignores.html#list-gitignore-templates
 type ListTemplatesOptions ListOptions
 
 // ListTemplates get a list of available git ignore templates
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/templates/gitignores.html#list-gitignore-templates
+// https://docs.gitlab.com/ee/api/templates/gitignores.html#list-gitignore-templates
 func (s *GitIgnoreTemplatesService) ListTemplates(opt *ListTemplatesOptions, options ...RequestOptionFunc) ([]*GitIgnoreTemplateListItem, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "templates/gitignores", opt, options)
 	if err != nil {
@@ -74,7 +74,7 @@ func (s *GitIgnoreTemplatesService) ListTemplates(opt *ListTemplatesOptions, opt
 // GetTemplate get a git ignore template
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/templates/gitignores.html#get-a-single-gitignore-template
+// https://docs.gitlab.com/ee/api/templates/gitignores.html#get-a-single-gitignore-template
 func (s *GitIgnoreTemplatesService) GetTemplate(key string, options ...RequestOptionFunc) (*GitIgnoreTemplate, *Response, error) {
 	u := fmt.Sprintf("templates/gitignores/%s", url.PathEscape(key))
 

--- a/gitlab.go
+++ b/gitlab.go
@@ -51,12 +51,12 @@ const (
 
 // AuthType represents an authentication type within GitLab.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/
+// GitLab API docs: https://docs.gitlab.com/ee/api/
 type AuthType int
 
 // List of available authentication types.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/
+// GitLab API docs: https://docs.gitlab.com/ee/api/
 const (
 	BasicAuth AuthType = iota
 	JobToken
@@ -873,7 +873,7 @@ func PathEscape(s string) string {
 // An ErrorResponse reports one or more errors caused by an API request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/README.html#data-validation-and-error-reporting
+// https://docs.gitlab.com/ee/api/README.html#data-validation-and-error-reporting
 type ErrorResponse struct {
 	Body     []byte
 	Response *http.Response

--- a/gitlab.go
+++ b/gitlab.go
@@ -873,7 +873,7 @@ func PathEscape(s string) string {
 // An ErrorResponse reports one or more errors caused by an API request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/README.html#data-validation-and-error-reporting
+// https://docs.gitlab.com/ee/api/index.html#data-validation-and-error-reporting
 type ErrorResponse struct {
 	Body     []byte
 	Response *http.Response

--- a/group_boards.go
+++ b/group_boards.go
@@ -25,7 +25,7 @@ import (
 // related methods of the GitLab API.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/group_boards.html
+// https://docs.gitlab.com/ee/api/group_boards.html
 type GroupIssueBoardsService struct {
 	client *Client
 }
@@ -33,7 +33,7 @@ type GroupIssueBoardsService struct {
 // GroupIssueBoard represents a GitLab group issue board.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/group_boards.html
+// https://docs.gitlab.com/ee/api/group_boards.html
 type GroupIssueBoard struct {
 	ID        int          `json:"id"`
 	Name      string       `json:"name"`
@@ -50,13 +50,13 @@ func (b GroupIssueBoard) String() string {
 // ListGroupIssueBoards() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/group_boards.html#group-board
+// https://docs.gitlab.com/ee/api/group_boards.html#group-board
 type ListGroupIssueBoardsOptions ListOptions
 
 // ListGroupIssueBoards gets a list of all issue boards in a group.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/group_boards.html#group-board
+// https://docs.gitlab.com/ee/api/group_boards.html#group-board
 func (s *GroupIssueBoardsService) ListGroupIssueBoards(gid interface{}, opt *ListGroupIssueBoardsOptions, options ...RequestOptionFunc) ([]*GroupIssueBoard, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -82,7 +82,7 @@ func (s *GroupIssueBoardsService) ListGroupIssueBoards(gid interface{}, opt *Lis
 // CreateGroupIssueBoard() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/group_boards.html#create-a-group-issue-board-premium
+// https://docs.gitlab.com/ee/api/group_boards.html#create-a-group-issue-board-premium
 type CreateGroupIssueBoardOptions struct {
 	Name *string `url:"name" json:"name"`
 }
@@ -90,7 +90,7 @@ type CreateGroupIssueBoardOptions struct {
 // CreateGroupIssueBoard creates a new issue board.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/group_boards.html#create-a-group-issue-board-premium
+// https://docs.gitlab.com/ee/api/group_boards.html#create-a-group-issue-board-premium
 func (s *GroupIssueBoardsService) CreateGroupIssueBoard(gid interface{}, opt *CreateGroupIssueBoardOptions, options ...RequestOptionFunc) (*GroupIssueBoard, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -115,7 +115,7 @@ func (s *GroupIssueBoardsService) CreateGroupIssueBoard(gid interface{}, opt *Cr
 // GetGroupIssueBoard gets a single issue board of a group.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/group_boards.html#single-board
+// https://docs.gitlab.com/ee/api/group_boards.html#single-board
 func (s *GroupIssueBoardsService) GetGroupIssueBoard(gid interface{}, board int, options ...RequestOptionFunc) (*GroupIssueBoard, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -140,7 +140,7 @@ func (s *GroupIssueBoardsService) GetGroupIssueBoard(gid interface{}, board int,
 // UpdateGroupIssueBoardOptions represents a group issue board.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/group_boards.html#update-a-group-issue-board-premium
+// https://docs.gitlab.com/ee/api/group_boards.html#update-a-group-issue-board-premium
 type UpdateGroupIssueBoardOptions struct {
 	Name        *string `url:"name,omitempty" json:"name,omitempty"`
 	AssigneeID  *int    `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
@@ -152,7 +152,7 @@ type UpdateGroupIssueBoardOptions struct {
 // UpdateIssueBoard updates a single issue board of a group.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/group_boards.html#update-a-group-issue-board-premium
+// https://docs.gitlab.com/ee/api/group_boards.html#update-a-group-issue-board-premium
 func (s *GroupIssueBoardsService) UpdateIssueBoard(gid interface{}, board int, opt *UpdateGroupIssueBoardOptions, options ...RequestOptionFunc) (*GroupIssueBoard, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -177,7 +177,7 @@ func (s *GroupIssueBoardsService) UpdateIssueBoard(gid interface{}, board int, o
 // DeleteIssueBoard delete a single issue board of a group.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/group_boards.html#delete-a-group-issue-board-premium
+// https://docs.gitlab.com/ee/api/group_boards.html#delete-a-group-issue-board-premium
 func (s *GroupIssueBoardsService) DeleteIssueBoard(gid interface{}, board int, options ...RequestOptionFunc) (*Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -197,13 +197,13 @@ func (s *GroupIssueBoardsService) DeleteIssueBoard(gid interface{}, board int, o
 // ListGroupIssueBoardLists() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/group_boards.html#list-board-lists
+// https://docs.gitlab.com/ee/api/group_boards.html#list-board-lists
 type ListGroupIssueBoardListsOptions ListOptions
 
 // ListGroupIssueBoardLists gets a list of the issue board's lists. Does not include
 // backlog and closed lists.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/group_boards.html#list-board-lists
+// GitLab API docs: https://docs.gitlab.com/ee/api/group_boards.html#list-board-lists
 func (s *GroupIssueBoardsService) ListGroupIssueBoardLists(gid interface{}, board int, opt *ListGroupIssueBoardListsOptions, options ...RequestOptionFunc) ([]*BoardList, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -228,7 +228,7 @@ func (s *GroupIssueBoardsService) ListGroupIssueBoardLists(gid interface{}, boar
 // GetGroupIssueBoardList gets a single issue board list.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/group_boards.html#single-board-list
+// https://docs.gitlab.com/ee/api/group_boards.html#single-board-list
 func (s *GroupIssueBoardsService) GetGroupIssueBoardList(gid interface{}, board, list int, options ...RequestOptionFunc) (*BoardList, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -258,7 +258,7 @@ func (s *GroupIssueBoardsService) GetGroupIssueBoardList(gid interface{}, board,
 // CreateGroupIssueBoardList() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/group_boards.html#new-board-list
+// https://docs.gitlab.com/ee/api/group_boards.html#new-board-list
 type CreateGroupIssueBoardListOptions struct {
 	LabelID *int `url:"label_id" json:"label_id"`
 }
@@ -266,7 +266,7 @@ type CreateGroupIssueBoardListOptions struct {
 // CreateGroupIssueBoardList creates a new issue board list.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/group_boards.html#new-board-list
+// https://docs.gitlab.com/ee/api/group_boards.html#new-board-list
 func (s *GroupIssueBoardsService) CreateGroupIssueBoardList(gid interface{}, board int, opt *CreateGroupIssueBoardListOptions, options ...RequestOptionFunc) (*BoardList, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -292,7 +292,7 @@ func (s *GroupIssueBoardsService) CreateGroupIssueBoardList(gid interface{}, boa
 // UpdateGroupIssueBoardList() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/group_boards.html#edit-board-list
+// https://docs.gitlab.com/ee/api/group_boards.html#edit-board-list
 type UpdateGroupIssueBoardListOptions struct {
 	Position *int `url:"position" json:"position"`
 }
@@ -301,7 +301,7 @@ type UpdateGroupIssueBoardListOptions struct {
 // group issue board list.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/group_boards.html#edit-board-list
+// https://docs.gitlab.com/ee/api/group_boards.html#edit-board-list
 func (s *GroupIssueBoardsService) UpdateIssueBoardList(gid interface{}, board, list int, opt *UpdateGroupIssueBoardListOptions, options ...RequestOptionFunc) ([]*BoardList, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -331,7 +331,7 @@ func (s *GroupIssueBoardsService) UpdateIssueBoardList(gid interface{}, board, l
 // Only for admins and group owners.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/group_boards.html#delete-a-board-list
+// https://docs.gitlab.com/ee/api/group_boards.html#delete-a-board-list
 func (s *GroupIssueBoardsService) DeleteGroupIssueBoardList(gid interface{}, board, list int, options ...RequestOptionFunc) (*Response, error) {
 	group, err := parseID(gid)
 	if err != nil {

--- a/group_boards.go
+++ b/group_boards.go
@@ -50,13 +50,13 @@ func (b GroupIssueBoard) String() string {
 // ListGroupIssueBoards() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/group_boards.html#group-board
+// https://docs.gitlab.com/ee/api/group_boards.html#list-all-group-issue-boards-in-a-group
 type ListGroupIssueBoardsOptions ListOptions
 
 // ListGroupIssueBoards gets a list of all issue boards in a group.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/group_boards.html#group-board
+// https://docs.gitlab.com/ee/api/group_boards.html#list-all-group-issue-boards-in-a-group
 func (s *GroupIssueBoardsService) ListGroupIssueBoards(gid interface{}, opt *ListGroupIssueBoardsOptions, options ...RequestOptionFunc) ([]*GroupIssueBoard, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -82,7 +82,7 @@ func (s *GroupIssueBoardsService) ListGroupIssueBoards(gid interface{}, opt *Lis
 // CreateGroupIssueBoard() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/group_boards.html#create-a-group-issue-board-premium
+// https://docs.gitlab.com/ee/api/group_boards.html#create-a-group-issue-board
 type CreateGroupIssueBoardOptions struct {
 	Name *string `url:"name" json:"name"`
 }
@@ -90,7 +90,7 @@ type CreateGroupIssueBoardOptions struct {
 // CreateGroupIssueBoard creates a new issue board.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/group_boards.html#create-a-group-issue-board-premium
+// https://docs.gitlab.com/ee/api/group_boards.html#create-a-group-issue-board
 func (s *GroupIssueBoardsService) CreateGroupIssueBoard(gid interface{}, opt *CreateGroupIssueBoardOptions, options ...RequestOptionFunc) (*GroupIssueBoard, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -115,7 +115,7 @@ func (s *GroupIssueBoardsService) CreateGroupIssueBoard(gid interface{}, opt *Cr
 // GetGroupIssueBoard gets a single issue board of a group.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/group_boards.html#single-board
+// https://docs.gitlab.com/ee/api/group_boards.html#single-group-issue-board
 func (s *GroupIssueBoardsService) GetGroupIssueBoard(gid interface{}, board int, options ...RequestOptionFunc) (*GroupIssueBoard, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -140,7 +140,7 @@ func (s *GroupIssueBoardsService) GetGroupIssueBoard(gid interface{}, board int,
 // UpdateGroupIssueBoardOptions represents a group issue board.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/group_boards.html#update-a-group-issue-board-premium
+// https://docs.gitlab.com/ee/api/group_boards.html#update-a-group-issue-board
 type UpdateGroupIssueBoardOptions struct {
 	Name        *string `url:"name,omitempty" json:"name,omitempty"`
 	AssigneeID  *int    `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
@@ -152,7 +152,7 @@ type UpdateGroupIssueBoardOptions struct {
 // UpdateIssueBoard updates a single issue board of a group.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/group_boards.html#update-a-group-issue-board-premium
+// https://docs.gitlab.com/ee/api/group_boards.html#update-a-group-issue-board
 func (s *GroupIssueBoardsService) UpdateIssueBoard(gid interface{}, board int, opt *UpdateGroupIssueBoardOptions, options ...RequestOptionFunc) (*GroupIssueBoard, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -177,7 +177,7 @@ func (s *GroupIssueBoardsService) UpdateIssueBoard(gid interface{}, board int, o
 // DeleteIssueBoard delete a single issue board of a group.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/group_boards.html#delete-a-group-issue-board-premium
+// https://docs.gitlab.com/ee/api/group_boards.html#delete-a-group-issue-board
 func (s *GroupIssueBoardsService) DeleteIssueBoard(gid interface{}, board int, options ...RequestOptionFunc) (*Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -197,13 +197,13 @@ func (s *GroupIssueBoardsService) DeleteIssueBoard(gid interface{}, board int, o
 // ListGroupIssueBoardLists() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/group_boards.html#list-board-lists
+// https://docs.gitlab.com/ee/api/group_boards.html#list-group-issue-board-lists
 type ListGroupIssueBoardListsOptions ListOptions
 
 // ListGroupIssueBoardLists gets a list of the issue board's lists. Does not include
 // backlog and closed lists.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/group_boards.html#list-board-lists
+// GitLab API docs: https://docs.gitlab.com/ee/api/group_boards.html#list-group-issue-board-lists
 func (s *GroupIssueBoardsService) ListGroupIssueBoardLists(gid interface{}, board int, opt *ListGroupIssueBoardListsOptions, options ...RequestOptionFunc) ([]*BoardList, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -228,7 +228,7 @@ func (s *GroupIssueBoardsService) ListGroupIssueBoardLists(gid interface{}, boar
 // GetGroupIssueBoardList gets a single issue board list.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/group_boards.html#single-board-list
+// https://docs.gitlab.com/ee/api/group_boards.html#single-group-issue-board-list
 func (s *GroupIssueBoardsService) GetGroupIssueBoardList(gid interface{}, board, list int, options ...RequestOptionFunc) (*BoardList, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -258,7 +258,7 @@ func (s *GroupIssueBoardsService) GetGroupIssueBoardList(gid interface{}, board,
 // CreateGroupIssueBoardList() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/group_boards.html#new-board-list
+// https://docs.gitlab.com/ee/api/group_boards.html#new-group-issue-board-list
 type CreateGroupIssueBoardListOptions struct {
 	LabelID *int `url:"label_id" json:"label_id"`
 }
@@ -266,7 +266,7 @@ type CreateGroupIssueBoardListOptions struct {
 // CreateGroupIssueBoardList creates a new issue board list.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/group_boards.html#new-board-list
+// https://docs.gitlab.com/ee/api/group_boards.html#new-group-issue-board-list
 func (s *GroupIssueBoardsService) CreateGroupIssueBoardList(gid interface{}, board int, opt *CreateGroupIssueBoardListOptions, options ...RequestOptionFunc) (*BoardList, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -292,7 +292,7 @@ func (s *GroupIssueBoardsService) CreateGroupIssueBoardList(gid interface{}, boa
 // UpdateGroupIssueBoardList() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/group_boards.html#edit-board-list
+// https://docs.gitlab.com/ee/api/group_boards.html#edit-group-issue-board-list
 type UpdateGroupIssueBoardListOptions struct {
 	Position *int `url:"position" json:"position"`
 }
@@ -301,7 +301,7 @@ type UpdateGroupIssueBoardListOptions struct {
 // group issue board list.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/group_boards.html#edit-board-list
+// https://docs.gitlab.com/ee/api/group_boards.html#edit-group-issue-board-list
 func (s *GroupIssueBoardsService) UpdateIssueBoardList(gid interface{}, board, list int, opt *UpdateGroupIssueBoardListOptions, options ...RequestOptionFunc) ([]*BoardList, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -331,7 +331,7 @@ func (s *GroupIssueBoardsService) UpdateIssueBoardList(gid interface{}, board, l
 // Only for admins and group owners.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/group_boards.html#delete-a-board-list
+// https://docs.gitlab.com/ee/api/group_boards.html#delete-a-group-issue-board-list
 func (s *GroupIssueBoardsService) DeleteGroupIssueBoardList(gid interface{}, board, list int, options ...RequestOptionFunc) (*Response, error) {
 	group, err := parseID(gid)
 	if err != nil {

--- a/group_hooks.go
+++ b/group_hooks.go
@@ -24,7 +24,7 @@ import (
 
 // GroupHook represents a GitLab group hook.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/groups.html#list-group-hooks
+// GitLab API docs: https://docs.gitlab.com/ee/api/groups.html#list-group-hooks
 type GroupHook struct {
 	ID                       int        `json:"id"`
 	URL                      string     `json:"url"`
@@ -49,12 +49,12 @@ type GroupHook struct {
 
 // ListGroupHooksOptions represents the available ListGroupHooks() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/groups.html#list-group-hooks
+// GitLab API docs: https://docs.gitlab.com/ee/api/groups.html#list-group-hooks
 type ListGroupHooksOptions ListOptions
 
 // ListGroupHooks gets a list of group hooks.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/groups.html#list-group-hooks
+// GitLab API docs: https://docs.gitlab.com/ee/api/groups.html#list-group-hooks
 func (s *GroupsService) ListGroupHooks(gid interface{}, opt *ListGroupHooksOptions, options ...RequestOptionFunc) ([]*GroupHook, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -78,7 +78,7 @@ func (s *GroupsService) ListGroupHooks(gid interface{}, opt *ListGroupHooksOptio
 // GetGroupHook gets a specific hook for a group.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/groups.html#get-group-hook
+// https://docs.gitlab.com/ee/api/groups.html#get-group-hook
 func (s *GroupsService) GetGroupHook(pid interface{}, hook int, options ...RequestOptionFunc) (*GroupHook, *Response, error) {
 	group, err := parseID(pid)
 	if err != nil {
@@ -150,7 +150,7 @@ func (s *GroupsService) AddGroupHook(gid interface{}, opt *AddGroupHookOptions, 
 // EditGroupHookOptions represents the available EditGroupHook() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/groups.html#edit-group-hook
+// https://docs.gitlab.com/ee/api/groups.html#edit-group-hook
 type EditGroupHookOptions struct {
 	URL                      *string `url:"url,omitempty" json:"url,omitempty"`
 	PushEvents               *bool   `url:"push_events,omitempty" json:"push_events,omitempty"`
@@ -174,7 +174,7 @@ type EditGroupHookOptions struct {
 // EditGroupHook edits a hook for a specified group.
 //
 // Gitlab API docs:
-// https://docs.gitlab.com/ce/api/groups.html#edit-group-hook
+// https://docs.gitlab.com/ee/api/groups.html#edit-group-hook
 func (s *GroupsService) EditGroupHook(pid interface{}, hook int, opt *EditGroupHookOptions, options ...RequestOptionFunc) (*GroupHook, *Response, error) {
 	group, err := parseID(pid)
 	if err != nil {
@@ -200,7 +200,7 @@ func (s *GroupsService) EditGroupHook(pid interface{}, hook int, opt *EditGroupH
 // method and can be called multiple times.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/groups.html#delete-group-hook
+// https://docs.gitlab.com/ee/api/groups.html#delete-group-hook
 func (s *GroupsService) DeleteGroupHook(pid interface{}, hook int, options ...RequestOptionFunc) (*Response, error) {
 	group, err := parseID(pid)
 	if err != nil {

--- a/group_import_export.go
+++ b/group_import_export.go
@@ -30,7 +30,7 @@ import (
 // GroupImportExportService handles communication with the group import export
 // related methods of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/group_import_export.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/group_import_export.html
 type GroupImportExportService struct {
 	client *Client
 }
@@ -38,7 +38,7 @@ type GroupImportExportService struct {
 // ScheduleExport starts a new group export.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/group_import_export.html#schedule-new-export
+// https://docs.gitlab.com/ee/api/group_import_export.html#schedule-new-export
 func (s *GroupImportExportService) ScheduleExport(gid interface{}, options ...RequestOptionFunc) (*Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -57,7 +57,7 @@ func (s *GroupImportExportService) ScheduleExport(gid interface{}, options ...Re
 // ExportDownload downloads the finished export.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/group_import_export.html#export-download
+// https://docs.gitlab.com/ee/api/group_import_export.html#export-download
 func (s *GroupImportExportService) ExportDownload(gid interface{}, options ...RequestOptionFunc) (*bytes.Reader, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -82,7 +82,7 @@ func (s *GroupImportExportService) ExportDownload(gid interface{}, options ...Re
 // GroupImportFileOptions represents the available ImportFile() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/group_import_export.html#import-a-file
+// https://docs.gitlab.com/ee/api/group_import_export.html#import-a-file
 type GroupImportFileOptions struct {
 	Name     *string `url:"name,omitempty" json:"name,omitempty"`
 	Path     *string `url:"path,omitempty" json:"path,omitempty"`
@@ -93,7 +93,7 @@ type GroupImportFileOptions struct {
 // ImportFile imports a file.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/group_import_export.html#import-a-file
+// https://docs.gitlab.com/ee/api/group_import_export.html#import-a-file
 func (s *GroupImportExportService) ImportFile(opt *GroupImportFileOptions, options ...RequestOptionFunc) (*Response, error) {
 	// First check if we got all required options.
 	if opt.Name == nil || *opt.Name == "" {

--- a/group_labels.go
+++ b/group_labels.go
@@ -144,7 +144,7 @@ type DeleteGroupLabelOptions DeleteLabelOptions
 
 // DeleteGroupLabel deletes a group label given by its name.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/labels.html#delete-a-label
+// GitLab API docs: https://docs.gitlab.com/ee/api/group_labels.html#delete-a-group-label
 func (s *GroupLabelsService) DeleteGroupLabel(gid interface{}, opt *DeleteGroupLabelOptions, options ...RequestOptionFunc) (*Response, error) {
 	group, err := parseID(gid)
 	if err != nil {

--- a/group_labels.go
+++ b/group_labels.go
@@ -24,14 +24,14 @@ import (
 // GroupLabelsService handles communication with the label related methods of the
 // GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/group_labels.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/group_labels.html
 type GroupLabelsService struct {
 	client *Client
 }
 
 // GroupLabel represents a GitLab group label.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/group_labels.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/group_labels.html
 type GroupLabel Label
 
 func (l GroupLabel) String() string {
@@ -53,7 +53,7 @@ type ListGroupLabelsOptions struct {
 // ListGroupLabels gets all labels for given group.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/group_labels.html#list-group-labels
+// https://docs.gitlab.com/ee/api/group_labels.html#list-group-labels
 func (s *GroupLabelsService) ListGroupLabels(gid interface{}, opt *ListGroupLabelsOptions, options ...RequestOptionFunc) ([]*GroupLabel, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -78,7 +78,7 @@ func (s *GroupLabelsService) ListGroupLabels(gid interface{}, opt *ListGroupLabe
 // GetGroupLabel get a single label for a given group.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/group_labels.html#get-a-single-group-label
+// https://docs.gitlab.com/ee/api/group_labels.html#get-a-single-group-label
 func (s *GroupLabelsService) GetGroupLabel(gid interface{}, labelID interface{}, options ...RequestOptionFunc) (*GroupLabel, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -107,14 +107,14 @@ func (s *GroupLabelsService) GetGroupLabel(gid interface{}, labelID interface{},
 // CreateGroupLabelOptions represents the available CreateGroupLabel() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/group_labels.html#create-a-new-group-label
+// https://docs.gitlab.com/ee/api/group_labels.html#create-a-new-group-label
 type CreateGroupLabelOptions CreateLabelOptions
 
 // CreateGroupLabel creates a new label for given group with given name and
 // color.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/group_labels.html#create-a-new-group-label
+// https://docs.gitlab.com/ee/api/group_labels.html#create-a-new-group-label
 func (s *GroupLabelsService) CreateGroupLabel(gid interface{}, opt *CreateGroupLabelOptions, options ...RequestOptionFunc) (*GroupLabel, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -139,12 +139,12 @@ func (s *GroupLabelsService) CreateGroupLabel(gid interface{}, opt *CreateGroupL
 // DeleteGroupLabelOptions represents the available DeleteGroupLabel() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/group_labels.html#delete-a-group-label
+// https://docs.gitlab.com/ee/api/group_labels.html#delete-a-group-label
 type DeleteGroupLabelOptions DeleteLabelOptions
 
 // DeleteGroupLabel deletes a group label given by its name.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/labels.html#delete-a-label
+// GitLab API docs: https://docs.gitlab.com/ee/api/labels.html#delete-a-label
 func (s *GroupLabelsService) DeleteGroupLabel(gid interface{}, opt *DeleteGroupLabelOptions, options ...RequestOptionFunc) (*Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -163,14 +163,14 @@ func (s *GroupLabelsService) DeleteGroupLabel(gid interface{}, opt *DeleteGroupL
 // UpdateGroupLabelOptions represents the available UpdateGroupLabel() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/group_labels.html#update-a-group-label
+// https://docs.gitlab.com/ee/api/group_labels.html#update-a-group-label
 type UpdateGroupLabelOptions UpdateLabelOptions
 
 // UpdateGroupLabel updates an existing label with new name or now color. At least
 // one parameter is required, to update the label.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/group_labels.html#update-a-group-label
+// https://docs.gitlab.com/ee/api/group_labels.html#update-a-group-label
 func (s *GroupLabelsService) UpdateGroupLabel(gid interface{}, opt *UpdateGroupLabelOptions, options ...RequestOptionFunc) (*GroupLabel, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -197,7 +197,7 @@ func (s *GroupLabelsService) UpdateGroupLabel(gid interface{}, opt *UpdateGroupL
 // code 304 is returned.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/group_labels.html#subscribe-to-a-group-label
+// https://docs.gitlab.com/ee/api/group_labels.html#subscribe-to-a-group-label
 func (s *GroupLabelsService) SubscribeToGroupLabel(gid interface{}, labelID interface{}, options ...RequestOptionFunc) (*GroupLabel, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -228,7 +228,7 @@ func (s *GroupLabelsService) SubscribeToGroupLabel(gid interface{}, labelID inte
 // status code 304 is returned.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/group_labels.html#unsubscribe-from-a-group-label
+// https://docs.gitlab.com/ee/api/group_labels.html#unsubscribe-from-a-group-label
 func (s *GroupLabelsService) UnsubscribeFromGroupLabel(gid interface{}, labelID interface{}, options ...RequestOptionFunc) (*Response, error) {
 	group, err := parseID(gid)
 	if err != nil {

--- a/group_members.go
+++ b/group_members.go
@@ -25,14 +25,14 @@ import (
 // GroupMembersService handles communication with the group members
 // related methods of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/members.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/members.html
 type GroupMembersService struct {
 	client *Client
 }
 
 // GroupMemberSAMLIdentity represents the SAML Identity link for the group member.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/members.html#list-all-members-of-a-group-or-project
+// GitLab API docs: https://docs.gitlab.com/ee/api/members.html#list-all-members-of-a-group-or-project
 // Gitlab MR for API change: https://gitlab.com/gitlab-org/gitlab/-/merge_requests/20357
 // Gitlab MR for API Doc change: https://gitlab.com/gitlab-org/gitlab/-/merge_requests/25652
 type GroupMemberSAMLIdentity struct {
@@ -43,7 +43,7 @@ type GroupMemberSAMLIdentity struct {
 
 // GroupMember represents a GitLab group member.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/members.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/members.html
 type GroupMember struct {
 	ID                int                      `json:"id"`
 	Username          string                   `json:"username"`
@@ -61,7 +61,7 @@ type GroupMember struct {
 // ListAllGroupMembers() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/members.html#list-all-members-of-a-group-or-project
+// https://docs.gitlab.com/ee/api/members.html#list-all-members-of-a-group-or-project
 type ListGroupMembersOptions struct {
 	ListOptions
 	Query   *string `url:"query,omitempty" json:"query,omitempty"`
@@ -72,7 +72,7 @@ type ListGroupMembersOptions struct {
 // user. Inherited members through ancestor groups are not included.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/members.html#list-all-members-of-a-group-or-project
+// https://docs.gitlab.com/ee/api/members.html#list-all-members-of-a-group-or-project
 func (s *GroupsService) ListGroupMembers(gid interface{}, opt *ListGroupMembersOptions, options ...RequestOptionFunc) ([]*GroupMember, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -98,7 +98,7 @@ func (s *GroupsService) ListGroupMembers(gid interface{}, opt *ListGroupMembersO
 // user. Returns a list including inherited members through ancestor groups.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/members.html#list-all-members-of-a-group-or-project-including-inherited-members
+// https://docs.gitlab.com/ee/api/members.html#list-all-members-of-a-group-or-project-including-inherited-members
 func (s *GroupsService) ListAllGroupMembers(gid interface{}, opt *ListGroupMembersOptions, options ...RequestOptionFunc) ([]*GroupMember, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -123,7 +123,7 @@ func (s *GroupsService) ListAllGroupMembers(gid interface{}, opt *ListGroupMembe
 // AddGroupMemberOptions represents the available AddGroupMember() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/members.html#add-a-member-to-a-group-or-project
+// https://docs.gitlab.com/ee/api/members.html#add-a-member-to-a-group-or-project
 type AddGroupMemberOptions struct {
 	UserID      *int              `url:"user_id,omitempty" json:"user_id,omitempty"`
 	AccessLevel *AccessLevelValue `url:"access_level,omitempty" json:"access_level,omitempty"`
@@ -133,7 +133,7 @@ type AddGroupMemberOptions struct {
 // GetGroupMember gets a member of a group.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/members.html#get-a-member-of-a-group-or-project
+// https://docs.gitlab.com/ee/api/members.html#get-a-member-of-a-group-or-project
 func (s *GroupMembersService) GetGroupMember(gid interface{}, user int, options ...RequestOptionFunc) (*GroupMember, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -232,7 +232,7 @@ func (s *GroupsService) RemoveBillableGroupMember(gid interface{}, user int, opt
 // AddGroupMember adds a user to the list of group members.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/members.html#add-a-member-to-a-group-or-project
+// https://docs.gitlab.com/ee/api/members.html#add-a-member-to-a-group-or-project
 func (s *GroupMembersService) AddGroupMember(gid interface{}, opt *AddGroupMemberOptions, options ...RequestOptionFunc) (*GroupMember, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -257,7 +257,7 @@ func (s *GroupMembersService) AddGroupMember(gid interface{}, opt *AddGroupMembe
 // ShareWithGroup shares a group with the group.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/groups.html#share-groups-with-groups
+// https://docs.gitlab.com/ee/api/groups.html#share-groups-with-groups
 func (s *GroupMembersService) ShareWithGroup(gid interface{}, opt *ShareWithGroupOptions, options ...RequestOptionFunc) (*Group, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -282,7 +282,7 @@ func (s *GroupMembersService) ShareWithGroup(gid interface{}, opt *ShareWithGrou
 // DeleteShareWithGroup allows to unshare a group from a group.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/groups.html#delete-link-sharing-group-with-another-group
+// https://docs.gitlab.com/ee/api/groups.html#delete-link-sharing-group-with-another-group
 func (s *GroupMembersService) DeleteShareWithGroup(gid interface{}, groupID int, options ...RequestOptionFunc) (*Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -302,7 +302,7 @@ func (s *GroupMembersService) DeleteShareWithGroup(gid interface{}, groupID int,
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/members.html#edit-a-member-of-a-group-or-project
+// https://docs.gitlab.com/ee/api/members.html#edit-a-member-of-a-group-or-project
 type EditGroupMemberOptions struct {
 	AccessLevel *AccessLevelValue `url:"access_level,omitempty" json:"access_level,omitempty"`
 	ExpiresAt   *string           `url:"expires_at,omitempty" json:"expires_at,omitempty"`
@@ -311,7 +311,7 @@ type EditGroupMemberOptions struct {
 // EditGroupMember updates a member of a group.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/members.html#edit-a-member-of-a-group-or-project
+// https://docs.gitlab.com/ee/api/members.html#edit-a-member-of-a-group-or-project
 func (s *GroupMembersService) EditGroupMember(gid interface{}, user int, opt *EditGroupMemberOptions, options ...RequestOptionFunc) (*GroupMember, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -344,7 +344,7 @@ type RemoveGroupMemberOptions struct {
 // RemoveGroupMember removes user from user team.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/members.html#remove-a-member-from-a-group-or-project
+// https://docs.gitlab.com/ee/api/members.html#remove-a-member-from-a-group-or-project
 func (s *GroupMembersService) RemoveGroupMember(gid interface{}, user int, opt *RemoveGroupMemberOptions, options ...RequestOptionFunc) (*Response, error) {
 	group, err := parseID(gid)
 	if err != nil {

--- a/group_members.go
+++ b/group_members.go
@@ -98,7 +98,7 @@ func (s *GroupsService) ListGroupMembers(gid interface{}, opt *ListGroupMembersO
 // user. Returns a list including inherited members through ancestor groups.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/members.html#list-all-members-of-a-group-or-project-including-inherited-members
+// https://docs.gitlab.com/ee/api/members.html#list-all-members-of-a-group-or-project-including-inherited-and-invited-members
 func (s *GroupsService) ListAllGroupMembers(gid interface{}, opt *ListGroupMembersOptions, options ...RequestOptionFunc) ([]*GroupMember, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {

--- a/group_milestones.go
+++ b/group_milestones.go
@@ -255,7 +255,7 @@ func (s *GroupMilestonesService) GetGroupMilestoneMergeRequests(gid interface{},
 // BurndownChartEvent reprensents a burnout chart event
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/group_milestones.html#get-all-burndown-chart-events-for-a-single-milestone-starter
+// https://docs.gitlab.com/ee/api/group_milestones.html#get-all-burndown-chart-events-for-a-single-milestone
 type BurndownChartEvent struct {
 	CreatedAt *time.Time `json:"created_at"`
 	Weight    *int       `json:"weight"`
@@ -266,14 +266,14 @@ type BurndownChartEvent struct {
 // GetGroupMilestoneBurndownChartEventsOptions() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/group_milestones.html#get-all-burndown-chart-events-for-a-single-milestone-starter
+// https://docs.gitlab.com/ee/api/group_milestones.html#get-all-burndown-chart-events-for-a-single-milestone
 type GetGroupMilestoneBurndownChartEventsOptions ListOptions
 
 // GetGroupMilestoneBurndownChartEvents gets all merge requests assigned to a
 // single group milestone.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/group_milestones.html#get-all-burndown-chart-events-for-a-single-milestone-starter
+// https://docs.gitlab.com/ee/api/group_milestones.html#get-all-burndown-chart-events-for-a-single-milestone
 func (s *GroupMilestonesService) GetGroupMilestoneBurndownChartEvents(gid interface{}, milestone int, opt *GetGroupMilestoneBurndownChartEventsOptions, options ...RequestOptionFunc) ([]*BurndownChartEvent, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {

--- a/group_milestones.go
+++ b/group_milestones.go
@@ -25,14 +25,14 @@ import (
 // GroupMilestonesService handles communication with the milestone related
 // methods of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/group_milestones.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/group_milestones.html
 type GroupMilestonesService struct {
 	client *Client
 }
 
 // GroupMilestone represents a GitLab milestone.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/group_milestones.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/group_milestones.html
 type GroupMilestone struct {
 	ID          int        `json:"id"`
 	IID         int        `json:"iid"`
@@ -55,7 +55,7 @@ func (m GroupMilestone) String() string {
 // ListGroupMilestones() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/group_milestones.html#list-group-milestones
+// https://docs.gitlab.com/ee/api/group_milestones.html#list-group-milestones
 type ListGroupMilestonesOptions struct {
 	ListOptions
 	IIDs                    *[]int  `url:"iids[],omitempty" json:"iids,omitempty"`
@@ -68,7 +68,7 @@ type ListGroupMilestonesOptions struct {
 // ListGroupMilestones returns a list of group milestones.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/group_milestones.html#list-group-milestones
+// https://docs.gitlab.com/ee/api/group_milestones.html#list-group-milestones
 func (s *GroupMilestonesService) ListGroupMilestones(gid interface{}, opt *ListGroupMilestonesOptions, options ...RequestOptionFunc) ([]*GroupMilestone, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -93,7 +93,7 @@ func (s *GroupMilestonesService) ListGroupMilestones(gid interface{}, opt *ListG
 // GetGroupMilestone gets a single group milestone.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/group_milestones.html#get-single-milestone
+// https://docs.gitlab.com/ee/api/group_milestones.html#get-single-milestone
 func (s *GroupMilestonesService) GetGroupMilestone(gid interface{}, milestone int, options ...RequestOptionFunc) (*GroupMilestone, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -118,7 +118,7 @@ func (s *GroupMilestonesService) GetGroupMilestone(gid interface{}, milestone in
 // CreateGroupMilestoneOptions represents the available CreateGroupMilestone() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/group_milestones.html#create-new-milestone
+// https://docs.gitlab.com/ee/api/group_milestones.html#create-new-milestone
 type CreateGroupMilestoneOptions struct {
 	Title       *string  `url:"title,omitempty" json:"title,omitempty"`
 	Description *string  `url:"description,omitempty" json:"description,omitempty"`
@@ -129,7 +129,7 @@ type CreateGroupMilestoneOptions struct {
 // CreateGroupMilestone creates a new group milestone.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/group_milestones.html#create-new-milestone
+// https://docs.gitlab.com/ee/api/group_milestones.html#create-new-milestone
 func (s *GroupMilestonesService) CreateGroupMilestone(gid interface{}, opt *CreateGroupMilestoneOptions, options ...RequestOptionFunc) (*GroupMilestone, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -154,7 +154,7 @@ func (s *GroupMilestonesService) CreateGroupMilestone(gid interface{}, opt *Crea
 // UpdateGroupMilestoneOptions represents the available UpdateGroupMilestone() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/group_milestones.html#edit-milestone
+// https://docs.gitlab.com/ee/api/group_milestones.html#edit-milestone
 type UpdateGroupMilestoneOptions struct {
 	Title       *string  `url:"title,omitempty" json:"title,omitempty"`
 	Description *string  `url:"description,omitempty" json:"description,omitempty"`
@@ -166,7 +166,7 @@ type UpdateGroupMilestoneOptions struct {
 // UpdateGroupMilestone updates an existing group milestone.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/group_milestones.html#edit-milestone
+// https://docs.gitlab.com/ee/api/group_milestones.html#edit-milestone
 func (s *GroupMilestonesService) UpdateGroupMilestone(gid interface{}, milestone int, opt *UpdateGroupMilestoneOptions, options ...RequestOptionFunc) (*GroupMilestone, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -191,13 +191,13 @@ func (s *GroupMilestonesService) UpdateGroupMilestone(gid interface{}, milestone
 // GetGroupMilestoneIssuesOptions represents the available GetGroupMilestoneIssues() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/group_milestones.html#get-all-issues-assigned-to-a-single-milestone
+// https://docs.gitlab.com/ee/api/group_milestones.html#get-all-issues-assigned-to-a-single-milestone
 type GetGroupMilestoneIssuesOptions ListOptions
 
 // GetGroupMilestoneIssues gets all issues assigned to a single group milestone.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/group_milestones.html#get-all-issues-assigned-to-a-single-milestone
+// https://docs.gitlab.com/ee/api/group_milestones.html#get-all-issues-assigned-to-a-single-milestone
 func (s *GroupMilestonesService) GetGroupMilestoneIssues(gid interface{}, milestone int, opt *GetGroupMilestoneIssuesOptions, options ...RequestOptionFunc) ([]*Issue, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -223,14 +223,14 @@ func (s *GroupMilestonesService) GetGroupMilestoneIssues(gid interface{}, milest
 // GetGroupMilestoneMergeRequests() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/group_milestones.html#get-all-merge-requests-assigned-to-a-single-milestone
+// https://docs.gitlab.com/ee/api/group_milestones.html#get-all-merge-requests-assigned-to-a-single-milestone
 type GetGroupMilestoneMergeRequestsOptions ListOptions
 
 // GetGroupMilestoneMergeRequests gets all merge requests assigned to a
 // single group milestone.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/group_milestones.html#get-all-merge-requests-assigned-to-a-single-milestone
+// https://docs.gitlab.com/ee/api/group_milestones.html#get-all-merge-requests-assigned-to-a-single-milestone
 func (s *GroupMilestonesService) GetGroupMilestoneMergeRequests(gid interface{}, milestone int, opt *GetGroupMilestoneMergeRequestsOptions, options ...RequestOptionFunc) ([]*MergeRequest, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {

--- a/groups.go
+++ b/groups.go
@@ -30,14 +30,14 @@ import (
 // GroupsService handles communication with the group related methods of
 // the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/groups.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/groups.html
 type GroupsService struct {
 	client *Client
 }
 
 // Group represents a GitLab group.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/groups.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/groups.html
 type Group struct {
 	ID                      int                        `json:"id"`
 	Name                    string                     `json:"name"`
@@ -89,7 +89,7 @@ type Group struct {
 
 // GroupAvatar represents a GitLab group avatar.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/groups.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/groups.html
 type GroupAvatar struct {
 	Filename string
 	Image    io.Reader
@@ -106,7 +106,7 @@ func (a *GroupAvatar) MarshalJSON() ([]byte, error) {
 
 // LDAPGroupLink represents a GitLab LDAP group link.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/groups.html#ldap-group-links
+// GitLab API docs: https://docs.gitlab.com/ee/api/groups.html#ldap-group-links
 type LDAPGroupLink struct {
 	CN          string           `json:"cn"`
 	Filter      string           `json:"filter"`
@@ -116,7 +116,7 @@ type LDAPGroupLink struct {
 
 // SAMLGroupLink represents a GitLab SAML group link.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/groups.html#saml-group-links
+// GitLab API docs: https://docs.gitlab.com/ee/api/groups.html#saml-group-links
 type SAMLGroupLink struct {
 	Name        string           `json:"name"`
 	AccessLevel AccessLevelValue `json:"access_level"`
@@ -124,7 +124,7 @@ type SAMLGroupLink struct {
 
 // ListGroupsOptions represents the available ListGroups() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/groups.html#list-project-groups
+// GitLab API docs: https://docs.gitlab.com/ee/api/groups.html#list-project-groups
 type ListGroupsOptions struct {
 	ListOptions
 	AllAvailable         *bool             `url:"all_available,omitempty" json:"all_available,omitempty"`
@@ -142,7 +142,7 @@ type ListGroupsOptions struct {
 // ListGroups gets a list of groups (as user: my groups, as admin: all groups).
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/groups.html#list-project-groups
+// https://docs.gitlab.com/ee/api/groups.html#list-project-groups
 func (s *GroupsService) ListGroups(opt *ListGroupsOptions, options ...RequestOptionFunc) ([]*Group, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "groups", opt, options)
 	if err != nil {
@@ -161,13 +161,13 @@ func (s *GroupsService) ListGroups(opt *ListGroupsOptions, options ...RequestOpt
 // ListSubGroupsOptions represents the available ListSubGroups() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/groups.html#list-a-groups-s-subgroups
+// https://docs.gitlab.com/ee/api/groups.html#list-a-groups-s-subgroups
 type ListSubGroupsOptions ListGroupsOptions
 
 // ListSubGroups gets a list of subgroups for a given group.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/groups.html#list-a-groups-s-subgroups
+// https://docs.gitlab.com/ee/api/groups.html#list-a-groups-s-subgroups
 func (s *GroupsService) ListSubGroups(gid interface{}, opt *ListSubGroupsOptions, options ...RequestOptionFunc) ([]*Group, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -193,13 +193,13 @@ func (s *GroupsService) ListSubGroups(gid interface{}, opt *ListSubGroupsOptions
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/groups.html#list-a-groups-descendant-groups
+// https://docs.gitlab.com/ee/api/groups.html#list-a-groups-descendant-groups
 type ListDescendantGroupsOptions ListGroupsOptions
 
 // ListDescendantGroups gets a list of subgroups for a given project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/groups.html#list-a-groups-descendant-groups
+// https://docs.gitlab.com/ee/api/groups.html#list-a-groups-descendant-groups
 func (s *GroupsService) ListDescendantGroups(gid interface{}, opt *ListDescendantGroupsOptions, options ...RequestOptionFunc) ([]*Group, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -224,7 +224,7 @@ func (s *GroupsService) ListDescendantGroups(gid interface{}, opt *ListDescendan
 // ListGroupProjectsOptions represents the available ListGroup() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/groups.html#list-a-group-39-s-projects
+// https://docs.gitlab.com/ee/api/groups.html#list-a-group-39-s-projects
 type ListGroupProjectsOptions struct {
 	ListOptions
 	Archived                 *bool             `url:"archived,omitempty" json:"archived,omitempty"`
@@ -248,7 +248,7 @@ type ListGroupProjectsOptions struct {
 // ListGroupProjects get a list of group projects
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/groups.html#list-a-group-39-s-projects
+// https://docs.gitlab.com/ee/api/groups.html#list-a-group-39-s-projects
 func (s *GroupsService) ListGroupProjects(gid interface{}, opt *ListGroupProjectsOptions, options ...RequestOptionFunc) ([]*Project, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -272,7 +272,7 @@ func (s *GroupsService) ListGroupProjects(gid interface{}, opt *ListGroupProject
 
 // GetGroupOptions represents the available GetGroup() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/groups.html#details-of-a-group
+// GitLab API docs: https://docs.gitlab.com/ee/api/groups.html#details-of-a-group
 type GetGroupOptions struct {
 	ListOptions
 	WithCustomAttributes *bool `url:"with_custom_attributes,omitempty" json:"with_custom_attributes,omitempty"`
@@ -281,7 +281,7 @@ type GetGroupOptions struct {
 
 // GetGroup gets all details of a group.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/groups.html#details-of-a-group
+// GitLab API docs: https://docs.gitlab.com/ee/api/groups.html#details-of-a-group
 func (s *GroupsService) GetGroup(gid interface{}, opt *GetGroupOptions, options ...RequestOptionFunc) (*Group, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -330,7 +330,7 @@ func (s *GroupsService) DownloadAvatar(gid interface{}, options ...RequestOption
 
 // CreateGroupOptions represents the available CreateGroup() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/groups.html#new-group
+// GitLab API docs: https://docs.gitlab.com/ee/api/groups.html#new-group
 type CreateGroupOptions struct {
 	Name                           *string                     `url:"name,omitempty" json:"name,omitempty"`
 	Path                           *string                     `url:"path,omitempty" json:"path,omitempty"`
@@ -358,7 +358,7 @@ type CreateGroupOptions struct {
 // CreateGroup creates a new project group. Available only for users who can
 // create groups.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/groups.html#new-group
+// GitLab API docs: https://docs.gitlab.com/ee/api/groups.html#new-group
 func (s *GroupsService) CreateGroup(opt *CreateGroupOptions, options ...RequestOptionFunc) (*Group, *Response, error) {
 	var err error
 	var req *retryablehttp.Request
@@ -393,7 +393,7 @@ func (s *GroupsService) CreateGroup(opt *CreateGroupOptions, options ...RequestO
 // for admin.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/groups.html#transfer-project-to-group
+// https://docs.gitlab.com/ee/api/groups.html#transfer-project-to-group
 func (s *GroupsService) TransferGroup(gid interface{}, pid interface{}, options ...RequestOptionFunc) (*Group, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -486,7 +486,7 @@ type UpdateGroupOptions struct {
 // UpdateGroup updates an existing group; only available to group owners and
 // administrators.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/groups.html#update-group
+// GitLab API docs: https://docs.gitlab.com/ee/api/groups.html#update-group
 func (s *GroupsService) UpdateGroup(gid interface{}, opt *UpdateGroupOptions, options ...RequestOptionFunc) (*Group, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -557,7 +557,7 @@ func (s *GroupsService) UploadAvatar(gid interface{}, avatar io.Reader, filename
 
 // DeleteGroup removes group with all projects inside.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/groups.html#remove-group
+// GitLab API docs: https://docs.gitlab.com/ee/api/groups.html#remove-group
 func (s *GroupsService) DeleteGroup(gid interface{}, options ...RequestOptionFunc) (*Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -600,7 +600,7 @@ func (s *GroupsService) RestoreGroup(gid interface{}, options ...RequestOptionFu
 
 // SearchGroup get all groups that match your string in their name or path.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/groups.html#search-for-group
+// GitLab API docs: https://docs.gitlab.com/ee/api/groups.html#search-for-group
 func (s *GroupsService) SearchGroup(query string, options ...RequestOptionFunc) ([]*Group, *Response, error) {
 	var q struct {
 		Search string `url:"search,omitempty" json:"search,omitempty"`

--- a/groups.go
+++ b/groups.go
@@ -124,7 +124,7 @@ type SAMLGroupLink struct {
 
 // ListGroupsOptions represents the available ListGroups() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/groups.html#list-project-groups
+// GitLab API docs: https://docs.gitlab.com/ee/api/groups.html#list-groups
 type ListGroupsOptions struct {
 	ListOptions
 	AllAvailable         *bool             `url:"all_available,omitempty" json:"all_available,omitempty"`
@@ -142,7 +142,7 @@ type ListGroupsOptions struct {
 // ListGroups gets a list of groups (as user: my groups, as admin: all groups).
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/groups.html#list-project-groups
+// https://docs.gitlab.com/ee/api/groups.html#list-groups
 func (s *GroupsService) ListGroups(opt *ListGroupsOptions, options ...RequestOptionFunc) ([]*Group, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "groups", opt, options)
 	if err != nil {
@@ -161,13 +161,13 @@ func (s *GroupsService) ListGroups(opt *ListGroupsOptions, options ...RequestOpt
 // ListSubGroupsOptions represents the available ListSubGroups() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/groups.html#list-a-groups-s-subgroups
+// https://docs.gitlab.com/ee/api/groups.html#list-a-groups-subgroups
 type ListSubGroupsOptions ListGroupsOptions
 
 // ListSubGroups gets a list of subgroups for a given group.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/groups.html#list-a-groups-s-subgroups
+// https://docs.gitlab.com/ee/api/groups.html#list-a-groups-subgroups
 func (s *GroupsService) ListSubGroups(gid interface{}, opt *ListSubGroupsOptions, options ...RequestOptionFunc) ([]*Group, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -224,7 +224,7 @@ func (s *GroupsService) ListDescendantGroups(gid interface{}, opt *ListDescendan
 // ListGroupProjectsOptions represents the available ListGroup() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/groups.html#list-a-group-39-s-projects
+// https://docs.gitlab.com/ee/api/groups.html#list-a-groups-projects
 type ListGroupProjectsOptions struct {
 	ListOptions
 	Archived                 *bool             `url:"archived,omitempty" json:"archived,omitempty"`
@@ -248,7 +248,7 @@ type ListGroupProjectsOptions struct {
 // ListGroupProjects get a list of group projects
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/groups.html#list-a-group-39-s-projects
+// https://docs.gitlab.com/ee/api/groups.html#list-a-groups-projects
 func (s *GroupsService) ListGroupProjects(gid interface{}, opt *ListGroupProjectsOptions, options ...RequestOptionFunc) ([]*Project, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -625,7 +625,7 @@ func (s *GroupsService) SearchGroup(query string, options ...RequestOptionFunc) 
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/groups.html#provisioned-users-api
+// https://docs.gitlab.com/ee/api/groups.html#list-provisioned-users
 type ListProvisionedUsersOptions struct {
 	ListOptions
 	Username      *string    `url:"username,omitempty" json:"username,omitempty"`
@@ -639,7 +639,7 @@ type ListProvisionedUsersOptions struct {
 // ListProvisionedUsers gets a list of users provisioned by the given group.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/groups.html#provisioned-users-api
+// https://docs.gitlab.com/ee/api/groups.html#list-provisioned-users
 func (s *GroupsService) ListProvisionedUsers(gid interface{}, opt *ListProvisionedUsersOptions, options ...RequestOptionFunc) ([]*User, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -665,7 +665,7 @@ func (s *GroupsService) ListProvisionedUsers(gid interface{}, opt *ListProvision
 // can edit groups.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/groups.html#list-ldap-group-links-starter
+// https://docs.gitlab.com/ee/api/groups.html#list-ldap-group-links
 func (s *GroupsService) ListGroupLDAPLinks(gid interface{}, options ...RequestOptionFunc) ([]*LDAPGroupLink, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -690,7 +690,7 @@ func (s *GroupsService) ListGroupLDAPLinks(gid interface{}, options ...RequestOp
 // AddGroupLDAPLinkOptions represents the available AddGroupLDAPLink() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/groups.html#add-ldap-group-link-starter
+// https://docs.gitlab.com/ee/api/groups.html#add-ldap-group-link-with-cn-or-filter
 type AddGroupLDAPLinkOptions struct {
 	CN          *string           `url:"cn,omitempty" json:"cn,omitempty"`
 	Filter      *string           `url:"filter,omitempty" json:"filter,omitempty"`
@@ -712,7 +712,7 @@ type DeleteGroupLDAPLinkWithCNOrFilterOptions struct {
 // can edit groups.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/groups.html#add-ldap-group-link-starter
+// https://docs.gitlab.com/ee/api/groups.html#add-ldap-group-link-with-cn-or-filter
 func (s *GroupsService) AddGroupLDAPLink(gid interface{}, opt *AddGroupLDAPLinkOptions, options ...RequestOptionFunc) (*LDAPGroupLink, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -738,7 +738,7 @@ func (s *GroupsService) AddGroupLDAPLink(gid interface{}, opt *AddGroupLDAPLinkO
 // can edit groups.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/groups.html#delete-ldap-group-link-starter
+// https://docs.gitlab.com/ee/api/groups.html#delete-ldap-group-link
 func (s *GroupsService) DeleteGroupLDAPLink(gid interface{}, cn string, options ...RequestOptionFunc) (*Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -778,7 +778,7 @@ func (s *GroupsService) DeleteGroupLDAPLinkWithCNOrFilter(gid interface{}, opts 
 // provider. Available only for users who can edit groups.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/groups.html#delete-ldap-group-link-starter
+// https://docs.gitlab.com/ee/api/groups.html#delete-ldap-group-link
 func (s *GroupsService) DeleteGroupLDAPLinkForProvider(gid interface{}, provider, cn string, options ...RequestOptionFunc) (*Response, error) {
 	group, err := parseID(gid)
 	if err != nil {

--- a/invites.go
+++ b/invites.go
@@ -107,7 +107,7 @@ func (s *InvitesService) ListPendingProjectInvitations(pid interface{}, opt *Lis
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/invitations.html#invite-by-email-to-group-or-project
+// https://docs.gitlab.com/ee/api/invitations.html#add-a-member-to-a-group-or-project
 type InvitesOptions struct {
 	ID          interface{}       `url:"id,omitempty" json:"id,omitempty"`
 	Email       *string           `url:"email,omitempty" json:"email,omitempty"`
@@ -119,7 +119,7 @@ type InvitesOptions struct {
 // InvitesResult represents an invitations result.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/invitations.html#invite-by-email-to-group-or-project
+// https://docs.gitlab.com/ee/api/invitations.html#add-a-member-to-a-group-or-project
 type InvitesResult struct {
 	Status  string            `json:"status"`
 	Message map[string]string `json:"message,omitempty"`
@@ -128,7 +128,7 @@ type InvitesResult struct {
 // GroupInvites invites new users by email to join a group.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/invitations.html#invite-by-email-to-group-or-project
+// https://docs.gitlab.com/ee/api/invitations.html#add-a-member-to-a-group-or-project
 func (s *InvitesService) GroupInvites(gid interface{}, opt *InvitesOptions, options ...RequestOptionFunc) (*InvitesResult, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -153,7 +153,7 @@ func (s *InvitesService) GroupInvites(gid interface{}, opt *InvitesOptions, opti
 // ProjectInvites invites new users by email to join a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/invitations.html#invite-by-email-to-group-or-project
+// https://docs.gitlab.com/ee/api/invitations.html#add-a-member-to-a-group-or-project
 func (s *InvitesService) ProjectInvites(pid interface{}, opt *InvitesOptions, options ...RequestOptionFunc) (*InvitesResult, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/issue_links.go
+++ b/issue_links.go
@@ -124,7 +124,7 @@ func (s *IssueLinksService) GetIssueLink(pid interface{}, issue, issueLink int, 
 
 // CreateIssueLinkOptions represents the available CreateIssueLink() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/issue_links.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/issue_links.html#create-an-issue-link
 type CreateIssueLinkOptions struct {
 	TargetProjectID *string `json:"target_project_id"`
 	TargetIssueIID  *string `json:"target_issue_iid"`

--- a/issues.go
+++ b/issues.go
@@ -389,7 +389,7 @@ func (s *IssuesService) ListProjectIssues(pid interface{}, opt *ListProjectIssue
 
 // GetIssue gets a single project issue.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/issues.html#single-issues
+// GitLab API docs: https://docs.gitlab.com/ee/api/issues.html#single-project-issue
 func (s *IssuesService) GetIssue(pid interface{}, issue int, options ...RequestOptionFunc) (*Issue, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -413,7 +413,7 @@ func (s *IssuesService) GetIssue(pid interface{}, issue int, options ...RequestO
 
 // CreateIssueOptions represents the available CreateIssue() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/issues.html#new-issues
+// GitLab API docs: https://docs.gitlab.com/ee/api/issues.html#new-issue
 type CreateIssueOptions struct {
 	IID                                *int       `url:"iid,omitempty" json:"iid,omitempty"`
 	Title                              *string    `url:"title,omitempty" json:"title,omitempty"`
@@ -432,7 +432,7 @@ type CreateIssueOptions struct {
 
 // CreateIssue creates a new project issue.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/issues.html#new-issues
+// GitLab API docs: https://docs.gitlab.com/ee/api/issues.html#new-issue
 func (s *IssuesService) CreateIssue(pid interface{}, opt *CreateIssueOptions, options ...RequestOptionFunc) (*Issue, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -554,7 +554,7 @@ func (s *IssuesService) MoveIssue(pid interface{}, issue int, opt *MoveIssueOpti
 // status code 304 is returned.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/merge_requests.html#subscribe-to-a-merge-request
+// https://docs.gitlab.com/ee/api/issues.html#subscribe-to-an-issue
 func (s *IssuesService) SubscribeToIssue(pid interface{}, issue int, options ...RequestOptionFunc) (*Issue, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -581,7 +581,7 @@ func (s *IssuesService) SubscribeToIssue(pid interface{}, issue int, options ...
 // is not subscribed to the issue, status code 304 is returned.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/merge_requests.html#unsubscribe-from-a-merge-request
+// https://docs.gitlab.com/ee/api/issues.html#unsubscribe-from-an-issue
 func (s *IssuesService) UnsubscribeFromIssue(pid interface{}, issue int, options ...RequestOptionFunc) (*Issue, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -634,14 +634,14 @@ func (s *IssuesService) CreateTodo(pid interface{}, issue int, options ...Reques
 // ListMergeRequestsClosingIssue() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/issues.html#list-merge-requests-that-will-close-issue-on-merge
+// https://docs.gitlab.com/ee/api/issues.html#list-merge-requests-that-close-a-particular-issue-on-merge
 type ListMergeRequestsClosingIssueOptions ListOptions
 
 // ListMergeRequestsClosingIssue gets all the merge requests that will close
 // issue when merged.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/issues.html#list-merge-requests-that-will-close-issue-on-merge
+// https://docs.gitlab.com/ee/api/issues.html#list-merge-requests-that-close-a-particular-issue-on-merge
 func (s *IssuesService) ListMergeRequestsClosingIssue(pid interface{}, issue int, opt *ListMergeRequestsClosingIssueOptions, options ...RequestOptionFunc) ([]*MergeRequest, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/issues.go
+++ b/issues.go
@@ -30,7 +30,7 @@ import (
 // IssuesService handles communication with the issue related methods
 // of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/issues.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/issues.html
 type IssuesService struct {
 	client    *Client
 	timeStats *timeStatsService
@@ -83,7 +83,7 @@ type IssueLinks struct {
 
 // Issue represents a GitLab issue.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/issues.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/issues.html
 type Issue struct {
 	ID                   int                    `json:"id"`
 	IID                  int                    `json:"iid"`
@@ -204,7 +204,7 @@ type LabelDetails struct {
 
 // ListIssuesOptions represents the available ListIssues() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/issues.html#list-issues
+// GitLab API docs: https://docs.gitlab.com/ee/api/issues.html#list-issues
 type ListIssuesOptions struct {
 	ListOptions
 	State               *string          `url:"state,omitempty" json:"state,omitempty"`
@@ -244,7 +244,7 @@ type ListIssuesOptions struct {
 // ListIssues gets all issues created by authenticated user. This function
 // takes pagination parameters page and per_page to restrict the list of issues.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/issues.html#list-issues
+// GitLab API docs: https://docs.gitlab.com/ee/api/issues.html#list-issues
 func (s *IssuesService) ListIssues(opt *ListIssuesOptions, options ...RequestOptionFunc) ([]*Issue, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "issues", opt, options)
 	if err != nil {
@@ -262,7 +262,7 @@ func (s *IssuesService) ListIssues(opt *ListIssuesOptions, options ...RequestOpt
 
 // ListGroupIssuesOptions represents the available ListGroupIssues() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/issues.html#list-group-issues
+// GitLab API docs: https://docs.gitlab.com/ee/api/issues.html#list-group-issues
 type ListGroupIssuesOptions struct {
 	ListOptions
 	State             *string `url:"state,omitempty" json:"state,omitempty"`
@@ -302,7 +302,7 @@ type ListGroupIssuesOptions struct {
 // ListGroupIssues gets a list of group issues. This function accepts
 // pagination parameters page and per_page to return the list of group issues.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/issues.html#list-group-issues
+// GitLab API docs: https://docs.gitlab.com/ee/api/issues.html#list-group-issues
 func (s *IssuesService) ListGroupIssues(pid interface{}, opt *ListGroupIssuesOptions, options ...RequestOptionFunc) ([]*Issue, *Response, error) {
 	group, err := parseID(pid)
 	if err != nil {
@@ -326,7 +326,7 @@ func (s *IssuesService) ListGroupIssues(pid interface{}, opt *ListGroupIssuesOpt
 
 // ListProjectIssuesOptions represents the available ListProjectIssues() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/issues.html#list-project-issues
+// GitLab API docs: https://docs.gitlab.com/ee/api/issues.html#list-project-issues
 type ListProjectIssuesOptions struct {
 	ListOptions
 	IIDs                *[]int           `url:"iids[],omitempty" json:"iids,omitempty"`
@@ -365,7 +365,7 @@ type ListProjectIssuesOptions struct {
 // ListProjectIssues gets a list of project issues. This function accepts
 // pagination parameters page and per_page to return the list of project issues.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/issues.html#list-project-issues
+// GitLab API docs: https://docs.gitlab.com/ee/api/issues.html#list-project-issues
 func (s *IssuesService) ListProjectIssues(pid interface{}, opt *ListProjectIssuesOptions, options ...RequestOptionFunc) ([]*Issue, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -389,7 +389,7 @@ func (s *IssuesService) ListProjectIssues(pid interface{}, opt *ListProjectIssue
 
 // GetIssue gets a single project issue.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/issues.html#single-issues
+// GitLab API docs: https://docs.gitlab.com/ee/api/issues.html#single-issues
 func (s *IssuesService) GetIssue(pid interface{}, issue int, options ...RequestOptionFunc) (*Issue, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -413,7 +413,7 @@ func (s *IssuesService) GetIssue(pid interface{}, issue int, options ...RequestO
 
 // CreateIssueOptions represents the available CreateIssue() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/issues.html#new-issues
+// GitLab API docs: https://docs.gitlab.com/ee/api/issues.html#new-issues
 type CreateIssueOptions struct {
 	IID                                *int       `url:"iid,omitempty" json:"iid,omitempty"`
 	Title                              *string    `url:"title,omitempty" json:"title,omitempty"`
@@ -432,7 +432,7 @@ type CreateIssueOptions struct {
 
 // CreateIssue creates a new project issue.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/issues.html#new-issues
+// GitLab API docs: https://docs.gitlab.com/ee/api/issues.html#new-issues
 func (s *IssuesService) CreateIssue(pid interface{}, opt *CreateIssueOptions, options ...RequestOptionFunc) (*Issue, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -477,7 +477,7 @@ type UpdateIssueOptions struct {
 // UpdateIssue updates an existing project issue. This function is also used
 // to mark an issue as closed.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/issues.html#edit-issues
+// GitLab API docs: https://docs.gitlab.com/ee/api/issues.html#edit-issues
 func (s *IssuesService) UpdateIssue(pid interface{}, issue int, opt *UpdateIssueOptions, options ...RequestOptionFunc) (*Issue, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -501,7 +501,7 @@ func (s *IssuesService) UpdateIssue(pid interface{}, issue int, opt *UpdateIssue
 
 // DeleteIssue deletes a single project issue.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/issues.html#delete-an-issue
+// GitLab API docs: https://docs.gitlab.com/ee/api/issues.html#delete-an-issue
 func (s *IssuesService) DeleteIssue(pid interface{}, issue int, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -554,7 +554,7 @@ func (s *IssuesService) MoveIssue(pid interface{}, issue int, opt *MoveIssueOpti
 // status code 304 is returned.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/merge_requests.html#subscribe-to-a-merge-request
+// https://docs.gitlab.com/ee/api/merge_requests.html#subscribe-to-a-merge-request
 func (s *IssuesService) SubscribeToIssue(pid interface{}, issue int, options ...RequestOptionFunc) (*Issue, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -581,7 +581,7 @@ func (s *IssuesService) SubscribeToIssue(pid interface{}, issue int, options ...
 // is not subscribed to the issue, status code 304 is returned.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/merge_requests.html#unsubscribe-from-a-merge-request
+// https://docs.gitlab.com/ee/api/merge_requests.html#unsubscribe-from-a-merge-request
 func (s *IssuesService) UnsubscribeFromIssue(pid interface{}, issue int, options ...RequestOptionFunc) (*Issue, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -634,14 +634,14 @@ func (s *IssuesService) CreateTodo(pid interface{}, issue int, options ...Reques
 // ListMergeRequestsClosingIssue() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/issues.html#list-merge-requests-that-will-close-issue-on-merge
+// https://docs.gitlab.com/ee/api/issues.html#list-merge-requests-that-will-close-issue-on-merge
 type ListMergeRequestsClosingIssueOptions ListOptions
 
 // ListMergeRequestsClosingIssue gets all the merge requests that will close
 // issue when merged.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/issues.html#list-merge-requests-that-will-close-issue-on-merge
+// https://docs.gitlab.com/ee/api/issues.html#list-merge-requests-that-will-close-issue-on-merge
 func (s *IssuesService) ListMergeRequestsClosingIssue(pid interface{}, issue int, opt *ListMergeRequestsClosingIssueOptions, options ...RequestOptionFunc) ([]*MergeRequest, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -667,14 +667,14 @@ func (s *IssuesService) ListMergeRequestsClosingIssue(pid interface{}, issue int
 // ListMergeRequestsRelatedToIssue() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/issues.html#list-merge-requests-related-to-issue
+// https://docs.gitlab.com/ee/api/issues.html#list-merge-requests-related-to-issue
 type ListMergeRequestsRelatedToIssueOptions ListOptions
 
 // ListMergeRequestsRelatedToIssue gets all the merge requests that are
 // related to the issue
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/issues.html#list-merge-requests-related-to-issue
+// https://docs.gitlab.com/ee/api/issues.html#list-merge-requests-related-to-issue
 func (s *IssuesService) ListMergeRequestsRelatedToIssue(pid interface{}, issue int, opt *ListMergeRequestsRelatedToIssueOptions, options ...RequestOptionFunc) ([]*MergeRequest, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -702,7 +702,7 @@ func (s *IssuesService) ListMergeRequestsRelatedToIssue(pid interface{}, issue i
 // SetTimeEstimate sets the time estimate for a single project issue.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/issues.html#set-a-time-estimate-for-an-issue
+// https://docs.gitlab.com/ee/api/issues.html#set-a-time-estimate-for-an-issue
 func (s *IssuesService) SetTimeEstimate(pid interface{}, issue int, opt *SetTimeEstimateOptions, options ...RequestOptionFunc) (*TimeStats, *Response, error) {
 	return s.timeStats.setTimeEstimate(pid, "issues", issue, opt, options...)
 }
@@ -710,7 +710,7 @@ func (s *IssuesService) SetTimeEstimate(pid interface{}, issue int, opt *SetTime
 // ResetTimeEstimate resets the time estimate for a single project issue.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/issues.html#reset-the-time-estimate-for-an-issue
+// https://docs.gitlab.com/ee/api/issues.html#reset-the-time-estimate-for-an-issue
 func (s *IssuesService) ResetTimeEstimate(pid interface{}, issue int, options ...RequestOptionFunc) (*TimeStats, *Response, error) {
 	return s.timeStats.resetTimeEstimate(pid, "issues", issue, options...)
 }
@@ -718,7 +718,7 @@ func (s *IssuesService) ResetTimeEstimate(pid interface{}, issue int, options ..
 // AddSpentTime adds spent time for a single project issue.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/issues.html#add-spent-time-for-an-issue
+// https://docs.gitlab.com/ee/api/issues.html#add-spent-time-for-an-issue
 func (s *IssuesService) AddSpentTime(pid interface{}, issue int, opt *AddSpentTimeOptions, options ...RequestOptionFunc) (*TimeStats, *Response, error) {
 	return s.timeStats.addSpentTime(pid, "issues", issue, opt, options...)
 }
@@ -726,7 +726,7 @@ func (s *IssuesService) AddSpentTime(pid interface{}, issue int, opt *AddSpentTi
 // ResetSpentTime resets the spent time for a single project issue.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/issues.html#reset-spent-time-for-an-issue
+// https://docs.gitlab.com/ee/api/issues.html#reset-spent-time-for-an-issue
 func (s *IssuesService) ResetSpentTime(pid interface{}, issue int, options ...RequestOptionFunc) (*TimeStats, *Response, error) {
 	return s.timeStats.resetSpentTime(pid, "issues", issue, options...)
 }
@@ -734,7 +734,7 @@ func (s *IssuesService) ResetSpentTime(pid interface{}, issue int, options ...Re
 // GetTimeSpent gets the spent time for a single project issue.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/issues.html#get-time-tracking-stats
+// https://docs.gitlab.com/ee/api/issues.html#get-time-tracking-stats
 func (s *IssuesService) GetTimeSpent(pid interface{}, issue int, options ...RequestOptionFunc) (*TimeStats, *Response, error) {
 	return s.timeStats.getTimeSpent(pid, "issues", issue, options...)
 }
@@ -742,7 +742,7 @@ func (s *IssuesService) GetTimeSpent(pid interface{}, issue int, options ...Requ
 // GetParticipants gets a list of issue participants.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/issues.html#participants-on-issues
+// https://docs.gitlab.com/ee/api/issues.html#participants-on-issues
 func (s *IssuesService) GetParticipants(pid interface{}, issue int, options ...RequestOptionFunc) ([]*BasicUser, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/jobs.go
+++ b/jobs.go
@@ -375,7 +375,7 @@ func (s *JobsService) DownloadSingleArtifactsFileByTagOrBranch(pid interface{}, 
 // GetTraceFile gets a trace of a specific job of a project
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/jobs.html#get-a-trace-file
+// https://docs.gitlab.com/ee/api/jobs.html#get-a-log-file
 func (s *JobsService) GetTraceFile(pid interface{}, jobID int, options ...RequestOptionFunc) (*bytes.Reader, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -545,7 +545,7 @@ func (s *JobsService) PlayJob(pid interface{}, jobID int, opt *PlayJobOptions, o
 // DeleteArtifacts delete artifacts of a job
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/job_artifacts.html#delete-artifacts
+// https://docs.gitlab.com/ee/api/job_artifacts.html#delete-job-artifacts
 func (s *JobsService) DeleteArtifacts(pid interface{}, jobID int, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/jobs.go
+++ b/jobs.go
@@ -26,14 +26,14 @@ import (
 // JobsService handles communication with the ci builds related methods
 // of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/jobs.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/jobs.html
 type JobsService struct {
 	client *Client
 }
 
 // Job represents a ci build.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/jobs.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/jobs.html
 type Job struct {
 	Commit            *Commit    `json:"commit"`
 	Coverage          float64    `json:"coverage"`
@@ -83,7 +83,7 @@ type Job struct {
 
 // Bridge represents a pipeline bridge.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/jobs.html#list-pipeline-bridges
+// GitLab API docs: https://docs.gitlab.com/ee/api/jobs.html#list-pipeline-bridges
 type Bridge struct {
 	Commit             *Commit       `json:"commit"`
 	Coverage           float64       `json:"coverage"`
@@ -107,7 +107,7 @@ type Bridge struct {
 // ListJobsOptions represents the available ListProjectJobs() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/jobs.html#list-project-jobs
+// https://docs.gitlab.com/ee/api/jobs.html#list-project-jobs
 type ListJobsOptions struct {
 	ListOptions
 	Scope          *[]BuildStateValue `url:"scope[],omitempty" json:"scope,omitempty"`
@@ -120,7 +120,7 @@ type ListJobsOptions struct {
 // failed, success, canceled, skipped; showing all jobs if none provided
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/jobs.html#list-project-jobs
+// https://docs.gitlab.com/ee/api/jobs.html#list-project-jobs
 func (s *JobsService) ListProjectJobs(pid interface{}, opts *ListJobsOptions, options ...RequestOptionFunc) ([]*Job, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -146,7 +146,7 @@ func (s *JobsService) ListProjectJobs(pid interface{}, opts *ListJobsOptions, op
 // project. If the pipeline ID is not found, it will respond with 404.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/jobs.html#list-pipeline-jobs
+// https://docs.gitlab.com/ee/api/jobs.html#list-pipeline-jobs
 func (s *JobsService) ListPipelineJobs(pid interface{}, pipelineID int, opts *ListJobsOptions, options ...RequestOptionFunc) ([]*Job, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -172,7 +172,7 @@ func (s *JobsService) ListPipelineJobs(pid interface{}, pipelineID int, opts *Li
 // project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/jobs.html#list-pipeline-jobs
+// https://docs.gitlab.com/ee/api/jobs.html#list-pipeline-jobs
 func (s *JobsService) ListPipelineBridges(pid interface{}, pipelineID int, opts *ListJobsOptions, options ...RequestOptionFunc) ([]*Bridge, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -196,14 +196,14 @@ func (s *JobsService) ListPipelineBridges(pid interface{}, pipelineID int, opts 
 
 // GetJobTokensJobOptions represents the available GetJobTokensJob() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/jobs.html#get-job-tokens-job
+// GitLab API docs: https://docs.gitlab.com/ee/api/jobs.html#get-job-tokens-job
 type GetJobTokensJobOptions struct {
 	JobToken *string `url:"job_token,omitempty" json:"job_token,omitempty"`
 }
 
 // GetJobTokensJob retrieves the job that generated a job token.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/jobs.html#get-job-tokens-job
+// GitLab API docs: https://docs.gitlab.com/ee/api/jobs.html#get-job-tokens-job
 func (s *JobsService) GetJobTokensJob(opts *GetJobTokensJobOptions, options ...RequestOptionFunc) (*Job, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "job", opts, options)
 	if err != nil {
@@ -222,7 +222,7 @@ func (s *JobsService) GetJobTokensJob(opts *GetJobTokensJobOptions, options ...R
 // GetJob gets a single job of a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/jobs.html#get-a-single-job
+// https://docs.gitlab.com/ee/api/jobs.html#get-a-single-job
 func (s *JobsService) GetJob(pid interface{}, jobID int, options ...RequestOptionFunc) (*Job, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -247,7 +247,7 @@ func (s *JobsService) GetJob(pid interface{}, jobID int, options ...RequestOptio
 // GetJobArtifacts get jobs artifacts of a project
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/job_artifacts.html#get-job-artifacts
+// https://docs.gitlab.com/ee/api/job_artifacts.html#get-job-artifacts
 func (s *JobsService) GetJobArtifacts(pid interface{}, jobID int, options ...RequestOptionFunc) (*bytes.Reader, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -273,7 +273,7 @@ func (s *JobsService) GetJobArtifacts(pid interface{}, jobID int, options ...Req
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/job_artifacts.html#download-the-artifacts-archive
+// https://docs.gitlab.com/ee/api/job_artifacts.html#download-the-artifacts-archive
 type DownloadArtifactsFileOptions struct {
 	Job *string `url:"job" json:"job"`
 }
@@ -282,7 +282,7 @@ type DownloadArtifactsFileOptions struct {
 // reference name and job provided the job finished successfully.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/job_artifacts.html#download-the-artifacts-archive
+// https://docs.gitlab.com/ee/api/job_artifacts.html#download-the-artifacts-archive
 func (s *JobsService) DownloadArtifactsFile(pid interface{}, refName string, opt *DownloadArtifactsFileOptions, options ...RequestOptionFunc) (*bytes.Reader, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -310,7 +310,7 @@ func (s *JobsService) DownloadArtifactsFile(pid interface{}, refName string, opt
 // to a client.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/job_artifacts.html#download-a-single-artifact-file-by-job-id
+// https://docs.gitlab.com/ee/api/job_artifacts.html#download-a-single-artifact-file-by-job-id
 func (s *JobsService) DownloadSingleArtifactsFile(pid interface{}, jobID int, artifactPath string, options ...RequestOptionFunc) (*bytes.Reader, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -344,7 +344,7 @@ func (s *JobsService) DownloadSingleArtifactsFile(pid interface{}, jobID int, ar
 // and streamed to the client.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/job_artifacts.html#download-a-single-artifact-file-from-specific-tag-or-branch
+// https://docs.gitlab.com/ee/api/job_artifacts.html#download-a-single-artifact-file-from-specific-tag-or-branch
 func (s *JobsService) DownloadSingleArtifactsFileByTagOrBranch(pid interface{}, refName string, artifactPath string, opt *DownloadArtifactsFileOptions, options ...RequestOptionFunc) (*bytes.Reader, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -375,7 +375,7 @@ func (s *JobsService) DownloadSingleArtifactsFileByTagOrBranch(pid interface{}, 
 // GetTraceFile gets a trace of a specific job of a project
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/jobs.html#get-a-trace-file
+// https://docs.gitlab.com/ee/api/jobs.html#get-a-trace-file
 func (s *JobsService) GetTraceFile(pid interface{}, jobID int, options ...RequestOptionFunc) (*bytes.Reader, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -400,7 +400,7 @@ func (s *JobsService) GetTraceFile(pid interface{}, jobID int, options ...Reques
 // CancelJob cancels a single job of a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/jobs.html#cancel-a-job
+// https://docs.gitlab.com/ee/api/jobs.html#cancel-a-job
 func (s *JobsService) CancelJob(pid interface{}, jobID int, options ...RequestOptionFunc) (*Job, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -425,7 +425,7 @@ func (s *JobsService) CancelJob(pid interface{}, jobID int, options ...RequestOp
 // RetryJob retries a single job of a project
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/jobs.html#retry-a-job
+// https://docs.gitlab.com/ee/api/jobs.html#retry-a-job
 func (s *JobsService) RetryJob(pid interface{}, jobID int, options ...RequestOptionFunc) (*Job, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -451,7 +451,7 @@ func (s *JobsService) RetryJob(pid interface{}, jobID int, options ...RequestOpt
 // artifacts and a job trace.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/jobs.html#erase-a-job
+// https://docs.gitlab.com/ee/api/jobs.html#erase-a-job
 func (s *JobsService) EraseJob(pid interface{}, jobID int, options ...RequestOptionFunc) (*Job, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -477,7 +477,7 @@ func (s *JobsService) EraseJob(pid interface{}, jobID int, options ...RequestOpt
 // expiration is set.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/job_artifacts.html#keep-artifacts
+// https://docs.gitlab.com/ee/api/job_artifacts.html#keep-artifacts
 func (s *JobsService) KeepArtifacts(pid interface{}, jobID int, options ...RequestOptionFunc) (*Job, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -502,7 +502,7 @@ func (s *JobsService) KeepArtifacts(pid interface{}, jobID int, options ...Reque
 // PlayJobOptions represents the available PlayJob() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/jobs.html#run-a-job
+// https://docs.gitlab.com/ee/api/jobs.html#run-a-job
 type PlayJobOptions struct {
 	JobVariablesAttributes *[]*JobVariableOptions `url:"job_variables_attributes,omitempty" json:"job_variables_attributes,omitempty"`
 }
@@ -510,7 +510,7 @@ type PlayJobOptions struct {
 // JobVariableOptions represents a single job variable.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/jobs.html#run-a-job
+// https://docs.gitlab.com/ee/api/jobs.html#run-a-job
 type JobVariableOptions struct {
 	Key          *string `url:"key,omitempty" json:"key,omitempty"`
 	Value        *string `url:"value,omitempty" json:"value,omitempty"`
@@ -520,7 +520,7 @@ type JobVariableOptions struct {
 // PlayJob triggers a manual action to start a job.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/jobs.html#run-a-job
+// https://docs.gitlab.com/ee/api/jobs.html#run-a-job
 func (s *JobsService) PlayJob(pid interface{}, jobID int, opt *PlayJobOptions, options ...RequestOptionFunc) (*Job, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -545,7 +545,7 @@ func (s *JobsService) PlayJob(pid interface{}, jobID int, opt *PlayJobOptions, o
 // DeleteArtifacts delete artifacts of a job
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/job_artifacts.html#delete-artifacts
+// https://docs.gitlab.com/ee/api/job_artifacts.html#delete-artifacts
 func (s *JobsService) DeleteArtifacts(pid interface{}, jobID int, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/labels.go
+++ b/labels.go
@@ -195,7 +195,7 @@ func (s *LabelsService) DeleteLabel(pid interface{}, opt *DeleteLabelOptions, op
 
 // UpdateLabelOptions represents the available UpdateLabel() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/labels.html#delete-a-label
+// GitLab API docs: https://docs.gitlab.com/ee/api/labels.html#edit-an-existing-label
 type UpdateLabelOptions struct {
 	Name        *string `url:"name,omitempty" json:"name,omitempty"`
 	NewName     *string `url:"new_name,omitempty" json:"new_name,omitempty"`

--- a/labels.go
+++ b/labels.go
@@ -25,14 +25,14 @@ import (
 // LabelsService handles communication with the label related methods of the
 // GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/labels.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/labels.html
 type LabelsService struct {
 	client *Client
 }
 
 // Label represents a GitLab label.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/labels.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/labels.html
 type Label struct {
 	ID                     int    `json:"id"`
 	Name                   string `json:"name"`
@@ -73,7 +73,7 @@ func (l Label) String() string {
 
 // ListLabelsOptions represents the available ListLabels() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/labels.html#list-labels
+// GitLab API docs: https://docs.gitlab.com/ee/api/labels.html#list-labels
 type ListLabelsOptions struct {
 	ListOptions
 	WithCounts            *bool   `url:"with_counts,omitempty" json:"with_counts,omitempty"`
@@ -83,7 +83,7 @@ type ListLabelsOptions struct {
 
 // ListLabels gets all labels for given project.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/labels.html#list-labels
+// GitLab API docs: https://docs.gitlab.com/ee/api/labels.html#list-labels
 func (s *LabelsService) ListLabels(pid interface{}, opt *ListLabelsOptions, options ...RequestOptionFunc) ([]*Label, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -107,7 +107,7 @@ func (s *LabelsService) ListLabels(pid interface{}, opt *ListLabelsOptions, opti
 
 // GetLabel get a single label for a given project.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/labels.html#get-a-single-project-label
+// GitLab API docs: https://docs.gitlab.com/ee/api/labels.html#get-a-single-project-label
 func (s *LabelsService) GetLabel(pid interface{}, labelID interface{}, options ...RequestOptionFunc) (*Label, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -135,7 +135,7 @@ func (s *LabelsService) GetLabel(pid interface{}, labelID interface{}, options .
 
 // CreateLabelOptions represents the available CreateLabel() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/labels.html#create-a-new-label
+// GitLab API docs: https://docs.gitlab.com/ee/api/labels.html#create-a-new-label
 type CreateLabelOptions struct {
 	Name        *string `url:"name,omitempty" json:"name,omitempty"`
 	Color       *string `url:"color,omitempty" json:"color,omitempty"`
@@ -146,7 +146,7 @@ type CreateLabelOptions struct {
 // CreateLabel creates a new label for given repository with given name and
 // color.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/labels.html#create-a-new-label
+// GitLab API docs: https://docs.gitlab.com/ee/api/labels.html#create-a-new-label
 func (s *LabelsService) CreateLabel(pid interface{}, opt *CreateLabelOptions, options ...RequestOptionFunc) (*Label, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -170,14 +170,14 @@ func (s *LabelsService) CreateLabel(pid interface{}, opt *CreateLabelOptions, op
 
 // DeleteLabelOptions represents the available DeleteLabel() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/labels.html#delete-a-label
+// GitLab API docs: https://docs.gitlab.com/ee/api/labels.html#delete-a-label
 type DeleteLabelOptions struct {
 	Name *string `url:"name,omitempty" json:"name,omitempty"`
 }
 
 // DeleteLabel deletes a label given by its name.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/labels.html#delete-a-label
+// GitLab API docs: https://docs.gitlab.com/ee/api/labels.html#delete-a-label
 func (s *LabelsService) DeleteLabel(pid interface{}, opt *DeleteLabelOptions, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -195,7 +195,7 @@ func (s *LabelsService) DeleteLabel(pid interface{}, opt *DeleteLabelOptions, op
 
 // UpdateLabelOptions represents the available UpdateLabel() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/labels.html#delete-a-label
+// GitLab API docs: https://docs.gitlab.com/ee/api/labels.html#delete-a-label
 type UpdateLabelOptions struct {
 	Name        *string `url:"name,omitempty" json:"name,omitempty"`
 	NewName     *string `url:"new_name,omitempty" json:"new_name,omitempty"`
@@ -207,7 +207,7 @@ type UpdateLabelOptions struct {
 // UpdateLabel updates an existing label with new name or now color. At least
 // one parameter is required, to update the label.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/labels.html#edit-an-existing-label
+// GitLab API docs: https://docs.gitlab.com/ee/api/labels.html#edit-an-existing-label
 func (s *LabelsService) UpdateLabel(pid interface{}, opt *UpdateLabelOptions, options ...RequestOptionFunc) (*Label, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -234,7 +234,7 @@ func (s *LabelsService) UpdateLabel(pid interface{}, opt *UpdateLabelOptions, op
 // code 304 is returned.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/labels.html#subscribe-to-a-label
+// https://docs.gitlab.com/ee/api/labels.html#subscribe-to-a-label
 func (s *LabelsService) SubscribeToLabel(pid interface{}, labelID interface{}, options ...RequestOptionFunc) (*Label, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -265,7 +265,7 @@ func (s *LabelsService) SubscribeToLabel(pid interface{}, labelID interface{}, o
 // status code 304 is returned.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/labels.html#unsubscribe-from-a-label
+// https://docs.gitlab.com/ee/api/labels.html#unsubscribe-from-a-label
 func (s *LabelsService) UnsubscribeFromLabel(pid interface{}, labelID interface{}, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -288,7 +288,7 @@ func (s *LabelsService) UnsubscribeFromLabel(pid interface{}, labelID interface{
 // PromoteLabel Promotes a project label to a group label.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/labels.html#promote-a-project-label-to-a-group-label
+// https://docs.gitlab.com/ee/api/labels.html#promote-a-project-label-to-a-group-label
 func (s *LabelsService) PromoteLabel(pid interface{}, labelID interface{}, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/license_templates.go
+++ b/license_templates.go
@@ -24,7 +24,7 @@ import (
 // LicenseTemplate represents a license template.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/templates/licenses.html
+// https://docs.gitlab.com/ee/api/templates/licenses.html
 type LicenseTemplate struct {
 	Key         string   `json:"key"`
 	Name        string   `json:"name"`
@@ -42,7 +42,7 @@ type LicenseTemplate struct {
 // LicenseTemplatesService handles communication with the license templates
 // related methods of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/templates/licenses.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/templates/licenses.html
 type LicenseTemplatesService struct {
 	client *Client
 }
@@ -51,7 +51,7 @@ type LicenseTemplatesService struct {
 // ListLicenseTemplates() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/templates/licenses.html#list-license-templates
+// https://docs.gitlab.com/ee/api/templates/licenses.html#list-license-templates
 type ListLicenseTemplatesOptions struct {
 	ListOptions
 	Popular *bool `url:"popular,omitempty" json:"popular,omitempty"`
@@ -60,7 +60,7 @@ type ListLicenseTemplatesOptions struct {
 // ListLicenseTemplates get all license templates.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/templates/licenses.html#list-license-templates
+// https://docs.gitlab.com/ee/api/templates/licenses.html#list-license-templates
 func (s *LicenseTemplatesService) ListLicenseTemplates(opt *ListLicenseTemplatesOptions, options ...RequestOptionFunc) ([]*LicenseTemplate, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "templates/licenses", opt, options)
 	if err != nil {
@@ -80,7 +80,7 @@ func (s *LicenseTemplatesService) ListLicenseTemplates(opt *ListLicenseTemplates
 // GetLicenseTemplate() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/templates/licenses.html#single-license-template
+// https://docs.gitlab.com/ee/api/templates/licenses.html#single-license-template
 type GetLicenseTemplateOptions struct {
 	Project  *string `url:"project,omitempty" json:"project,omitempty"`
 	Fullname *string `url:"fullname,omitempty" json:"fullname,omitempty"`
@@ -90,7 +90,7 @@ type GetLicenseTemplateOptions struct {
 // to replace the license placeholder.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/templates/licenses.html#single-license-template
+// https://docs.gitlab.com/ee/api/templates/licenses.html#single-license-template
 func (s *LicenseTemplatesService) GetLicenseTemplate(template string, opt *GetLicenseTemplateOptions, options ...RequestOptionFunc) (*LicenseTemplate, *Response, error) {
 	u := fmt.Sprintf("templates/licenses/%s", template)
 

--- a/merge_request_approvals.go
+++ b/merge_request_approvals.go
@@ -184,7 +184,7 @@ func (s *MergeRequestApprovalsService) UnapproveMergeRequest(pid interface{}, mr
 // ChangeMergeRequestApprovalConfiguration() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/merge_request_approvals.html#change-approval-configuration
+// https://docs.gitlab.com/ee/api/merge_request_approvals.html#change-approval-configuration-deprecated
 type ChangeMergeRequestApprovalConfigurationOptions struct {
 	ApprovalsRequired *int `url:"approvals_required,omitempty" json:"approvals_required,omitempty"`
 }
@@ -217,7 +217,7 @@ func (s *MergeRequestApprovalsService) GetConfiguration(pid interface{}, mr int,
 // ChangeApprovalConfiguration updates the approval configuration of a merge request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/merge_request_approvals.html#change-approval-configuration
+// https://docs.gitlab.com/ee/api/merge_request_approvals.html#change-approval-configuration-deprecated
 func (s *MergeRequestApprovalsService) ChangeApprovalConfiguration(pid interface{}, mergeRequest int, opt *ChangeMergeRequestApprovalConfigurationOptions, options ...RequestOptionFunc) (*MergeRequest, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/merge_requests.go
+++ b/merge_requests.go
@@ -25,7 +25,7 @@ import (
 // MergeRequestsService handles communication with the merge requests related
 // methods of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/merge_requests.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/merge_requests.html
 type MergeRequestsService struct {
 	client    *Client
 	timeStats *timeStatsService
@@ -33,7 +33,7 @@ type MergeRequestsService struct {
 
 // MergeRequest represents a GitLab merge request.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/merge_requests.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/merge_requests.html
 type MergeRequest struct {
 	ID                        int              `json:"id"`
 	IID                       int              `json:"iid"`
@@ -119,7 +119,7 @@ func (m MergeRequest) String() string {
 // MergeRequestDiffVersion represents Gitlab merge request version.
 //
 // Gitlab API docs:
-// https://docs.gitlab.com/ce/api/merge_requests.html#get-a-single-mr-diff-version
+// https://docs.gitlab.com/ee/api/merge_requests.html#get-a-single-mr-diff-version
 type MergeRequestDiffVersion struct {
 	ID             int        `json:"id"`
 	HeadCommitSHA  string     `json:"head_commit_sha,omitempty"`
@@ -141,7 +141,7 @@ func (m MergeRequestDiffVersion) String() string {
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/merge_requests.html#list-merge-requests
+// https://docs.gitlab.com/ee/api/merge_requests.html#list-merge-requests
 type ListMergeRequestsOptions struct {
 	ListOptions
 	State                  *string           `url:"state,omitempty" json:"state,omitempty"`
@@ -180,7 +180,7 @@ type ListMergeRequestsOptions struct {
 // used to restrict the list of merge requests.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/merge_requests.html#list-merge-requests
+// https://docs.gitlab.com/ee/api/merge_requests.html#list-merge-requests
 func (s *MergeRequestsService) ListMergeRequests(opt *ListMergeRequestsOptions, options ...RequestOptionFunc) ([]*MergeRequest, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "merge_requests", opt, options)
 	if err != nil {
@@ -200,7 +200,7 @@ func (s *MergeRequestsService) ListMergeRequests(opt *ListMergeRequestsOptions, 
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/merge_requests.html#list-project-merge-requests
+// https://docs.gitlab.com/ee/api/merge_requests.html#list-project-merge-requests
 type ListProjectMergeRequestsOptions struct {
 	ListOptions
 	IIDs                   *[]int            `url:"iids[],omitempty" json:"iids,omitempty"`
@@ -236,7 +236,7 @@ type ListProjectMergeRequestsOptions struct {
 // ListProjectMergeRequests gets all merge requests for this project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/merge_requests.html#list-project-merge-requests
+// https://docs.gitlab.com/ee/api/merge_requests.html#list-project-merge-requests
 func (s *MergeRequestsService) ListProjectMergeRequests(pid interface{}, opt *ListProjectMergeRequestsOptions, options ...RequestOptionFunc) ([]*MergeRequest, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -262,7 +262,7 @@ func (s *MergeRequestsService) ListProjectMergeRequests(pid interface{}, opt *Li
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/merge_requests.html#list-group-merge-requests
+// https://docs.gitlab.com/ee/api/merge_requests.html#list-group-merge-requests
 type ListGroupMergeRequestsOptions struct {
 	ListOptions
 	State                  *string           `url:"state,omitempty" json:"state,omitempty"`
@@ -298,7 +298,7 @@ type ListGroupMergeRequestsOptions struct {
 // ListGroupMergeRequests gets all merge requests for this group.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/merge_requests.html#list-group-merge-requests
+// https://docs.gitlab.com/ee/api/merge_requests.html#list-group-merge-requests
 func (s *MergeRequestsService) ListGroupMergeRequests(gid interface{}, opt *ListGroupMergeRequestsOptions, options ...RequestOptionFunc) ([]*MergeRequest, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -324,7 +324,7 @@ func (s *MergeRequestsService) ListGroupMergeRequests(gid interface{}, opt *List
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/merge_requests.html#get-single-mr
+// https://docs.gitlab.com/ee/api/merge_requests.html#get-single-mr
 type GetMergeRequestsOptions struct {
 	RenderHTML                  *bool `url:"render_html,omitempty" json:"render_html,omitempty"`
 	IncludeDivergedCommitsCount *bool `url:"include_diverged_commits_count,omitempty" json:"include_diverged_commits_count,omitempty"`
@@ -334,7 +334,7 @@ type GetMergeRequestsOptions struct {
 // GetMergeRequest shows information about a single merge request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/merge_requests.html#get-single-mr
+// https://docs.gitlab.com/ee/api/merge_requests.html#get-single-mr
 func (s *MergeRequestsService) GetMergeRequest(pid interface{}, mergeRequest int, opt *GetMergeRequestsOptions, options ...RequestOptionFunc) (*MergeRequest, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -385,13 +385,13 @@ func (s *MergeRequestsService) GetMergeRequestApprovals(pid interface{}, mergeRe
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/merge_requests.html#get-single-mr-commits
+// https://docs.gitlab.com/ee/api/merge_requests.html#get-single-mr-commits
 type GetMergeRequestCommitsOptions ListOptions
 
 // GetMergeRequestCommits gets a list of merge request commits.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/merge_requests.html#get-single-mr-commits
+// https://docs.gitlab.com/ee/api/merge_requests.html#get-single-mr-commits
 func (s *MergeRequestsService) GetMergeRequestCommits(pid interface{}, mergeRequest int, opt *GetMergeRequestCommitsOptions, options ...RequestOptionFunc) ([]*Commit, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -417,7 +417,7 @@ func (s *MergeRequestsService) GetMergeRequestCommits(pid interface{}, mergeRequ
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/merge_requests.html#get-single-mr-changes
+// https://docs.gitlab.com/ee/api/merge_requests.html#get-single-mr-changes
 type GetMergeRequestChangesOptions struct {
 	AccessRawDiffs *bool `url:"access_raw_diffs,omitempty" json:"access_raw_diffs,omitempty"`
 }
@@ -426,7 +426,7 @@ type GetMergeRequestChangesOptions struct {
 // its files and changes.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/merge_requests.html#get-single-mr-changes
+// https://docs.gitlab.com/ee/api/merge_requests.html#get-single-mr-changes
 func (s *MergeRequestsService) GetMergeRequestChanges(pid interface{}, mergeRequest int, opt *GetMergeRequestChangesOptions, options ...RequestOptionFunc) (*MergeRequest, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -476,7 +476,7 @@ func (s *MergeRequestsService) GetMergeRequestParticipants(pid interface{}, merg
 // ListMergeRequestPipelines gets all pipelines for the provided merge request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/merge_requests.html#list-mr-pipelines
+// https://docs.gitlab.com/ee/api/merge_requests.html#list-mr-pipelines
 func (s *MergeRequestsService) ListMergeRequestPipelines(pid interface{}, mergeRequest int, options ...RequestOptionFunc) ([]*PipelineInfo, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -501,7 +501,7 @@ func (s *MergeRequestsService) ListMergeRequestPipelines(pid interface{}, mergeR
 // CreateMergeRequestPipeline creates a new pipeline for a merge request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/merge_requests.html#create-mr-pipeline
+// https://docs.gitlab.com/ee/api/merge_requests.html#create-mr-pipeline
 func (s *MergeRequestsService) CreateMergeRequestPipeline(pid interface{}, mergeRequest int, options ...RequestOptionFunc) (*PipelineInfo, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -560,7 +560,7 @@ func (s *MergeRequestsService) GetIssuesClosedOnMerge(pid interface{}, mergeRequ
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/merge_requests.html#create-mr
+// https://docs.gitlab.com/ee/api/merge_requests.html#create-mr
 type CreateMergeRequestOptions struct {
 	Title              *string `url:"title,omitempty" json:"title,omitempty"`
 	Description        *string `url:"description,omitempty" json:"description,omitempty"`
@@ -580,7 +580,7 @@ type CreateMergeRequestOptions struct {
 // CreateMergeRequest creates a new merge request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/merge_requests.html#create-mr
+// https://docs.gitlab.com/ee/api/merge_requests.html#create-mr
 func (s *MergeRequestsService) CreateMergeRequest(pid interface{}, opt *CreateMergeRequestOptions, options ...RequestOptionFunc) (*MergeRequest, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -606,7 +606,7 @@ func (s *MergeRequestsService) CreateMergeRequest(pid interface{}, opt *CreateMe
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/merge_requests.html#update-mr
+// https://docs.gitlab.com/ee/api/merge_requests.html#update-mr
 type UpdateMergeRequestOptions struct {
 	Title              *string `url:"title,omitempty" json:"title,omitempty"`
 	Description        *string `url:"description,omitempty" json:"description,omitempty"`
@@ -628,7 +628,7 @@ type UpdateMergeRequestOptions struct {
 // UpdateMergeRequest updates an existing project milestone.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/merge_requests.html#update-mr
+// https://docs.gitlab.com/ee/api/merge_requests.html#update-mr
 func (s *MergeRequestsService) UpdateMergeRequest(pid interface{}, mergeRequest int, opt *UpdateMergeRequestOptions, options ...RequestOptionFunc) (*MergeRequest, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -653,7 +653,7 @@ func (s *MergeRequestsService) UpdateMergeRequest(pid interface{}, mergeRequest 
 // DeleteMergeRequest deletes a merge request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/merge_requests.html#delete-a-merge-request
+// https://docs.gitlab.com/ee/api/merge_requests.html#delete-a-merge-request
 func (s *MergeRequestsService) DeleteMergeRequest(pid interface{}, mergeRequest int, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -718,7 +718,7 @@ func (s *MergeRequestsService) AcceptMergeRequest(pid interface{}, mergeRequest 
 // merged when the pipeline succeeds, you'll also get a 406 error.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/merge_requests.html#cancel-merge-when-pipeline-succeeds
+// https://docs.gitlab.com/ee/api/merge_requests.html#cancel-merge-when-pipeline-succeeds
 func (s *MergeRequestsService) CancelMergeWhenPipelineSucceeds(pid interface{}, mergeRequest int, options ...RequestOptionFunc) (*MergeRequest, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -745,7 +745,7 @@ func (s *MergeRequestsService) CancelMergeWhenPipelineSucceeds(pid interface{}, 
 // to the merge request’s source branch, you’ll get a 403 Forbidden response.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/merge_requests.html#rebase-a-merge-request
+// https://docs.gitlab.com/ee/api/merge_requests.html#rebase-a-merge-request
 func (s *MergeRequestsService) RebaseMergeRequest(pid interface{}, mergeRequest int, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -765,13 +765,13 @@ func (s *MergeRequestsService) RebaseMergeRequest(pid interface{}, mergeRequest 
 // GetMergeRequestDiffVersions() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/merge_requests.html#get-mr-diff-versions
+// https://docs.gitlab.com/ee/api/merge_requests.html#get-mr-diff-versions
 type GetMergeRequestDiffVersionsOptions ListOptions
 
 // GetMergeRequestDiffVersions get a list of merge request diff versions.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/merge_requests.html#get-mr-diff-versions
+// https://docs.gitlab.com/ee/api/merge_requests.html#get-mr-diff-versions
 func (s *MergeRequestsService) GetMergeRequestDiffVersions(pid interface{}, mergeRequest int, opt *GetMergeRequestDiffVersionsOptions, options ...RequestOptionFunc) ([]*MergeRequestDiffVersion, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -796,7 +796,7 @@ func (s *MergeRequestsService) GetMergeRequestDiffVersions(pid interface{}, merg
 // GetSingleMergeRequestDiffVersion get a single MR diff version
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/merge_requests.html#get-a-single-mr-diff-version
+// https://docs.gitlab.com/ee/api/merge_requests.html#get-a-single-mr-diff-version
 func (s *MergeRequestsService) GetSingleMergeRequestDiffVersion(pid interface{}, mergeRequest, version int, options ...RequestOptionFunc) (*MergeRequestDiffVersion, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -823,7 +823,7 @@ func (s *MergeRequestsService) GetSingleMergeRequestDiffVersion(pid interface{},
 // merge request, the status code 304 is returned.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/merge_requests.html#subscribe-to-a-merge-request
+// https://docs.gitlab.com/ee/api/merge_requests.html#subscribe-to-a-merge-request
 func (s *MergeRequestsService) SubscribeToMergeRequest(pid interface{}, mergeRequest int, options ...RequestOptionFunc) (*MergeRequest, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -851,7 +851,7 @@ func (s *MergeRequestsService) SubscribeToMergeRequest(pid interface{}, mergeReq
 // returned.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/merge_requests.html#unsubscribe-from-a-merge-request
+// https://docs.gitlab.com/ee/api/merge_requests.html#unsubscribe-from-a-merge-request
 func (s *MergeRequestsService) UnsubscribeFromMergeRequest(pid interface{}, mergeRequest int, options ...RequestOptionFunc) (*MergeRequest, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -903,7 +903,7 @@ func (s *MergeRequestsService) CreateTodo(pid interface{}, mergeRequest int, opt
 // SetTimeEstimate sets the time estimate for a single project merge request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/merge_requests.html#set-a-time-estimate-for-a-merge-request
+// https://docs.gitlab.com/ee/api/merge_requests.html#set-a-time-estimate-for-a-merge-request
 func (s *MergeRequestsService) SetTimeEstimate(pid interface{}, mergeRequest int, opt *SetTimeEstimateOptions, options ...RequestOptionFunc) (*TimeStats, *Response, error) {
 	return s.timeStats.setTimeEstimate(pid, "merge_requests", mergeRequest, opt, options...)
 }
@@ -911,7 +911,7 @@ func (s *MergeRequestsService) SetTimeEstimate(pid interface{}, mergeRequest int
 // ResetTimeEstimate resets the time estimate for a single project merge request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/merge_requests.html#reset-the-time-estimate-for-a-merge-request
+// https://docs.gitlab.com/ee/api/merge_requests.html#reset-the-time-estimate-for-a-merge-request
 func (s *MergeRequestsService) ResetTimeEstimate(pid interface{}, mergeRequest int, options ...RequestOptionFunc) (*TimeStats, *Response, error) {
 	return s.timeStats.resetTimeEstimate(pid, "merge_requests", mergeRequest, options...)
 }
@@ -919,7 +919,7 @@ func (s *MergeRequestsService) ResetTimeEstimate(pid interface{}, mergeRequest i
 // AddSpentTime adds spent time for a single project merge request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/merge_requests.html#add-spent-time-for-a-merge-request
+// https://docs.gitlab.com/ee/api/merge_requests.html#add-spent-time-for-a-merge-request
 func (s *MergeRequestsService) AddSpentTime(pid interface{}, mergeRequest int, opt *AddSpentTimeOptions, options ...RequestOptionFunc) (*TimeStats, *Response, error) {
 	return s.timeStats.addSpentTime(pid, "merge_requests", mergeRequest, opt, options...)
 }
@@ -927,7 +927,7 @@ func (s *MergeRequestsService) AddSpentTime(pid interface{}, mergeRequest int, o
 // ResetSpentTime resets the spent time for a single project merge request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/merge_requests.html#reset-spent-time-for-a-merge-request
+// https://docs.gitlab.com/ee/api/merge_requests.html#reset-spent-time-for-a-merge-request
 func (s *MergeRequestsService) ResetSpentTime(pid interface{}, mergeRequest int, options ...RequestOptionFunc) (*TimeStats, *Response, error) {
 	return s.timeStats.resetSpentTime(pid, "merge_requests", mergeRequest, options...)
 }
@@ -935,7 +935,7 @@ func (s *MergeRequestsService) ResetSpentTime(pid interface{}, mergeRequest int,
 // GetTimeSpent gets the spent time for a single project merge request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/merge_requests.html#get-time-tracking-stats
+// https://docs.gitlab.com/ee/api/merge_requests.html#get-time-tracking-stats
 func (s *MergeRequestsService) GetTimeSpent(pid interface{}, mergeRequest int, options ...RequestOptionFunc) (*TimeStats, *Response, error) {
 	return s.timeStats.getTimeSpent(pid, "merge_requests", mergeRequest, options...)
 }

--- a/merge_requests.go
+++ b/merge_requests.go
@@ -119,7 +119,7 @@ func (m MergeRequest) String() string {
 // MergeRequestDiffVersion represents Gitlab merge request version.
 //
 // Gitlab API docs:
-// https://docs.gitlab.com/ee/api/merge_requests.html#get-a-single-mr-diff-version
+// https://docs.gitlab.com/ee/api/merge_requests.html#get-merge-request-diff-versions
 type MergeRequestDiffVersion struct {
 	ID             int        `json:"id"`
 	HeadCommitSHA  string     `json:"head_commit_sha,omitempty"`
@@ -385,13 +385,13 @@ func (s *MergeRequestsService) GetMergeRequestApprovals(pid interface{}, mergeRe
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/merge_requests.html#get-single-mr-commits
+// https://docs.gitlab.com/ee/api/merge_requests.html#get-single-merge-request-commits
 type GetMergeRequestCommitsOptions ListOptions
 
 // GetMergeRequestCommits gets a list of merge request commits.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/merge_requests.html#get-single-mr-commits
+// https://docs.gitlab.com/ee/api/merge_requests.html#get-single-merge-request-commits
 func (s *MergeRequestsService) GetMergeRequestCommits(pid interface{}, mergeRequest int, opt *GetMergeRequestCommitsOptions, options ...RequestOptionFunc) ([]*Commit, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -417,7 +417,7 @@ func (s *MergeRequestsService) GetMergeRequestCommits(pid interface{}, mergeRequ
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/merge_requests.html#get-single-mr-changes
+// https://docs.gitlab.com/ee/api/merge_requests.html#get-single-merge-request-changes
 type GetMergeRequestChangesOptions struct {
 	AccessRawDiffs *bool `url:"access_raw_diffs,omitempty" json:"access_raw_diffs,omitempty"`
 }
@@ -426,7 +426,7 @@ type GetMergeRequestChangesOptions struct {
 // its files and changes.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/merge_requests.html#get-single-mr-changes
+// https://docs.gitlab.com/ee/api/merge_requests.html#get-single-merge-request-changes
 func (s *MergeRequestsService) GetMergeRequestChanges(pid interface{}, mergeRequest int, opt *GetMergeRequestChangesOptions, options ...RequestOptionFunc) (*MergeRequest, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -451,7 +451,7 @@ func (s *MergeRequestsService) GetMergeRequestChanges(pid interface{}, mergeRequ
 // GetMergeRequestParticipants gets a list of merge request participants.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/merge_requests.html#get-single-mr-participants
+// https://docs.gitlab.com/ee/api/merge_requests.html#get-single-merge-request-participants
 func (s *MergeRequestsService) GetMergeRequestParticipants(pid interface{}, mergeRequest int, options ...RequestOptionFunc) ([]*BasicUser, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -476,7 +476,7 @@ func (s *MergeRequestsService) GetMergeRequestParticipants(pid interface{}, merg
 // ListMergeRequestPipelines gets all pipelines for the provided merge request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/merge_requests.html#list-mr-pipelines
+// https://docs.gitlab.com/ee/api/merge_requests.html#list-merge-request-pipelines
 func (s *MergeRequestsService) ListMergeRequestPipelines(pid interface{}, mergeRequest int, options ...RequestOptionFunc) ([]*PipelineInfo, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -501,7 +501,7 @@ func (s *MergeRequestsService) ListMergeRequestPipelines(pid interface{}, mergeR
 // CreateMergeRequestPipeline creates a new pipeline for a merge request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/merge_requests.html#create-mr-pipeline
+// https://docs.gitlab.com/ee/api/merge_requests.html#create-merge-request-pipeline
 func (s *MergeRequestsService) CreateMergeRequestPipeline(pid interface{}, mergeRequest int, options ...RequestOptionFunc) (*PipelineInfo, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -765,13 +765,13 @@ func (s *MergeRequestsService) RebaseMergeRequest(pid interface{}, mergeRequest 
 // GetMergeRequestDiffVersions() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/merge_requests.html#get-mr-diff-versions
+// https://docs.gitlab.com/ee/api/merge_requests.html#get-merge-request-diff-versions
 type GetMergeRequestDiffVersionsOptions ListOptions
 
 // GetMergeRequestDiffVersions get a list of merge request diff versions.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/merge_requests.html#get-mr-diff-versions
+// https://docs.gitlab.com/ee/api/merge_requests.html#get-merge-request-diff-versions
 func (s *MergeRequestsService) GetMergeRequestDiffVersions(pid interface{}, mergeRequest int, opt *GetMergeRequestDiffVersionsOptions, options ...RequestOptionFunc) ([]*MergeRequestDiffVersion, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -796,7 +796,7 @@ func (s *MergeRequestsService) GetMergeRequestDiffVersions(pid interface{}, merg
 // GetSingleMergeRequestDiffVersion get a single MR diff version
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/merge_requests.html#get-a-single-mr-diff-version
+// https://docs.gitlab.com/ee/api/merge_requests.html#get-a-single-merge-request-diff-version
 func (s *MergeRequestsService) GetSingleMergeRequestDiffVersion(pid interface{}, mergeRequest, version int, options ...RequestOptionFunc) (*MergeRequestDiffVersion, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/metadata.go
+++ b/metadata.go
@@ -21,14 +21,14 @@ import "net/http"
 // MetadataService handles communication with the GitLab server instance to
 // retrieve its metadata information via the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/version.md
+// GitLab API docs: https://docs.gitlab.com/ee/api/version.md
 type MetadataService struct {
 	client *Client
 }
 
 // Metadata represents a GitLab instance version.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/metadata.md
+// GitLab API docs: https://docs.gitlab.com/ee/api/metadata.md
 type Metadata struct {
 	Version  string `json:"version"`
 	Revision string `json:"revision"`
@@ -45,7 +45,7 @@ func (s Metadata) String() string {
 
 // GetMetadata gets a GitLab server instance meteadata.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/metadata.md
+// GitLab API docs: https://docs.gitlab.com/ee/api/metadata.md
 func (s *MetadataService) GetMetadata(options ...RequestOptionFunc) (*Metadata, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "metadata", nil, options)
 	if err != nil {
@@ -60,4 +60,3 @@ func (s *MetadataService) GetMetadata(options ...RequestOptionFunc) (*Metadata, 
 
 	return v, resp, err
 }
-

--- a/metadata.go
+++ b/metadata.go
@@ -21,14 +21,14 @@ import "net/http"
 // MetadataService handles communication with the GitLab server instance to
 // retrieve its metadata information via the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/version.md
+// GitLab API docs: https://docs.gitlab.com/ee/api/metadata.html
 type MetadataService struct {
 	client *Client
 }
 
 // Metadata represents a GitLab instance version.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/metadata.md
+// GitLab API docs: https://docs.gitlab.com/ee/api/metadata.html
 type Metadata struct {
 	Version  string `json:"version"`
 	Revision string `json:"revision"`
@@ -45,7 +45,7 @@ func (s Metadata) String() string {
 
 // GetMetadata gets a GitLab server instance meteadata.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/metadata.md
+// GitLab API docs: https://docs.gitlab.com/ee/api/metadata.html
 func (s *MetadataService) GetMetadata(options ...RequestOptionFunc) (*Metadata, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "metadata", nil, options)
 	if err != nil {

--- a/milestones.go
+++ b/milestones.go
@@ -25,14 +25,14 @@ import (
 // MilestonesService handles communication with the milestone related methods
 // of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/milestones.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/milestones.html
 type MilestonesService struct {
 	client *Client
 }
 
 // Milestone represents a GitLab milestone.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/milestones.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/milestones.html
 type Milestone struct {
 	ID          int        `json:"id"`
 	IID         int        `json:"iid"`
@@ -55,7 +55,7 @@ func (m Milestone) String() string {
 // ListMilestonesOptions represents the available ListMilestones() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/milestones.html#list-project-milestones
+// https://docs.gitlab.com/ee/api/milestones.html#list-project-milestones
 type ListMilestonesOptions struct {
 	ListOptions
 	IIDs                    *[]int  `url:"iids[],omitempty" json:"iids,omitempty"`
@@ -68,7 +68,7 @@ type ListMilestonesOptions struct {
 // ListMilestones returns a list of project milestones.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/milestones.html#list-project-milestones
+// https://docs.gitlab.com/ee/api/milestones.html#list-project-milestones
 func (s *MilestonesService) ListMilestones(pid interface{}, opt *ListMilestonesOptions, options ...RequestOptionFunc) ([]*Milestone, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -93,7 +93,7 @@ func (s *MilestonesService) ListMilestones(pid interface{}, opt *ListMilestonesO
 // GetMilestone gets a single project milestone.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/milestones.html#get-single-milestone
+// https://docs.gitlab.com/ee/api/milestones.html#get-single-milestone
 func (s *MilestonesService) GetMilestone(pid interface{}, milestone int, options ...RequestOptionFunc) (*Milestone, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -118,7 +118,7 @@ func (s *MilestonesService) GetMilestone(pid interface{}, milestone int, options
 // CreateMilestoneOptions represents the available CreateMilestone() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/milestones.html#create-new-milestone
+// https://docs.gitlab.com/ee/api/milestones.html#create-new-milestone
 type CreateMilestoneOptions struct {
 	Title       *string  `url:"title,omitempty" json:"title,omitempty"`
 	Description *string  `url:"description,omitempty" json:"description,omitempty"`
@@ -129,7 +129,7 @@ type CreateMilestoneOptions struct {
 // CreateMilestone creates a new project milestone.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/milestones.html#create-new-milestone
+// https://docs.gitlab.com/ee/api/milestones.html#create-new-milestone
 func (s *MilestonesService) CreateMilestone(pid interface{}, opt *CreateMilestoneOptions, options ...RequestOptionFunc) (*Milestone, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -154,7 +154,7 @@ func (s *MilestonesService) CreateMilestone(pid interface{}, opt *CreateMileston
 // UpdateMilestoneOptions represents the available UpdateMilestone() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/milestones.html#edit-milestone
+// https://docs.gitlab.com/ee/api/milestones.html#edit-milestone
 type UpdateMilestoneOptions struct {
 	Title       *string  `url:"title,omitempty" json:"title,omitempty"`
 	Description *string  `url:"description,omitempty" json:"description,omitempty"`
@@ -166,7 +166,7 @@ type UpdateMilestoneOptions struct {
 // UpdateMilestone updates an existing project milestone.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/milestones.html#edit-milestone
+// https://docs.gitlab.com/ee/api/milestones.html#edit-milestone
 func (s *MilestonesService) UpdateMilestone(pid interface{}, milestone int, opt *UpdateMilestoneOptions, options ...RequestOptionFunc) (*Milestone, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -191,7 +191,7 @@ func (s *MilestonesService) UpdateMilestone(pid interface{}, milestone int, opt 
 // DeleteMilestone deletes a specified project milestone.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/milestones.html#delete-project-milestone
+// https://docs.gitlab.com/ee/api/milestones.html#delete-project-milestone
 func (s *MilestonesService) DeleteMilestone(pid interface{}, milestone int, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -209,13 +209,13 @@ func (s *MilestonesService) DeleteMilestone(pid interface{}, milestone int, opti
 // GetMilestoneIssuesOptions represents the available GetMilestoneIssues() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/milestones.html#get-all-issues-assigned-to-a-single-milestone
+// https://docs.gitlab.com/ee/api/milestones.html#get-all-issues-assigned-to-a-single-milestone
 type GetMilestoneIssuesOptions ListOptions
 
 // GetMilestoneIssues gets all issues assigned to a single project milestone.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/milestones.html#get-all-issues-assigned-to-a-single-milestone
+// https://docs.gitlab.com/ee/api/milestones.html#get-all-issues-assigned-to-a-single-milestone
 func (s *MilestonesService) GetMilestoneIssues(pid interface{}, milestone int, opt *GetMilestoneIssuesOptions, options ...RequestOptionFunc) ([]*Issue, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -241,14 +241,14 @@ func (s *MilestonesService) GetMilestoneIssues(pid interface{}, milestone int, o
 // GetMilestoneMergeRequests() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/milestones.html#get-all-merge-requests-assigned-to-a-single-milestone
+// https://docs.gitlab.com/ee/api/milestones.html#get-all-merge-requests-assigned-to-a-single-milestone
 type GetMilestoneMergeRequestsOptions ListOptions
 
 // GetMilestoneMergeRequests gets all merge requests assigned to a single
 // project milestone.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/milestones.html#get-all-merge-requests-assigned-to-a-single-milestone
+// https://docs.gitlab.com/ee/api/milestones.html#get-all-merge-requests-assigned-to-a-single-milestone
 func (s *MilestonesService) GetMilestoneMergeRequests(pid interface{}, milestone int, opt *GetMilestoneMergeRequestsOptions, options ...RequestOptionFunc) ([]*MergeRequest, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/namespaces.go
+++ b/namespaces.go
@@ -24,14 +24,14 @@ import (
 // NamespacesService handles communication with the namespace related methods
 // of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/namespaces.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/namespaces.html
 type NamespacesService struct {
 	client *Client
 }
 
 // Namespace represents a GitLab namespace.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/namespaces.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/namespaces.html
 type Namespace struct {
 	ID                          int      `json:"id"`
 	Name                        string   `json:"name"`
@@ -56,7 +56,7 @@ func (n Namespace) String() string {
 
 // ListNamespacesOptions represents the available ListNamespaces() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/namespaces.html#list-namespaces
+// GitLab API docs: https://docs.gitlab.com/ee/api/namespaces.html#list-namespaces
 type ListNamespacesOptions struct {
 	ListOptions
 	Search    *string `url:"search,omitempty" json:"search,omitempty"`
@@ -65,7 +65,7 @@ type ListNamespacesOptions struct {
 
 // ListNamespaces gets a list of projects accessible by the authenticated user.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/namespaces.html#list-namespaces
+// GitLab API docs: https://docs.gitlab.com/ee/api/namespaces.html#list-namespaces
 func (s *NamespacesService) ListNamespaces(opt *ListNamespacesOptions, options ...RequestOptionFunc) ([]*Namespace, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "namespaces", opt, options)
 	if err != nil {
@@ -85,7 +85,7 @@ func (s *NamespacesService) ListNamespaces(opt *ListNamespacesOptions, options .
 // or path.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/namespaces.html#search-for-namespace
+// https://docs.gitlab.com/ee/api/namespaces.html#search-for-namespace
 func (s *NamespacesService) SearchNamespace(query string, options ...RequestOptionFunc) ([]*Namespace, *Response, error) {
 	var q struct {
 		Search string `url:"search,omitempty" json:"search,omitempty"`
@@ -109,7 +109,7 @@ func (s *NamespacesService) SearchNamespace(query string, options ...RequestOpti
 // GetNamespace gets a namespace by id.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/namespaces.html#get-namespace-by-id
+// https://docs.gitlab.com/ee/api/namespaces.html#get-namespace-by-id
 func (s *NamespacesService) GetNamespace(id interface{}, options ...RequestOptionFunc) (*Namespace, *Response, error) {
 	namespace, err := parseID(id)
 	if err != nil {

--- a/namespaces.go
+++ b/namespaces.go
@@ -85,7 +85,7 @@ func (s *NamespacesService) ListNamespaces(opt *ListNamespacesOptions, options .
 // or path.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/namespaces.html#search-for-namespace
+// https://docs.gitlab.com/ee/api/namespaces.html#list-namespaces
 func (s *NamespacesService) SearchNamespace(query string, options ...RequestOptionFunc) ([]*Namespace, *Response, error) {
 	var q struct {
 		Search string `url:"search,omitempty" json:"search,omitempty"`

--- a/notes.go
+++ b/notes.go
@@ -25,14 +25,14 @@ import (
 // NotesService handles communication with the notes related methods
 // of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/notes.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/notes.html
 type NotesService struct {
 	client *Client
 }
 
 // Note represents a GitLab note.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/notes.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/notes.html
 type Note struct {
 	ID         int           `json:"id"`
 	Type       NoteTypeValue `json:"type"`
@@ -106,7 +106,7 @@ func (n Note) String() string {
 // ListIssueNotesOptions represents the available ListIssueNotes() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notes.html#list-project-issue-notes
+// https://docs.gitlab.com/ee/api/notes.html#list-project-issue-notes
 type ListIssueNotesOptions struct {
 	ListOptions
 	OrderBy *string `url:"order_by,omitempty" json:"order_by,omitempty"`
@@ -116,7 +116,7 @@ type ListIssueNotesOptions struct {
 // ListIssueNotes gets a list of all notes for a single issue.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notes.html#list-project-issue-notes
+// https://docs.gitlab.com/ee/api/notes.html#list-project-issue-notes
 func (s *NotesService) ListIssueNotes(pid interface{}, issue int, opt *ListIssueNotesOptions, options ...RequestOptionFunc) ([]*Note, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -141,7 +141,7 @@ func (s *NotesService) ListIssueNotes(pid interface{}, issue int, opt *ListIssue
 // GetIssueNote returns a single note for a specific project issue.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notes.html#get-single-issue-note
+// https://docs.gitlab.com/ee/api/notes.html#get-single-issue-note
 func (s *NotesService) GetIssueNote(pid interface{}, issue, note int, options ...RequestOptionFunc) (*Note, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -167,7 +167,7 @@ func (s *NotesService) GetIssueNote(pid interface{}, issue, note int, options ..
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notes.html#create-new-issue-note
+// https://docs.gitlab.com/ee/api/notes.html#create-new-issue-note
 type CreateIssueNoteOptions struct {
 	Body      *string    `url:"body,omitempty" json:"body,omitempty"`
 	CreatedAt *time.Time `url:"created_at,omitempty" json:"created_at,omitempty"`
@@ -176,7 +176,7 @@ type CreateIssueNoteOptions struct {
 // CreateIssueNote creates a new note to a single project issue.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notes.html#create-new-issue-note
+// https://docs.gitlab.com/ee/api/notes.html#create-new-issue-note
 func (s *NotesService) CreateIssueNote(pid interface{}, issue int, opt *CreateIssueNoteOptions, options ...RequestOptionFunc) (*Note, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -202,7 +202,7 @@ func (s *NotesService) CreateIssueNote(pid interface{}, issue int, opt *CreateIs
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notes.html#modify-existing-issue-note
+// https://docs.gitlab.com/ee/api/notes.html#modify-existing-issue-note
 type UpdateIssueNoteOptions struct {
 	Body *string `url:"body,omitempty" json:"body,omitempty"`
 }
@@ -210,7 +210,7 @@ type UpdateIssueNoteOptions struct {
 // UpdateIssueNote modifies existing note of an issue.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notes.html#modify-existing-issue-note
+// https://docs.gitlab.com/ee/api/notes.html#modify-existing-issue-note
 func (s *NotesService) UpdateIssueNote(pid interface{}, issue, note int, opt *UpdateIssueNoteOptions, options ...RequestOptionFunc) (*Note, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -235,7 +235,7 @@ func (s *NotesService) UpdateIssueNote(pid interface{}, issue, note int, opt *Up
 // DeleteIssueNote deletes an existing note of an issue.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notes.html#delete-an-issue-note
+// https://docs.gitlab.com/ee/api/notes.html#delete-an-issue-note
 func (s *NotesService) DeleteIssueNote(pid interface{}, issue, note int, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -254,7 +254,7 @@ func (s *NotesService) DeleteIssueNote(pid interface{}, issue, note int, options
 // ListSnippetNotesOptions represents the available ListSnippetNotes() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notes.html#list-all-snippet-notes
+// https://docs.gitlab.com/ee/api/notes.html#list-all-snippet-notes
 type ListSnippetNotesOptions struct {
 	ListOptions
 	OrderBy *string `url:"order_by,omitempty" json:"order_by,omitempty"`
@@ -265,7 +265,7 @@ type ListSnippetNotesOptions struct {
 // notes are comments users can post to a snippet.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notes.html#list-all-snippet-notes
+// https://docs.gitlab.com/ee/api/notes.html#list-all-snippet-notes
 func (s *NotesService) ListSnippetNotes(pid interface{}, snippet int, opt *ListSnippetNotesOptions, options ...RequestOptionFunc) ([]*Note, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -290,7 +290,7 @@ func (s *NotesService) ListSnippetNotes(pid interface{}, snippet int, opt *ListS
 // GetSnippetNote returns a single note for a given snippet.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notes.html#get-single-snippet-note
+// https://docs.gitlab.com/ee/api/notes.html#get-single-snippet-note
 func (s *NotesService) GetSnippetNote(pid interface{}, snippet, note int, options ...RequestOptionFunc) (*Note, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -316,7 +316,7 @@ func (s *NotesService) GetSnippetNote(pid interface{}, snippet, note int, option
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notes.html#create-new-snippet-note
+// https://docs.gitlab.com/ee/api/notes.html#create-new-snippet-note
 type CreateSnippetNoteOptions struct {
 	Body *string `url:"body,omitempty" json:"body,omitempty"`
 }
@@ -325,7 +325,7 @@ type CreateSnippetNoteOptions struct {
 // comments users can post to a snippet.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notes.html#create-new-snippet-note
+// https://docs.gitlab.com/ee/api/notes.html#create-new-snippet-note
 func (s *NotesService) CreateSnippetNote(pid interface{}, snippet int, opt *CreateSnippetNoteOptions, options ...RequestOptionFunc) (*Note, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -351,7 +351,7 @@ func (s *NotesService) CreateSnippetNote(pid interface{}, snippet int, opt *Crea
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notes.html#modify-existing-snippet-note
+// https://docs.gitlab.com/ee/api/notes.html#modify-existing-snippet-note
 type UpdateSnippetNoteOptions struct {
 	Body *string `url:"body,omitempty" json:"body,omitempty"`
 }
@@ -359,7 +359,7 @@ type UpdateSnippetNoteOptions struct {
 // UpdateSnippetNote modifies existing note of a snippet.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notes.html#modify-existing-snippet-note
+// https://docs.gitlab.com/ee/api/notes.html#modify-existing-snippet-note
 func (s *NotesService) UpdateSnippetNote(pid interface{}, snippet, note int, opt *UpdateSnippetNoteOptions, options ...RequestOptionFunc) (*Note, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -384,7 +384,7 @@ func (s *NotesService) UpdateSnippetNote(pid interface{}, snippet, note int, opt
 // DeleteSnippetNote deletes an existing note of a snippet.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notes.html#delete-a-snippet-note
+// https://docs.gitlab.com/ee/api/notes.html#delete-a-snippet-note
 func (s *NotesService) DeleteSnippetNote(pid interface{}, snippet, note int, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -404,7 +404,7 @@ func (s *NotesService) DeleteSnippetNote(pid interface{}, snippet, note int, opt
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notes.html#list-all-merge-request-notes
+// https://docs.gitlab.com/ee/api/notes.html#list-all-merge-request-notes
 type ListMergeRequestNotesOptions struct {
 	ListOptions
 	OrderBy *string `url:"order_by,omitempty" json:"order_by,omitempty"`
@@ -414,7 +414,7 @@ type ListMergeRequestNotesOptions struct {
 // ListMergeRequestNotes gets a list of all notes for a single merge request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notes.html#list-all-merge-request-notes
+// https://docs.gitlab.com/ee/api/notes.html#list-all-merge-request-notes
 func (s *NotesService) ListMergeRequestNotes(pid interface{}, mergeRequest int, opt *ListMergeRequestNotesOptions, options ...RequestOptionFunc) ([]*Note, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -439,7 +439,7 @@ func (s *NotesService) ListMergeRequestNotes(pid interface{}, mergeRequest int, 
 // GetMergeRequestNote returns a single note for a given merge request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notes.html#get-single-merge-request-note
+// https://docs.gitlab.com/ee/api/notes.html#get-single-merge-request-note
 func (s *NotesService) GetMergeRequestNote(pid interface{}, mergeRequest, note int, options ...RequestOptionFunc) (*Note, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -465,7 +465,7 @@ func (s *NotesService) GetMergeRequestNote(pid interface{}, mergeRequest, note i
 // CreateMergeRequestNote() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notes.html#create-new-merge-request-note
+// https://docs.gitlab.com/ee/api/notes.html#create-new-merge-request-note
 type CreateMergeRequestNoteOptions struct {
 	Body *string `url:"body,omitempty" json:"body,omitempty"`
 }
@@ -473,7 +473,7 @@ type CreateMergeRequestNoteOptions struct {
 // CreateMergeRequestNote creates a new note for a single merge request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notes.html#create-new-merge-request-note
+// https://docs.gitlab.com/ee/api/notes.html#create-new-merge-request-note
 func (s *NotesService) CreateMergeRequestNote(pid interface{}, mergeRequest int, opt *CreateMergeRequestNoteOptions, options ...RequestOptionFunc) (*Note, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -499,7 +499,7 @@ func (s *NotesService) CreateMergeRequestNote(pid interface{}, mergeRequest int,
 // UpdateMergeRequestNote() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notes.html#modify-existing-merge-request-note
+// https://docs.gitlab.com/ee/api/notes.html#modify-existing-merge-request-note
 type UpdateMergeRequestNoteOptions struct {
 	Body *string `url:"body,omitempty" json:"body,omitempty"`
 }
@@ -507,7 +507,7 @@ type UpdateMergeRequestNoteOptions struct {
 // UpdateMergeRequestNote modifies existing note of a merge request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notes.html#modify-existing-merge-request-note
+// https://docs.gitlab.com/ee/api/notes.html#modify-existing-merge-request-note
 func (s *NotesService) UpdateMergeRequestNote(pid interface{}, mergeRequest, note int, opt *UpdateMergeRequestNoteOptions, options ...RequestOptionFunc) (*Note, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -532,7 +532,7 @@ func (s *NotesService) UpdateMergeRequestNote(pid interface{}, mergeRequest, not
 // DeleteMergeRequestNote deletes an existing note of a merge request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notes.html#delete-a-merge-request-note
+// https://docs.gitlab.com/ee/api/notes.html#delete-a-merge-request-note
 func (s *NotesService) DeleteMergeRequestNote(pid interface{}, mergeRequest, note int, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/notifications.go
+++ b/notifications.go
@@ -33,7 +33,7 @@ type NotificationSettingsService struct {
 // NotificationSettings represents the Gitlab notification setting.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/notification_settings.html#notification-settings
+// https://docs.gitlab.com/ee/api/notification_settings.html#valid-notification-levels
 type NotificationSettings struct {
 	Level             NotificationLevelValue `json:"level"`
 	NotificationEmail string                 `json:"notification_email"`
@@ -43,7 +43,7 @@ type NotificationSettings struct {
 // NotificationEvents represents the available notification setting events.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/notification_settings.html#notification-settings
+// https://docs.gitlab.com/ee/api/notification_settings.html#valid-notification-levels
 type NotificationEvents struct {
 	CloseIssue           bool `json:"close_issue"`
 	CloseMergeRequest    bool `json:"close_merge_request"`
@@ -132,7 +132,7 @@ func (s *NotificationSettingsService) UpdateGlobalSettings(opt *NotificationSett
 // GetSettingsForGroup returns current group notification settings.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/notification_settings.html#group-project-level-notification-settings
+// https://docs.gitlab.com/ee/api/notification_settings.html#group--project-level-notification-settings
 func (s *NotificationSettingsService) GetSettingsForGroup(gid interface{}, options ...RequestOptionFunc) (*NotificationSettings, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -157,7 +157,7 @@ func (s *NotificationSettingsService) GetSettingsForGroup(gid interface{}, optio
 // GetSettingsForProject returns current project notification settings.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/notification_settings.html#group-project-level-notification-settings
+// https://docs.gitlab.com/ee/api/notification_settings.html#group--project-level-notification-settings
 func (s *NotificationSettingsService) GetSettingsForProject(pid interface{}, options ...RequestOptionFunc) (*NotificationSettings, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -182,7 +182,7 @@ func (s *NotificationSettingsService) GetSettingsForProject(pid interface{}, opt
 // UpdateSettingsForGroup updates current group notification settings.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/notification_settings.html#update-group-project-level-notification-settings
+// https://docs.gitlab.com/ee/api/notification_settings.html#update-groupproject-level-notification-settings
 func (s *NotificationSettingsService) UpdateSettingsForGroup(gid interface{}, opt *NotificationSettingsOptions, options ...RequestOptionFunc) (*NotificationSettings, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -207,7 +207,7 @@ func (s *NotificationSettingsService) UpdateSettingsForGroup(gid interface{}, op
 // UpdateSettingsForProject updates current project notification settings.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/notification_settings.html#update-group-project-level-notification-settings
+// https://docs.gitlab.com/ee/api/notification_settings.html#update-groupproject-level-notification-settings
 func (s *NotificationSettingsService) UpdateSettingsForProject(pid interface{}, opt *NotificationSettingsOptions, options ...RequestOptionFunc) (*NotificationSettings, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/notifications.go
+++ b/notifications.go
@@ -25,7 +25,7 @@ import (
 // NotificationSettingsService handles communication with the notification settings
 // related methods of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/notification_settings.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/notification_settings.html
 type NotificationSettingsService struct {
 	client *Client
 }
@@ -33,7 +33,7 @@ type NotificationSettingsService struct {
 // NotificationSettings represents the Gitlab notification setting.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notification_settings.html#notification-settings
+// https://docs.gitlab.com/ee/api/notification_settings.html#notification-settings
 type NotificationSettings struct {
 	Level             NotificationLevelValue `json:"level"`
 	NotificationEmail string                 `json:"notification_email"`
@@ -43,7 +43,7 @@ type NotificationSettings struct {
 // NotificationEvents represents the available notification setting events.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notification_settings.html#notification-settings
+// https://docs.gitlab.com/ee/api/notification_settings.html#notification-settings
 type NotificationEvents struct {
 	CloseIssue           bool `json:"close_issue"`
 	CloseMergeRequest    bool `json:"close_merge_request"`
@@ -66,7 +66,7 @@ func (ns NotificationSettings) String() string {
 // GetGlobalSettings returns current notification settings and email address.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notification_settings.html#global-notification-settings
+// https://docs.gitlab.com/ee/api/notification_settings.html#global-notification-settings
 func (s *NotificationSettingsService) GetGlobalSettings(options ...RequestOptionFunc) (*NotificationSettings, *Response, error) {
 	u := "notification_settings"
 
@@ -106,7 +106,7 @@ type NotificationSettingsOptions struct {
 // UpdateGlobalSettings updates current notification settings and email address.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notification_settings.html#update-global-notification-settings
+// https://docs.gitlab.com/ee/api/notification_settings.html#update-global-notification-settings
 func (s *NotificationSettingsService) UpdateGlobalSettings(opt *NotificationSettingsOptions, options ...RequestOptionFunc) (*NotificationSettings, *Response, error) {
 	if opt.Level != nil && *opt.Level == GlobalNotificationLevel {
 		return nil, nil, errors.New(
@@ -132,7 +132,7 @@ func (s *NotificationSettingsService) UpdateGlobalSettings(opt *NotificationSett
 // GetSettingsForGroup returns current group notification settings.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notification_settings.html#group-project-level-notification-settings
+// https://docs.gitlab.com/ee/api/notification_settings.html#group-project-level-notification-settings
 func (s *NotificationSettingsService) GetSettingsForGroup(gid interface{}, options ...RequestOptionFunc) (*NotificationSettings, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -157,7 +157,7 @@ func (s *NotificationSettingsService) GetSettingsForGroup(gid interface{}, optio
 // GetSettingsForProject returns current project notification settings.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notification_settings.html#group-project-level-notification-settings
+// https://docs.gitlab.com/ee/api/notification_settings.html#group-project-level-notification-settings
 func (s *NotificationSettingsService) GetSettingsForProject(pid interface{}, options ...RequestOptionFunc) (*NotificationSettings, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -182,7 +182,7 @@ func (s *NotificationSettingsService) GetSettingsForProject(pid interface{}, opt
 // UpdateSettingsForGroup updates current group notification settings.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notification_settings.html#update-group-project-level-notification-settings
+// https://docs.gitlab.com/ee/api/notification_settings.html#update-group-project-level-notification-settings
 func (s *NotificationSettingsService) UpdateSettingsForGroup(gid interface{}, opt *NotificationSettingsOptions, options ...RequestOptionFunc) (*NotificationSettings, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -207,7 +207,7 @@ func (s *NotificationSettingsService) UpdateSettingsForGroup(gid interface{}, op
 // UpdateSettingsForProject updates current project notification settings.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notification_settings.html#update-group-project-level-notification-settings
+// https://docs.gitlab.com/ee/api/notification_settings.html#update-group-project-level-notification-settings
 func (s *NotificationSettingsService) UpdateSettingsForProject(pid interface{}, opt *NotificationSettingsOptions, options ...RequestOptionFunc) (*NotificationSettings, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/pages_domains.go
+++ b/pages_domains.go
@@ -25,14 +25,14 @@ import (
 // PagesDomainsService handles communication with the pages domains
 // related methods of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/pages_domains.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/pages_domains.html
 type PagesDomainsService struct {
 	client *Client
 }
 
 // PagesDomain represents a pages domain.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/pages_domains.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/pages_domains.html
 type PagesDomain struct {
 	Domain           string     `json:"domain"`
 	AutoSslEnabled   bool       `json:"auto_ssl_enabled"`
@@ -50,13 +50,13 @@ type PagesDomain struct {
 // ListPagesDomainsOptions represents the available ListPagesDomains() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/pages_domains.html#list-pages-domains
+// https://docs.gitlab.com/ee/api/pages_domains.html#list-pages-domains
 type ListPagesDomainsOptions ListOptions
 
 // ListPagesDomains gets a list of project pages domains.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/pages_domains.html#list-pages-domains
+// https://docs.gitlab.com/ee/api/pages_domains.html#list-pages-domains
 func (s *PagesDomainsService) ListPagesDomains(pid interface{}, opt *ListPagesDomainsOptions, options ...RequestOptionFunc) ([]*PagesDomain, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -81,7 +81,7 @@ func (s *PagesDomainsService) ListPagesDomains(pid interface{}, opt *ListPagesDo
 // ListAllPagesDomains gets a list of all pages domains.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/pages_domains.html#list-all-pages-domains
+// https://docs.gitlab.com/ee/api/pages_domains.html#list-all-pages-domains
 func (s *PagesDomainsService) ListAllPagesDomains(options ...RequestOptionFunc) ([]*PagesDomain, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "pages/domains", nil, options)
 	if err != nil {
@@ -100,7 +100,7 @@ func (s *PagesDomainsService) ListAllPagesDomains(options ...RequestOptionFunc) 
 // GetPagesDomain get a specific pages domain for a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/pages_domains.html#single-pages-domain
+// https://docs.gitlab.com/ee/api/pages_domains.html#single-pages-domain
 func (s *PagesDomainsService) GetPagesDomain(pid interface{}, domain string, options ...RequestOptionFunc) (*PagesDomain, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -125,7 +125,7 @@ func (s *PagesDomainsService) GetPagesDomain(pid interface{}, domain string, opt
 // CreatePagesDomainOptions represents the available CreatePagesDomain() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/pages_domains.html#create-new-pages-domain
+// https://docs.gitlab.com/ee/api/pages_domains.html#create-new-pages-domain
 type CreatePagesDomainOptions struct {
 	Domain         *string `url:"domain,omitempty" json:"domain,omitempty"`
 	AutoSslEnabled *bool   `url:"auto_ssl_enabled,omitempty" json:"auto_ssl_enabled,omitempty"`
@@ -136,7 +136,7 @@ type CreatePagesDomainOptions struct {
 // CreatePagesDomain creates a new project pages domain.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/pages_domains.html#create-new-pages-domain
+// https://docs.gitlab.com/ee/api/pages_domains.html#create-new-pages-domain
 func (s *PagesDomainsService) CreatePagesDomain(pid interface{}, opt *CreatePagesDomainOptions, options ...RequestOptionFunc) (*PagesDomain, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -161,7 +161,7 @@ func (s *PagesDomainsService) CreatePagesDomain(pid interface{}, opt *CreatePage
 // UpdatePagesDomainOptions represents the available UpdatePagesDomain() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/pages_domains.html#update-pages-domain
+// https://docs.gitlab.com/ee/api/pages_domains.html#update-pages-domain
 type UpdatePagesDomainOptions struct {
 	AutoSslEnabled *bool   `url:"auto_ssl_enabled,omitempty" json:"auto_ssl_enabled,omitempty"`
 	Certificate    *string `url:"certificate,omitempty" json:"certificate,omitempty"`
@@ -171,7 +171,7 @@ type UpdatePagesDomainOptions struct {
 // UpdatePagesDomain updates an existing project pages domain.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/pages_domains.html#update-pages-domain
+// https://docs.gitlab.com/ee/api/pages_domains.html#update-pages-domain
 func (s *PagesDomainsService) UpdatePagesDomain(pid interface{}, domain string, opt *UpdatePagesDomainOptions, options ...RequestOptionFunc) (*PagesDomain, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -196,7 +196,7 @@ func (s *PagesDomainsService) UpdatePagesDomain(pid interface{}, domain string, 
 // DeletePagesDomain deletes an existing prject pages domain.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/pages_domains.html#delete-pages-domain
+// https://docs.gitlab.com/ee/api/pages_domains.html#delete-pages-domain
 func (s *PagesDomainsService) DeletePagesDomain(pid interface{}, domain string, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/pipeline_schedules.go
+++ b/pipeline_schedules.go
@@ -25,7 +25,7 @@ import (
 // PipelineSchedulesService handles communication with the pipeline
 // schedules related methods of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/pipeline_schedules.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/pipeline_schedules.html
 type PipelineSchedulesService struct {
 	client *Client
 }
@@ -33,7 +33,7 @@ type PipelineSchedulesService struct {
 // PipelineSchedule represents a pipeline schedule.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/pipeline_schedules.html
+// https://docs.gitlab.com/ee/api/pipeline_schedules.html
 type PipelineSchedule struct {
 	ID           int        `json:"id"`
 	Description  string     `json:"description"`
@@ -57,13 +57,13 @@ type PipelineSchedule struct {
 // ListPipelineSchedulesOptions represents the available ListPipelineTriggers() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/pipeline_triggers.html#list-project-triggers
+// https://docs.gitlab.com/ee/api/pipeline_triggers.html#list-project-triggers
 type ListPipelineSchedulesOptions ListOptions
 
 // ListPipelineSchedules gets a list of project triggers.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/pipeline_schedules.html
+// https://docs.gitlab.com/ee/api/pipeline_schedules.html
 func (s *PipelineSchedulesService) ListPipelineSchedules(pid interface{}, opt *ListPipelineSchedulesOptions, options ...RequestOptionFunc) ([]*PipelineSchedule, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -88,7 +88,7 @@ func (s *PipelineSchedulesService) ListPipelineSchedules(pid interface{}, opt *L
 // GetPipelineSchedule gets a pipeline schedule.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/pipeline_schedules.html
+// https://docs.gitlab.com/ee/api/pipeline_schedules.html
 func (s *PipelineSchedulesService) GetPipelineSchedule(pid interface{}, schedule int, options ...RequestOptionFunc) (*PipelineSchedule, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -147,7 +147,7 @@ func (s *PipelineSchedulesService) ListPipelinesTriggeredBySchedule(pid interfac
 // CreatePipelineSchedule() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/pipeline_schedules.html#create-a-new-pipeline-schedule
+// https://docs.gitlab.com/ee/api/pipeline_schedules.html#create-a-new-pipeline-schedule
 type CreatePipelineScheduleOptions struct {
 	Description  *string `url:"description" json:"description"`
 	Ref          *string `url:"ref" json:"ref"`
@@ -159,7 +159,7 @@ type CreatePipelineScheduleOptions struct {
 // CreatePipelineSchedule creates a pipeline schedule.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/pipeline_schedules.html#create-a-new-pipeline-schedule
+// https://docs.gitlab.com/ee/api/pipeline_schedules.html#create-a-new-pipeline-schedule
 func (s *PipelineSchedulesService) CreatePipelineSchedule(pid interface{}, opt *CreatePipelineScheduleOptions, options ...RequestOptionFunc) (*PipelineSchedule, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -185,7 +185,7 @@ func (s *PipelineSchedulesService) CreatePipelineSchedule(pid interface{}, opt *
 // EditPipelineSchedule() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/pipeline_schedules.html#create-a-new-pipeline-schedule
+// https://docs.gitlab.com/ee/api/pipeline_schedules.html#create-a-new-pipeline-schedule
 type EditPipelineScheduleOptions struct {
 	Description  *string `url:"description,omitempty" json:"description,omitempty"`
 	Ref          *string `url:"ref,omitempty" json:"ref,omitempty"`
@@ -197,7 +197,7 @@ type EditPipelineScheduleOptions struct {
 // EditPipelineSchedule edits a pipeline schedule.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/pipeline_schedules.html#edit-a-pipeline-schedule
+// https://docs.gitlab.com/ee/api/pipeline_schedules.html#edit-a-pipeline-schedule
 func (s *PipelineSchedulesService) EditPipelineSchedule(pid interface{}, schedule int, opt *EditPipelineScheduleOptions, options ...RequestOptionFunc) (*PipelineSchedule, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -223,7 +223,7 @@ func (s *PipelineSchedulesService) EditPipelineSchedule(pid interface{}, schedul
 // pipeline schedule to the user issuing the request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/pipeline_schedules.html#take-ownership-of-a-pipeline-schedule
+// https://docs.gitlab.com/ee/api/pipeline_schedules.html#take-ownership-of-a-pipeline-schedule
 func (s *PipelineSchedulesService) TakeOwnershipOfPipelineSchedule(pid interface{}, schedule int, options ...RequestOptionFunc) (*PipelineSchedule, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -248,7 +248,7 @@ func (s *PipelineSchedulesService) TakeOwnershipOfPipelineSchedule(pid interface
 // DeletePipelineSchedule deletes a pipeline schedule.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/pipeline_schedules.html#delete-a-pipeline-schedule
+// https://docs.gitlab.com/ee/api/pipeline_schedules.html#delete-a-pipeline-schedule
 func (s *PipelineSchedulesService) DeletePipelineSchedule(pid interface{}, schedule int, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -267,7 +267,7 @@ func (s *PipelineSchedulesService) DeletePipelineSchedule(pid interface{}, sched
 // RunPipelineSchedule triggers a new scheduled pipeline to run immediately.
 //
 // Gitlab API docs:
-// https://docs.gitlab.com/ce/api/pipeline_schedules.html#run-a-scheduled-pipeline-immediately
+// https://docs.gitlab.com/ee/api/pipeline_schedules.html#run-a-scheduled-pipeline-immediately
 func (s *PipelineSchedulesService) RunPipelineSchedule(pid interface{}, schedule int, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -287,7 +287,7 @@ func (s *PipelineSchedulesService) RunPipelineSchedule(pid interface{}, schedule
 // CreatePipelineScheduleVariable() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/pipeline_schedules.html#create-a-new-pipeline-schedule
+// https://docs.gitlab.com/ee/api/pipeline_schedules.html#create-a-new-pipeline-schedule
 type CreatePipelineScheduleVariableOptions struct {
 	Key          *string `url:"key" json:"key"`
 	Value        *string `url:"value" json:"value"`
@@ -297,7 +297,7 @@ type CreatePipelineScheduleVariableOptions struct {
 // CreatePipelineScheduleVariable creates a pipeline schedule variable.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/pipeline_schedules.html#create-a-new-pipeline-schedule
+// https://docs.gitlab.com/ee/api/pipeline_schedules.html#create-a-new-pipeline-schedule
 func (s *PipelineSchedulesService) CreatePipelineScheduleVariable(pid interface{}, schedule int, opt *CreatePipelineScheduleVariableOptions, options ...RequestOptionFunc) (*PipelineVariable, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -323,7 +323,7 @@ func (s *PipelineSchedulesService) CreatePipelineScheduleVariable(pid interface{
 // EditPipelineScheduleVariable() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/pipeline_schedules.html#edit-a-pipeline-schedule-variable
+// https://docs.gitlab.com/ee/api/pipeline_schedules.html#edit-a-pipeline-schedule-variable
 type EditPipelineScheduleVariableOptions struct {
 	Value        *string `url:"value" json:"value"`
 	VariableType *string `url:"variable_type,omitempty" json:"variable_type,omitempty"`
@@ -332,7 +332,7 @@ type EditPipelineScheduleVariableOptions struct {
 // EditPipelineScheduleVariable creates a pipeline schedule variable.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/pipeline_schedules.html#edit-a-pipeline-schedule-variable
+// https://docs.gitlab.com/ee/api/pipeline_schedules.html#edit-a-pipeline-schedule-variable
 func (s *PipelineSchedulesService) EditPipelineScheduleVariable(pid interface{}, schedule int, key string, opt *EditPipelineScheduleVariableOptions, options ...RequestOptionFunc) (*PipelineVariable, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -357,7 +357,7 @@ func (s *PipelineSchedulesService) EditPipelineScheduleVariable(pid interface{},
 // DeletePipelineScheduleVariable creates a pipeline schedule variable.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/pipeline_schedules.html#delete-a-pipeline-schedule-variable
+// https://docs.gitlab.com/ee/api/pipeline_schedules.html#delete-a-pipeline-schedule-variable
 func (s *PipelineSchedulesService) DeletePipelineScheduleVariable(pid interface{}, schedule int, key string, options ...RequestOptionFunc) (*PipelineVariable, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/pipeline_schedules.go
+++ b/pipeline_schedules.go
@@ -57,13 +57,13 @@ type PipelineSchedule struct {
 // ListPipelineSchedulesOptions represents the available ListPipelineTriggers() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/pipeline_triggers.html#list-project-triggers
+// https://docs.gitlab.com/ee/api/pipeline_schedules.html#get-all-pipeline-schedules
 type ListPipelineSchedulesOptions ListOptions
 
 // ListPipelineSchedules gets a list of project triggers.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/pipeline_schedules.html
+// https://docs.gitlab.com/ee/api/pipeline_schedules.html#get-all-pipeline-schedules
 func (s *PipelineSchedulesService) ListPipelineSchedules(pid interface{}, opt *ListPipelineSchedulesOptions, options ...RequestOptionFunc) ([]*PipelineSchedule, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -88,7 +88,7 @@ func (s *PipelineSchedulesService) ListPipelineSchedules(pid interface{}, opt *L
 // GetPipelineSchedule gets a pipeline schedule.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/pipeline_schedules.html
+// https://docs.gitlab.com/ee/api/pipeline_schedules.html#get-a-single-pipeline-schedule
 func (s *PipelineSchedulesService) GetPipelineSchedule(pid interface{}, schedule int, options ...RequestOptionFunc) (*PipelineSchedule, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -185,7 +185,7 @@ func (s *PipelineSchedulesService) CreatePipelineSchedule(pid interface{}, opt *
 // EditPipelineSchedule() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/pipeline_schedules.html#create-a-new-pipeline-schedule
+// https://docs.gitlab.com/ee/api/pipeline_schedules.html#edit-a-pipeline-schedule
 type EditPipelineScheduleOptions struct {
 	Description  *string `url:"description,omitempty" json:"description,omitempty"`
 	Ref          *string `url:"ref,omitempty" json:"ref,omitempty"`

--- a/pipeline_triggers.go
+++ b/pipeline_triggers.go
@@ -33,7 +33,7 @@ type PipelineTriggersService struct {
 // PipelineTrigger represents a project pipeline trigger.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/pipeline_triggers.html#pipeline-triggers
+// https://docs.gitlab.com/ee/api/pipeline_triggers.html
 type PipelineTrigger struct {
 	ID          int        `json:"id"`
 	Description string     `json:"description"`
@@ -48,13 +48,13 @@ type PipelineTrigger struct {
 // ListPipelineTriggersOptions represents the available ListPipelineTriggers() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/pipeline_triggers.html#list-project-triggers
+// https://docs.gitlab.com/ee/api/pipeline_triggers.html#list-project-trigger-tokens
 type ListPipelineTriggersOptions ListOptions
 
 // ListPipelineTriggers gets a list of project triggers.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/pipeline_triggers.html#list-project-triggers
+// https://docs.gitlab.com/ee/api/pipeline_triggers.html#list-project-trigger-tokens
 func (s *PipelineTriggersService) ListPipelineTriggers(pid interface{}, opt *ListPipelineTriggersOptions, options ...RequestOptionFunc) ([]*PipelineTrigger, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -79,7 +79,7 @@ func (s *PipelineTriggersService) ListPipelineTriggers(pid interface{}, opt *Lis
 // GetPipelineTrigger gets a specific pipeline trigger for a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/pipeline_triggers.html#get-trigger-details
+// https://docs.gitlab.com/ee/api/pipeline_triggers.html#get-trigger-token-details
 func (s *PipelineTriggersService) GetPipelineTrigger(pid interface{}, trigger int, options ...RequestOptionFunc) (*PipelineTrigger, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -104,7 +104,7 @@ func (s *PipelineTriggersService) GetPipelineTrigger(pid interface{}, trigger in
 // AddPipelineTriggerOptions represents the available AddPipelineTrigger() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/pipeline_triggers.html#create-a-project-trigger
+// https://docs.gitlab.com/ee/api/pipeline_triggers.html#create-a-trigger-token
 type AddPipelineTriggerOptions struct {
 	Description *string `url:"description,omitempty" json:"description,omitempty"`
 }
@@ -112,7 +112,7 @@ type AddPipelineTriggerOptions struct {
 // AddPipelineTrigger adds a pipeline trigger to a specified project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/pipeline_triggers.html#create-a-project-trigger
+// https://docs.gitlab.com/ee/api/pipeline_triggers.html#create-a-trigger-token
 func (s *PipelineTriggersService) AddPipelineTrigger(pid interface{}, opt *AddPipelineTriggerOptions, options ...RequestOptionFunc) (*PipelineTrigger, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -137,7 +137,7 @@ func (s *PipelineTriggersService) AddPipelineTrigger(pid interface{}, opt *AddPi
 // EditPipelineTriggerOptions represents the available EditPipelineTrigger() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/pipeline_triggers.html#update-a-project-trigger
+// https://docs.gitlab.com/ee/api/pipeline_triggers.html#update-a-project-trigger-token
 type EditPipelineTriggerOptions struct {
 	Description *string `url:"description,omitempty" json:"description,omitempty"`
 }
@@ -145,7 +145,7 @@ type EditPipelineTriggerOptions struct {
 // EditPipelineTrigger edits a trigger for a specified project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/pipeline_triggers.html#update-a-project-trigger
+// https://docs.gitlab.com/ee/api/pipeline_triggers.html#update-a-project-trigger-token
 func (s *PipelineTriggersService) EditPipelineTrigger(pid interface{}, trigger int, opt *EditPipelineTriggerOptions, options ...RequestOptionFunc) (*PipelineTrigger, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -196,7 +196,7 @@ func (s *PipelineTriggersService) TakeOwnershipOfPipelineTrigger(pid interface{}
 // DeletePipelineTrigger removes a trigger from a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/pipeline_triggers.html#remove-a-project-trigger
+// https://docs.gitlab.com/ee/api/pipeline_triggers.html#remove-a-project-trigger-token
 func (s *PipelineTriggersService) DeletePipelineTrigger(pid interface{}, trigger int, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -215,7 +215,7 @@ func (s *PipelineTriggersService) DeletePipelineTrigger(pid interface{}, trigger
 // RunPipelineTriggerOptions represents the available RunPipelineTrigger() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/ci/triggers/README.html#triggering-a-pipeline
+// https://docs.gitlab.com/ee/api/pipeline_triggers.html#trigger-a-pipeline-with-a-token
 type RunPipelineTriggerOptions struct {
 	Ref       *string           `url:"ref" json:"ref"`
 	Token     *string           `url:"token" json:"token"`
@@ -225,7 +225,7 @@ type RunPipelineTriggerOptions struct {
 // RunPipelineTrigger starts a trigger from a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/ci/triggers/README.html#triggering-a-pipeline
+// https://docs.gitlab.com/ee/api/pipeline_triggers.html#trigger-a-pipeline-with-a-token
 func (s *PipelineTriggersService) RunPipelineTrigger(pid interface{}, opt *RunPipelineTriggerOptions, options ...RequestOptionFunc) (*Pipeline, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/pipeline_triggers.go
+++ b/pipeline_triggers.go
@@ -25,7 +25,7 @@ import (
 // PipelineTriggersService handles Project pipeline triggers.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/pipeline_triggers.html
+// https://docs.gitlab.com/ee/api/pipeline_triggers.html
 type PipelineTriggersService struct {
 	client *Client
 }
@@ -33,7 +33,7 @@ type PipelineTriggersService struct {
 // PipelineTrigger represents a project pipeline trigger.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/pipeline_triggers.html#pipeline-triggers
+// https://docs.gitlab.com/ee/api/pipeline_triggers.html#pipeline-triggers
 type PipelineTrigger struct {
 	ID          int        `json:"id"`
 	Description string     `json:"description"`
@@ -48,13 +48,13 @@ type PipelineTrigger struct {
 // ListPipelineTriggersOptions represents the available ListPipelineTriggers() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/pipeline_triggers.html#list-project-triggers
+// https://docs.gitlab.com/ee/api/pipeline_triggers.html#list-project-triggers
 type ListPipelineTriggersOptions ListOptions
 
 // ListPipelineTriggers gets a list of project triggers.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/pipeline_triggers.html#list-project-triggers
+// https://docs.gitlab.com/ee/api/pipeline_triggers.html#list-project-triggers
 func (s *PipelineTriggersService) ListPipelineTriggers(pid interface{}, opt *ListPipelineTriggersOptions, options ...RequestOptionFunc) ([]*PipelineTrigger, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -79,7 +79,7 @@ func (s *PipelineTriggersService) ListPipelineTriggers(pid interface{}, opt *Lis
 // GetPipelineTrigger gets a specific pipeline trigger for a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/pipeline_triggers.html#get-trigger-details
+// https://docs.gitlab.com/ee/api/pipeline_triggers.html#get-trigger-details
 func (s *PipelineTriggersService) GetPipelineTrigger(pid interface{}, trigger int, options ...RequestOptionFunc) (*PipelineTrigger, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -104,7 +104,7 @@ func (s *PipelineTriggersService) GetPipelineTrigger(pid interface{}, trigger in
 // AddPipelineTriggerOptions represents the available AddPipelineTrigger() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/pipeline_triggers.html#create-a-project-trigger
+// https://docs.gitlab.com/ee/api/pipeline_triggers.html#create-a-project-trigger
 type AddPipelineTriggerOptions struct {
 	Description *string `url:"description,omitempty" json:"description,omitempty"`
 }
@@ -112,7 +112,7 @@ type AddPipelineTriggerOptions struct {
 // AddPipelineTrigger adds a pipeline trigger to a specified project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/pipeline_triggers.html#create-a-project-trigger
+// https://docs.gitlab.com/ee/api/pipeline_triggers.html#create-a-project-trigger
 func (s *PipelineTriggersService) AddPipelineTrigger(pid interface{}, opt *AddPipelineTriggerOptions, options ...RequestOptionFunc) (*PipelineTrigger, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -137,7 +137,7 @@ func (s *PipelineTriggersService) AddPipelineTrigger(pid interface{}, opt *AddPi
 // EditPipelineTriggerOptions represents the available EditPipelineTrigger() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/pipeline_triggers.html#update-a-project-trigger
+// https://docs.gitlab.com/ee/api/pipeline_triggers.html#update-a-project-trigger
 type EditPipelineTriggerOptions struct {
 	Description *string `url:"description,omitempty" json:"description,omitempty"`
 }
@@ -145,7 +145,7 @@ type EditPipelineTriggerOptions struct {
 // EditPipelineTrigger edits a trigger for a specified project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/pipeline_triggers.html#update-a-project-trigger
+// https://docs.gitlab.com/ee/api/pipeline_triggers.html#update-a-project-trigger
 func (s *PipelineTriggersService) EditPipelineTrigger(pid interface{}, trigger int, opt *EditPipelineTriggerOptions, options ...RequestOptionFunc) (*PipelineTrigger, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -171,7 +171,7 @@ func (s *PipelineTriggersService) EditPipelineTrigger(pid interface{}, trigger i
 // pipeline trigger to the user issuing the request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/pipeline_triggers.html#take-ownership-of-a-project-trigger
+// https://docs.gitlab.com/ee/api/pipeline_triggers.html#take-ownership-of-a-project-trigger
 func (s *PipelineTriggersService) TakeOwnershipOfPipelineTrigger(pid interface{}, trigger int, options ...RequestOptionFunc) (*PipelineTrigger, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -196,7 +196,7 @@ func (s *PipelineTriggersService) TakeOwnershipOfPipelineTrigger(pid interface{}
 // DeletePipelineTrigger removes a trigger from a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/pipeline_triggers.html#remove-a-project-trigger
+// https://docs.gitlab.com/ee/api/pipeline_triggers.html#remove-a-project-trigger
 func (s *PipelineTriggersService) DeletePipelineTrigger(pid interface{}, trigger int, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -215,7 +215,7 @@ func (s *PipelineTriggersService) DeletePipelineTrigger(pid interface{}, trigger
 // RunPipelineTriggerOptions represents the available RunPipelineTrigger() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/ci/triggers/README.html#triggering-a-pipeline
+// https://docs.gitlab.com/ee/ci/triggers/README.html#triggering-a-pipeline
 type RunPipelineTriggerOptions struct {
 	Ref       *string           `url:"ref" json:"ref"`
 	Token     *string           `url:"token" json:"token"`
@@ -225,7 +225,7 @@ type RunPipelineTriggerOptions struct {
 // RunPipelineTrigger starts a trigger from a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/ci/triggers/README.html#triggering-a-pipeline
+// https://docs.gitlab.com/ee/ci/triggers/README.html#triggering-a-pipeline
 func (s *PipelineTriggersService) RunPipelineTrigger(pid interface{}, opt *RunPipelineTriggerOptions, options ...RequestOptionFunc) (*Pipeline, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/pipelines.go
+++ b/pipelines.go
@@ -305,7 +305,7 @@ type CreatePipelineOptions struct {
 
 // PipelineVariable represents a pipeline variable.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/pipelines.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/pipelines.html#create-a-new-pipeline
 type PipelineVariableOptions struct {
 	Key          *string `url:"key,omitempty" json:"key,omitempty"`
 	Value        *string `url:"value,omitempty" json:"value,omitempty"`
@@ -339,7 +339,7 @@ func (s *PipelinesService) CreatePipeline(pid interface{}, opt *CreatePipelineOp
 // RetryPipelineBuild retries failed builds in a pipeline
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/pipelines.html#retry-failed-builds-in-a-pipeline
+// https://docs.gitlab.com/ee/api/pipelines.html#retry-jobs-in-a-pipeline
 func (s *PipelinesService) RetryPipelineBuild(pid interface{}, pipeline int, options ...RequestOptionFunc) (*Pipeline, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -364,7 +364,7 @@ func (s *PipelinesService) RetryPipelineBuild(pid interface{}, pipeline int, opt
 // CancelPipelineBuild cancels a pipeline builds
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/pipelines.html#cancel-a-pipelines-builds
+// https://docs.gitlab.com/ee/api/pipelines.html#cancel-a-pipelines-jobs
 func (s *PipelinesService) CancelPipelineBuild(pid interface{}, pipeline int, options ...RequestOptionFunc) (*Pipeline, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/pipelines.go
+++ b/pipelines.go
@@ -25,14 +25,14 @@ import (
 // PipelinesService handles communication with the repositories related
 // methods of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/pipelines.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/pipelines.html
 type PipelinesService struct {
 	client *Client
 }
 
 // PipelineVariable represents a pipeline variable.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/pipelines.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/pipelines.html
 type PipelineVariable struct {
 	Key          string `json:"key"`
 	Value        string `json:"value"`
@@ -41,7 +41,7 @@ type PipelineVariable struct {
 
 // Pipeline represents a GitLab pipeline.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/pipelines.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/pipelines.html
 type Pipeline struct {
 	ID             int             `json:"id"`
 	IID            int             `json:"iid"`
@@ -151,7 +151,7 @@ func (p PipelineInfo) String() string {
 
 // ListProjectPipelinesOptions represents the available ListProjectPipelines() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/pipelines.html#list-project-pipelines
+// GitLab API docs: https://docs.gitlab.com/ee/api/pipelines.html#list-project-pipelines
 type ListProjectPipelinesOptions struct {
 	ListOptions
 	Scope         *string          `url:"scope,omitempty" json:"scope,omitempty"`
@@ -170,7 +170,7 @@ type ListProjectPipelinesOptions struct {
 
 // ListProjectPipelines gets a list of project piplines.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/pipelines.html#list-project-pipelines
+// GitLab API docs: https://docs.gitlab.com/ee/api/pipelines.html#list-project-pipelines
 func (s *PipelinesService) ListProjectPipelines(pid interface{}, opt *ListProjectPipelinesOptions, options ...RequestOptionFunc) ([]*PipelineInfo, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -194,7 +194,7 @@ func (s *PipelinesService) ListProjectPipelines(pid interface{}, opt *ListProjec
 
 // GetPipeline gets a single project pipeline.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/pipelines.html#get-a-single-pipeline
+// GitLab API docs: https://docs.gitlab.com/ee/api/pipelines.html#get-a-single-pipeline
 func (s *PipelinesService) GetPipeline(pid interface{}, pipeline int, options ...RequestOptionFunc) (*Pipeline, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -218,7 +218,7 @@ func (s *PipelinesService) GetPipeline(pid interface{}, pipeline int, options ..
 
 // GetPipelineVariables gets the variables of a single project pipeline.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/pipelines.html#get-variables-of-a-pipeline
+// GitLab API docs: https://docs.gitlab.com/ee/api/pipelines.html#get-variables-of-a-pipeline
 func (s *PipelinesService) GetPipelineVariables(pid interface{}, pipeline int, options ...RequestOptionFunc) ([]*PipelineVariable, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -297,7 +297,7 @@ func (s *PipelinesService) GetLatestPipeline(pid interface{}, opt *GetLatestPipe
 
 // CreatePipelineOptions represents the available CreatePipeline() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/pipelines.html#create-a-new-pipeline
+// GitLab API docs: https://docs.gitlab.com/ee/api/pipelines.html#create-a-new-pipeline
 type CreatePipelineOptions struct {
 	Ref       *string                     `url:"ref" json:"ref"`
 	Variables *[]*PipelineVariableOptions `url:"variables,omitempty" json:"variables,omitempty"`
@@ -305,7 +305,7 @@ type CreatePipelineOptions struct {
 
 // PipelineVariable represents a pipeline variable.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/pipelines.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/pipelines.html
 type PipelineVariableOptions struct {
 	Key          *string `url:"key,omitempty" json:"key,omitempty"`
 	Value        *string `url:"value,omitempty" json:"value,omitempty"`
@@ -314,7 +314,7 @@ type PipelineVariableOptions struct {
 
 // CreatePipeline creates a new project pipeline.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/pipelines.html#create-a-new-pipeline
+// GitLab API docs: https://docs.gitlab.com/ee/api/pipelines.html#create-a-new-pipeline
 func (s *PipelinesService) CreatePipeline(pid interface{}, opt *CreatePipelineOptions, options ...RequestOptionFunc) (*Pipeline, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -339,7 +339,7 @@ func (s *PipelinesService) CreatePipeline(pid interface{}, opt *CreatePipelineOp
 // RetryPipelineBuild retries failed builds in a pipeline
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/pipelines.html#retry-failed-builds-in-a-pipeline
+// https://docs.gitlab.com/ee/api/pipelines.html#retry-failed-builds-in-a-pipeline
 func (s *PipelinesService) RetryPipelineBuild(pid interface{}, pipeline int, options ...RequestOptionFunc) (*Pipeline, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -364,7 +364,7 @@ func (s *PipelinesService) RetryPipelineBuild(pid interface{}, pipeline int, opt
 // CancelPipelineBuild cancels a pipeline builds
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/pipelines.html#cancel-a-pipelines-builds
+// https://docs.gitlab.com/ee/api/pipelines.html#cancel-a-pipelines-builds
 func (s *PipelinesService) CancelPipelineBuild(pid interface{}, pipeline int, options ...RequestOptionFunc) (*Pipeline, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -389,7 +389,7 @@ func (s *PipelinesService) CancelPipelineBuild(pid interface{}, pipeline int, op
 // DeletePipeline deletes an existing pipeline.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/pipelines.html#delete-a-pipeline
+// https://docs.gitlab.com/ee/api/pipelines.html#delete-a-pipeline
 func (s *PipelinesService) DeletePipeline(pid interface{}, pipeline int, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/project_access_tokens.go
+++ b/project_access_tokens.go
@@ -25,14 +25,14 @@ import (
 // ProjectAccessTokensService handles communication with the
 // project access tokens related methods of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/resource_access_tokens.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/project_access_tokens.html
 type ProjectAccessTokensService struct {
 	client *Client
 }
 
 // ProjectAccessToken represents a GitLab project access token.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/resource_access_tokens.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/project_access_tokens.html
 type ProjectAccessToken struct {
 	ID          int              `json:"id"`
 	UserID      int              `json:"user_id"`
@@ -55,14 +55,14 @@ func (v ProjectAccessToken) String() string {
 // ListProjectAccessTokens() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/resource_access_tokens.html#list-project-access-tokens
+// https://docs.gitlab.com/ee/api/project_access_tokens.html#list-project-access-tokens
 type ListProjectAccessTokensOptions ListOptions
 
 // ListProjectAccessTokens gets a list of all project access tokens in a
 // project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/resource_access_tokens.html#list-project-access-tokens
+// https://docs.gitlab.com/ee/api/project_access_tokens.html#list-project-access-tokens
 func (s *ProjectAccessTokensService) ListProjectAccessTokens(pid interface{}, opt *ListProjectAccessTokensOptions, options ...RequestOptionFunc) ([]*ProjectAccessToken, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -113,7 +113,7 @@ func (s *ProjectAccessTokensService) GetProjectAccessToken(pid interface{}, id i
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/resource_access_tokens.html#create-a-project-access-token
+// https://docs.gitlab.com/ee/api/project_access_tokens.html#create-a-project-access-token
 type CreateProjectAccessTokenOptions struct {
 	Name        *string           `url:"name,omitempty" json:"name,omitempty"`
 	Scopes      *[]string         `url:"scopes,omitempty" json:"scopes,omitempty"`
@@ -124,7 +124,7 @@ type CreateProjectAccessTokenOptions struct {
 // CreateProjectAccessToken creates a new project access token.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/resource_access_tokens.html#create-a-project-access-token
+// https://docs.gitlab.com/ee/api/project_access_tokens.html#create-a-project-access-token
 func (s *ProjectAccessTokensService) CreateProjectAccessToken(pid interface{}, opt *CreateProjectAccessTokenOptions, options ...RequestOptionFunc) (*ProjectAccessToken, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -149,7 +149,7 @@ func (s *ProjectAccessTokensService) CreateProjectAccessToken(pid interface{}, o
 // RevokeProjectAccessToken revokes a project access token.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/resource_access_tokens.html#revoke-a-project-access-token
+// https://docs.gitlab.com/ee/api/project_access_tokens.html#revoke-a-project-access-token
 func (s *ProjectAccessTokensService) RevokeProjectAccessToken(pid interface{}, id int, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/project_import_export.go
+++ b/project_import_export.go
@@ -28,7 +28,7 @@ import (
 // import/export related methods of the GitLab API.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/user/project/settings/import_export.html
+// https://docs.gitlab.com/ee/user/project/settings/import_export.html
 type ProjectImportExportService struct {
 	client *Client
 }
@@ -36,7 +36,7 @@ type ProjectImportExportService struct {
 // ImportStatus represents a project import status.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/project_import_export.html#import-status
+// https://docs.gitlab.com/ee/api/project_import_export.html#import-status
 type ImportStatus struct {
 	ID                int        `json:"id"`
 	Description       string     `json:"description"`
@@ -58,7 +58,7 @@ func (s ImportStatus) String() string {
 // ExportStatus represents a project export status.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/project_import_export.html#export-status
+// https://docs.gitlab.com/ee/api/project_import_export.html#export-status
 type ExportStatus struct {
 	ID                int        `json:"id"`
 	Description       string     `json:"description"`
@@ -82,7 +82,7 @@ func (s ExportStatus) String() string {
 // ScheduleExportOptions represents the available ScheduleExport() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/project_import_export.html#schedule-an-export
+// https://docs.gitlab.com/ee/api/project_import_export.html#schedule-an-export
 type ScheduleExportOptions struct {
 	Description *string `url:"description,omitempty" json:"description,omitempty"`
 	Upload      struct {
@@ -94,7 +94,7 @@ type ScheduleExportOptions struct {
 // ScheduleExport schedules a project export.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/project_import_export.html#schedule-an-export
+// https://docs.gitlab.com/ee/api/project_import_export.html#schedule-an-export
 func (s *ProjectImportExportService) ScheduleExport(pid interface{}, opt *ScheduleExportOptions, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -113,7 +113,7 @@ func (s *ProjectImportExportService) ScheduleExport(pid interface{}, opt *Schedu
 // ExportStatus get the status of export.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/project_import_export.html#export-status
+// https://docs.gitlab.com/ee/api/project_import_export.html#export-status
 func (s *ProjectImportExportService) ExportStatus(pid interface{}, options ...RequestOptionFunc) (*ExportStatus, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -138,7 +138,7 @@ func (s *ProjectImportExportService) ExportStatus(pid interface{}, options ...Re
 // ExportDownload download the finished export.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/project_import_export.html#export-download
+// https://docs.gitlab.com/ee/api/project_import_export.html#export-download
 func (s *ProjectImportExportService) ExportDownload(pid interface{}, options ...RequestOptionFunc) ([]byte, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -163,7 +163,7 @@ func (s *ProjectImportExportService) ExportDownload(pid interface{}, options ...
 // ImportFileOptions represents the available ImportFile() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/project_import_export.html#import-a-file
+// https://docs.gitlab.com/ee/api/project_import_export.html#import-a-file
 type ImportFileOptions struct {
 	Namespace      *string               `url:"namespace,omitempty" json:"namespace,omitempty"`
 	Name           *string               `url:"name,omitempty" json:"name,omitempty"`
@@ -175,7 +175,7 @@ type ImportFileOptions struct {
 // Import a project from an archive file.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/project_import_export.html#import-a-file
+// https://docs.gitlab.com/ee/api/project_import_export.html#import-a-file
 func (s *ProjectImportExportService) ImportFromFile(archive io.Reader, opt *ImportFileOptions, options ...RequestOptionFunc) (*ImportStatus, *Response, error) {
 	req, err := s.client.UploadRequest(
 		http.MethodPost,
@@ -202,7 +202,7 @@ func (s *ProjectImportExportService) ImportFromFile(archive io.Reader, opt *Impo
 // ImportStatus get the status of an import.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/project_import_export.html#import-status
+// https://docs.gitlab.com/ee/api/project_import_export.html#import-status
 func (s *ProjectImportExportService) ImportStatus(pid interface{}, options ...RequestOptionFunc) (*ImportStatus, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/project_import_export.go
+++ b/project_import_export.go
@@ -28,7 +28,7 @@ import (
 // import/export related methods of the GitLab API.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/user/project/settings/import_export.html
+// https://docs.gitlab.com/ee/api/project_import_export.html
 type ProjectImportExportService struct {
 	client *Client
 }

--- a/project_iterations.go
+++ b/project_iterations.go
@@ -56,7 +56,7 @@ func (i ProjectIteration) String() string {
 // options
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/group_iterations.html#list-project-iterations
+// https://docs.gitlab.com/ee/api/iterations.html#list-project-iterations
 type ListProjectIterationsOptions struct {
 	ListOptions
 	State            *string `url:"state,omitempty" json:"state,omitempty"`
@@ -67,7 +67,7 @@ type ListProjectIterationsOptions struct {
 // ListProjectIterations returns a list of projects iterations.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/group_iterations.html#list-project-iterations
+// https://docs.gitlab.com/ee/api/iterations.html#list-project-iterations
 func (i *ProjectIterationsService) ListProjectIterations(pid interface{}, opt *ListProjectIterationsOptions, options ...RequestOptionFunc) ([]*ProjectIteration, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/project_members.go
+++ b/project_members.go
@@ -24,7 +24,7 @@ import (
 // ProjectMembersService handles communication with the project members
 // related methods of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/members.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/members.html
 type ProjectMembersService struct {
 	client *Client
 }
@@ -33,7 +33,7 @@ type ProjectMembersService struct {
 // ListAllProjectMembers() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/members.html#list-all-members-of-a-group-or-project
+// https://docs.gitlab.com/ee/api/members.html#list-all-members-of-a-group-or-project
 type ListProjectMembersOptions struct {
 	ListOptions
 	Query   *string `url:"query,omitempty" json:"query,omitempty"`
@@ -45,7 +45,7 @@ type ListProjectMembersOptions struct {
 // through ancestors groups.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/members.html#list-all-members-of-a-group-or-project
+// https://docs.gitlab.com/ee/api/members.html#list-all-members-of-a-group-or-project
 func (s *ProjectMembersService) ListProjectMembers(pid interface{}, opt *ListProjectMembersOptions, options ...RequestOptionFunc) ([]*ProjectMember, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -72,7 +72,7 @@ func (s *ProjectMembersService) ListProjectMembers(pid interface{}, opt *ListPro
 // ancestor groups.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/members.html#list-all-members-of-a-group-or-project-including-inherited-members
+// https://docs.gitlab.com/ee/api/members.html#list-all-members-of-a-group-or-project-including-inherited-members
 func (s *ProjectMembersService) ListAllProjectMembers(pid interface{}, opt *ListProjectMembersOptions, options ...RequestOptionFunc) ([]*ProjectMember, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -97,7 +97,7 @@ func (s *ProjectMembersService) ListAllProjectMembers(pid interface{}, opt *List
 // GetProjectMember gets a project team member.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/members.html#get-a-member-of-a-group-or-project
+// https://docs.gitlab.com/ee/api/members.html#get-a-member-of-a-group-or-project
 func (s *ProjectMembersService) GetProjectMember(pid interface{}, user int, options ...RequestOptionFunc) (*ProjectMember, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -122,7 +122,7 @@ func (s *ProjectMembersService) GetProjectMember(pid interface{}, user int, opti
 // GetInheritedProjectMember gets a project team member, including inherited
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/members.html#get-a-member-of-a-group-or-project-including-inherited-members
+// https://docs.gitlab.com/ee/api/members.html#get-a-member-of-a-group-or-project-including-inherited-members
 func (s *ProjectMembersService) GetInheritedProjectMember(pid interface{}, user int, options ...RequestOptionFunc) (*ProjectMember, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -147,7 +147,7 @@ func (s *ProjectMembersService) GetInheritedProjectMember(pid interface{}, user 
 // AddProjectMemberOptions represents the available AddProjectMember() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/members.html#add-a-member-to-a-group-or-project
+// https://docs.gitlab.com/ee/api/members.html#add-a-member-to-a-group-or-project
 type AddProjectMemberOptions struct {
 	UserID      interface{}       `url:"user_id,omitempty" json:"user_id,omitempty"`
 	AccessLevel *AccessLevelValue `url:"access_level,omitempty" json:"access_level,omitempty"`
@@ -160,7 +160,7 @@ type AddProjectMemberOptions struct {
 // existing membership.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/members.html#add-a-member-to-a-group-or-project
+// https://docs.gitlab.com/ee/api/members.html#add-a-member-to-a-group-or-project
 func (s *ProjectMembersService) AddProjectMember(pid interface{}, opt *AddProjectMemberOptions, options ...RequestOptionFunc) (*ProjectMember, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -185,7 +185,7 @@ func (s *ProjectMembersService) AddProjectMember(pid interface{}, opt *AddProjec
 // EditProjectMemberOptions represents the available EditProjectMember() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/members.html#edit-a-member-of-a-group-or-project
+// https://docs.gitlab.com/ee/api/members.html#edit-a-member-of-a-group-or-project
 type EditProjectMemberOptions struct {
 	AccessLevel *AccessLevelValue `url:"access_level,omitempty" json:"access_level,omitempty"`
 	ExpiresAt   *string           `url:"expires_at,omitempty" json:"expires_at,omitempty"`
@@ -194,7 +194,7 @@ type EditProjectMemberOptions struct {
 // EditProjectMember updates a project team member to a specified access level..
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/members.html#edit-a-member-of-a-group-or-project
+// https://docs.gitlab.com/ee/api/members.html#edit-a-member-of-a-group-or-project
 func (s *ProjectMembersService) EditProjectMember(pid interface{}, user int, opt *EditProjectMemberOptions, options ...RequestOptionFunc) (*ProjectMember, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -219,7 +219,7 @@ func (s *ProjectMembersService) EditProjectMember(pid interface{}, user int, opt
 // DeleteProjectMember removes a user from a project team.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/members.html#remove-a-member-from-a-group-or-project
+// https://docs.gitlab.com/ee/api/members.html#remove-a-member-from-a-group-or-project
 func (s *ProjectMembersService) DeleteProjectMember(pid interface{}, user int, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/project_members.go
+++ b/project_members.go
@@ -72,7 +72,7 @@ func (s *ProjectMembersService) ListProjectMembers(pid interface{}, opt *ListPro
 // ancestor groups.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/members.html#list-all-members-of-a-group-or-project-including-inherited-members
+// https://docs.gitlab.com/ee/api/members.html#list-all-members-of-a-group-or-project-including-inherited-and-invited-members
 func (s *ProjectMembersService) ListAllProjectMembers(pid interface{}, opt *ListProjectMembersOptions, options ...RequestOptionFunc) ([]*ProjectMember, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -122,7 +122,7 @@ func (s *ProjectMembersService) GetProjectMember(pid interface{}, user int, opti
 // GetInheritedProjectMember gets a project team member, including inherited
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/members.html#get-a-member-of-a-group-or-project-including-inherited-members
+// https://docs.gitlab.com/ee/api/members.html#get-a-member-of-a-group-or-project-including-inherited-and-invited-members
 func (s *ProjectMembersService) GetInheritedProjectMember(pid interface{}, user int, options ...RequestOptionFunc) (*ProjectMember, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/project_mirror.go
+++ b/project_mirror.go
@@ -103,7 +103,7 @@ func (s *ProjectMirrorService) GetProjectMirror(pid interface{}, mirror int, opt
 // a new project mirror.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/remote_mirrors.html#create-a-remote-mirror
+// https://docs.gitlab.com/ee/api/remote_mirrors.html#create-a-push-mirror
 type AddProjectMirrorOptions struct {
 	URL                   *string `url:"url,omitempty" json:"url,omitempty"`
 	Enabled               *bool   `url:"enabled,omitempty" json:"enabled,omitempty"`
@@ -114,7 +114,7 @@ type AddProjectMirrorOptions struct {
 // AddProjectMirror creates a new mirror on the project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/remote_mirrors.html#create-a-remote-mirror
+// https://docs.gitlab.com/ee/api/remote_mirrors.html#create-a-push-mirror
 func (s *ProjectMirrorService) AddProjectMirror(pid interface{}, opt *AddProjectMirrorOptions, options ...RequestOptionFunc) (*ProjectMirror, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/project_mirror.go
+++ b/project_mirror.go
@@ -25,14 +25,14 @@ import (
 // ProjectMirrorService handles communication with the project mirror
 // related methods of the GitLab API.
 //
-// GitLAb API docs: https://docs.gitlab.com/ce/api/remote_mirrors.html
+// GitLAb API docs: https://docs.gitlab.com/ee/api/remote_mirrors.html
 type ProjectMirrorService struct {
 	client *Client
 }
 
 // ProjectMirror represents a project mirror configuration.
 //
-// GitLAb API docs: https://docs.gitlab.com/ce/api/remote_mirrors.html
+// GitLAb API docs: https://docs.gitlab.com/ee/api/remote_mirrors.html
 type ProjectMirror struct {
 	Enabled                bool       `json:"enabled"`
 	ID                     int        `json:"id"`
@@ -52,7 +52,7 @@ type ListProjectMirrorOptions ListOptions
 // ListProjectMirror gets a list of mirrors configured on the project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/remote_mirrors.html#list-a-projects-remote-mirrors
+// https://docs.gitlab.com/ee/api/remote_mirrors.html#list-a-projects-remote-mirrors
 func (s *ProjectMirrorService) ListProjectMirror(pid interface{}, opt *ListProjectMirrorOptions, options ...RequestOptionFunc) ([]*ProjectMirror, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -103,7 +103,7 @@ func (s *ProjectMirrorService) GetProjectMirror(pid interface{}, mirror int, opt
 // a new project mirror.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/remote_mirrors.html#create-a-remote-mirror
+// https://docs.gitlab.com/ee/api/remote_mirrors.html#create-a-remote-mirror
 type AddProjectMirrorOptions struct {
 	URL                   *string `url:"url,omitempty" json:"url,omitempty"`
 	Enabled               *bool   `url:"enabled,omitempty" json:"enabled,omitempty"`
@@ -114,7 +114,7 @@ type AddProjectMirrorOptions struct {
 // AddProjectMirror creates a new mirror on the project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/remote_mirrors.html#create-a-remote-mirror
+// https://docs.gitlab.com/ee/api/remote_mirrors.html#create-a-remote-mirror
 func (s *ProjectMirrorService) AddProjectMirror(pid interface{}, opt *AddProjectMirrorOptions, options ...RequestOptionFunc) (*ProjectMirror, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -140,7 +140,7 @@ func (s *ProjectMirrorService) AddProjectMirror(pid interface{}, opt *AddProject
 // an existing project mirror.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/remote_mirrors.html#update-a-remote-mirrors-attributes
+// https://docs.gitlab.com/ee/api/remote_mirrors.html#update-a-remote-mirrors-attributes
 type EditProjectMirrorOptions struct {
 	Enabled               *bool `url:"enabled,omitempty" json:"enabled,omitempty"`
 	OnlyProtectedBranches *bool `url:"only_protected_branches,omitempty" json:"only_protected_branches,omitempty"`
@@ -150,7 +150,7 @@ type EditProjectMirrorOptions struct {
 // EditProjectMirror updates a project team member to a specified access level..
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/remote_mirrors.html#update-a-remote-mirrors-attributes
+// https://docs.gitlab.com/ee/api/remote_mirrors.html#update-a-remote-mirrors-attributes
 func (s *ProjectMirrorService) EditProjectMirror(pid interface{}, mirror int, opt *EditProjectMirrorOptions, options ...RequestOptionFunc) (*ProjectMirror, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/project_snippets.go
+++ b/project_snippets.go
@@ -25,19 +25,19 @@ import (
 // ProjectSnippetsService handles communication with the project snippets
 // related methods of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/project_snippets.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/project_snippets.html
 type ProjectSnippetsService struct {
 	client *Client
 }
 
 // ListProjectSnippetsOptions represents the available ListSnippets() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/project_snippets.html#list-snippets
+// GitLab API docs: https://docs.gitlab.com/ee/api/project_snippets.html#list-snippets
 type ListProjectSnippetsOptions ListOptions
 
 // ListSnippets gets a list of project snippets.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/project_snippets.html#list-snippets
+// GitLab API docs: https://docs.gitlab.com/ee/api/project_snippets.html#list-snippets
 func (s *ProjectSnippetsService) ListSnippets(pid interface{}, opt *ListProjectSnippetsOptions, options ...RequestOptionFunc) ([]*Snippet, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -62,7 +62,7 @@ func (s *ProjectSnippetsService) ListSnippets(pid interface{}, opt *ListProjectS
 // GetSnippet gets a single project snippet
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/project_snippets.html#single-snippet
+// https://docs.gitlab.com/ee/api/project_snippets.html#single-snippet
 func (s *ProjectSnippetsService) GetSnippet(pid interface{}, snippet int, options ...RequestOptionFunc) (*Snippet, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -87,7 +87,7 @@ func (s *ProjectSnippetsService) GetSnippet(pid interface{}, snippet int, option
 // CreateProjectSnippetOptions represents the available CreateSnippet() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/project_snippets.html#create-new-snippet
+// https://docs.gitlab.com/ee/api/project_snippets.html#create-new-snippet
 type CreateProjectSnippetOptions struct {
 	Title       *string          `url:"title,omitempty" json:"title,omitempty"`
 	FileName    *string          `url:"file_name,omitempty" json:"file_name,omitempty"`
@@ -101,7 +101,7 @@ type CreateProjectSnippetOptions struct {
 // to create new snippets.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/project_snippets.html#create-new-snippet
+// https://docs.gitlab.com/ee/api/project_snippets.html#create-new-snippet
 func (s *ProjectSnippetsService) CreateSnippet(pid interface{}, opt *CreateProjectSnippetOptions, options ...RequestOptionFunc) (*Snippet, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -126,7 +126,7 @@ func (s *ProjectSnippetsService) CreateSnippet(pid interface{}, opt *CreateProje
 // UpdateProjectSnippetOptions represents the available UpdateSnippet() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/project_snippets.html#update-snippet
+// https://docs.gitlab.com/ee/api/project_snippets.html#update-snippet
 type UpdateProjectSnippetOptions struct {
 	Title       *string          `url:"title,omitempty" json:"title,omitempty"`
 	FileName    *string          `url:"file_name,omitempty" json:"file_name,omitempty"`
@@ -139,7 +139,7 @@ type UpdateProjectSnippetOptions struct {
 // permission to change an existing snippet.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/project_snippets.html#update-snippet
+// https://docs.gitlab.com/ee/api/project_snippets.html#update-snippet
 func (s *ProjectSnippetsService) UpdateSnippet(pid interface{}, snippet int, opt *UpdateProjectSnippetOptions, options ...RequestOptionFunc) (*Snippet, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -166,7 +166,7 @@ func (s *ProjectSnippetsService) UpdateSnippet(pid interface{}, snippet int, opt
 // code.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/project_snippets.html#delete-snippet
+// https://docs.gitlab.com/ee/api/project_snippets.html#delete-snippet
 func (s *ProjectSnippetsService) DeleteSnippet(pid interface{}, snippet int, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -185,7 +185,7 @@ func (s *ProjectSnippetsService) DeleteSnippet(pid interface{}, snippet int, opt
 // SnippetContent returns the raw project snippet as plain text.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/project_snippets.html#snippet-content
+// https://docs.gitlab.com/ee/api/project_snippets.html#snippet-content
 func (s *ProjectSnippetsService) SnippetContent(pid interface{}, snippet int, options ...RequestOptionFunc) ([]byte, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/project_variables.go
+++ b/project_variables.go
@@ -48,7 +48,7 @@ func (v ProjectVariable) String() string {
 	return Stringify(v)
 }
 
-//VariableFilter filters available for project variable related functions
+// VariableFilter filters available for project variable related functions
 type VariableFilter struct {
 	EnvironmentScope string `url:"environment_scope, omitempty" json:"environment_scope,omitempty"`
 }
@@ -89,7 +89,7 @@ func (s *ProjectVariablesService) ListVariables(pid interface{}, opt *ListProjec
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/project_level_variables.html#show-variable-details
+// https://docs.gitlab.com/ee/api/project_level_variables.html#get-a-single-variable
 type GetProjectVariableOptions struct {
 	Filter *VariableFilter `url:"filter,omitempty" json:"filter,omitempty"`
 }
@@ -97,7 +97,7 @@ type GetProjectVariableOptions struct {
 // GetVariable gets a variable.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/project_level_variables.html#show-variable-details
+// https://docs.gitlab.com/ee/api/project_level_variables.html#get-a-single-variable
 func (s *ProjectVariablesService) GetVariable(pid interface{}, key string, opt *GetProjectVariableOptions, options ...RequestOptionFunc) (*ProjectVariable, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -123,7 +123,7 @@ func (s *ProjectVariablesService) GetVariable(pid interface{}, key string, opt *
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/project_level_variables.html#create-variable
+// https://docs.gitlab.com/ee/api/project_level_variables.html#create-a-variable
 type CreateProjectVariableOptions struct {
 	Key              *string            `url:"key,omitempty" json:"key,omitempty"`
 	Value            *string            `url:"value,omitempty" json:"value,omitempty"`
@@ -136,7 +136,7 @@ type CreateProjectVariableOptions struct {
 // CreateVariable creates a new project variable.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/project_level_variables.html#create-variable
+// https://docs.gitlab.com/ee/api/project_level_variables.html#create-a-variable
 func (s *ProjectVariablesService) CreateVariable(pid interface{}, opt *CreateProjectVariableOptions, options ...RequestOptionFunc) (*ProjectVariable, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -162,7 +162,7 @@ func (s *ProjectVariablesService) CreateVariable(pid interface{}, opt *CreatePro
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/project_level_variables.html#update-variable
+// https://docs.gitlab.com/ee/api/project_level_variables.html#update-a-variable
 type UpdateProjectVariableOptions struct {
 	Value            *string            `url:"value,omitempty" json:"value,omitempty"`
 	VariableType     *VariableTypeValue `url:"variable_type,omitempty" json:"variable_type,omitempty"`
@@ -175,7 +175,7 @@ type UpdateProjectVariableOptions struct {
 // UpdateVariable updates a project's variable.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/project_level_variables.html#update-variable
+// https://docs.gitlab.com/ee/api/project_level_variables.html#update-a-variable
 func (s *ProjectVariablesService) UpdateVariable(pid interface{}, key string, opt *UpdateProjectVariableOptions, options ...RequestOptionFunc) (*ProjectVariable, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -201,7 +201,7 @@ func (s *ProjectVariablesService) UpdateVariable(pid interface{}, key string, op
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/project_level_variables.html#remove-variable
+// https://docs.gitlab.com/ee/api/project_level_variables.html#delete-a-variable
 type RemoveProjectVariableOptions struct {
 	Filter *VariableFilter `url:"filter,omitempty" json:"filter,omitempty"`
 }
@@ -209,7 +209,7 @@ type RemoveProjectVariableOptions struct {
 // RemoveVariable removes a project's variable.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/project_level_variables.html#remove-variable
+// https://docs.gitlab.com/ee/api/project_level_variables.html#delete-a-variable
 func (s *ProjectVariablesService) RemoveVariable(pid interface{}, key string, opt *RemoveProjectVariableOptions, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/projects.go
+++ b/projects.go
@@ -298,7 +298,7 @@ func (s ProjectApprovalRule) String() string {
 
 // ListProjectsOptions represents the available ListProjects() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/projects.html#list-projects
+// GitLab API docs: https://docs.gitlab.com/ee/api/projects.html#list-all-projects
 type ListProjectsOptions struct {
 	ListOptions
 	Archived                 *bool             `url:"archived,omitempty" json:"archived,omitempty"`
@@ -329,7 +329,7 @@ type ListProjectsOptions struct {
 
 // ListProjects gets a list of projects accessible by the authenticated user.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/projects.html#list-projects
+// GitLab API docs: https://docs.gitlab.com/ee/api/projects.html#list-all-projects
 func (s *ProjectsService) ListProjects(opt *ListProjectsOptions, options ...RequestOptionFunc) ([]*Project, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "projects", opt, options)
 	if err != nil {
@@ -552,7 +552,7 @@ func (s *ProjectsService) GetProject(pid interface{}, opt *GetProjectOptions, op
 // ProjectEvent represents a GitLab project event.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/projects.html#get-project-events
+// https://docs.gitlab.com/ee/api/events.html#list-a-projects-visible-events
 type ProjectEvent struct {
 	Title          interface{} `json:"title"`
 	ProjectID      int         `json:"project_id"`
@@ -581,14 +581,14 @@ func (s ProjectEvent) String() string {
 // GetProjectEventsOptions represents the available GetProjectEvents() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/projects.html#get-project-events
+// https://docs.gitlab.com/ee/api/events.html#list-a-projects-visible-events
 type GetProjectEventsOptions ListOptions
 
 // GetProjectEvents gets the events for the specified project. Sorted from
 // newest to latest.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/projects.html#get-project-events
+// https://docs.gitlab.com/ee/api/events.html#list-a-projects-visible-events
 func (s *ProjectsService) GetProjectEvents(pid interface{}, opt *GetProjectEventsOptions, options ...RequestOptionFunc) ([]*ProjectEvent, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -1090,7 +1090,7 @@ func (s *ProjectsService) UnarchiveProject(pid interface{}, options ...RequestOp
 // DeleteProject removes a project including all associated resources
 // (issues, merge requests etc.)
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/projects.html#remove-project
+// GitLab API docs: https://docs.gitlab.com/ee/api/projects.html#delete-project
 func (s *ProjectsService) DeleteProject(pid interface{}, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -1810,7 +1810,7 @@ func (s *ProjectsService) GetProjectApprovalRule(pid interface{}, ruleID int, op
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/merge_request_approvals.html#create-project-level-rules
+// https://docs.gitlab.com/ee/api/merge_request_approvals.html#create-project-level-rule
 type CreateProjectLevelRuleOptions struct {
 	Name                          *string `url:"name,omitempty" json:"name,omitempty"`
 	ApprovalsRequired             *int    `url:"approvals_required,omitempty" json:"approvals_required,omitempty"`
@@ -1824,7 +1824,7 @@ type CreateProjectLevelRuleOptions struct {
 // CreateProjectApprovalRule creates a new project-level approval rule.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/merge_request_approvals.html#create-project-level-rules
+// https://docs.gitlab.com/ee/api/merge_request_approvals.html#create-project-level-rule
 func (s *ProjectsService) CreateProjectApprovalRule(pid interface{}, opt *CreateProjectLevelRuleOptions, options ...RequestOptionFunc) (*ProjectApprovalRule, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -1850,7 +1850,7 @@ func (s *ProjectsService) CreateProjectApprovalRule(pid interface{}, opt *Create
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/merge_request_approvals.html#update-project-level-rules
+// https://docs.gitlab.com/ee/api/merge_request_approvals.html#update-project-level-rule
 type UpdateProjectLevelRuleOptions struct {
 	Name                          *string `url:"name,omitempty" json:"name,omitempty"`
 	ApprovalsRequired             *int    `url:"approvals_required,omitempty" json:"approvals_required,omitempty"`
@@ -1863,7 +1863,7 @@ type UpdateProjectLevelRuleOptions struct {
 // UpdateProjectApprovalRule updates an existing approval rule with new options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/merge_request_approvals.html#update-project-level-rules
+// https://docs.gitlab.com/ee/api/merge_request_approvals.html#update-project-level-rule
 func (s *ProjectsService) UpdateProjectApprovalRule(pid interface{}, approvalRule int, opt *UpdateProjectLevelRuleOptions, options ...RequestOptionFunc) (*ProjectApprovalRule, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -1888,7 +1888,7 @@ func (s *ProjectsService) UpdateProjectApprovalRule(pid interface{}, approvalRul
 // DeleteProjectApprovalRule deletes a project-level approval rule.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/merge_request_approvals.html#delete-project-level-rules
+// https://docs.gitlab.com/ee/api/merge_request_approvals.html#delete-project-level-rule
 func (s *ProjectsService) DeleteProjectApprovalRule(pid interface{}, approvalRule int, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -1942,7 +1942,7 @@ func (s *ProjectsService) ChangeAllowedApprovers(pid interface{}, opt *ChangeAll
 // StartMirroringProject start the pull mirroring process for a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/projects.html#start-the-pull-mirroring-process-for-a-project-starter
+// https://docs.gitlab.com/ee/api/projects.html#start-the-pull-mirroring-process-for-a-project
 func (s *ProjectsService) StartMirroringProject(pid interface{}, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/projects.go
+++ b/projects.go
@@ -29,14 +29,14 @@ import (
 // ProjectsService handles communication with the repositories related methods
 // of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/projects.html
 type ProjectsService struct {
 	client *Client
 }
 
 // Project represents a GitLab project.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/projects.html
 type Project struct {
 	ID                                        int                        `json:"id"`
 	Description                               string                     `json:"description"`
@@ -298,7 +298,7 @@ func (s ProjectApprovalRule) String() string {
 
 // ListProjectsOptions represents the available ListProjects() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#list-projects
+// GitLab API docs: https://docs.gitlab.com/ee/api/projects.html#list-projects
 type ListProjectsOptions struct {
 	ListOptions
 	Archived                 *bool             `url:"archived,omitempty" json:"archived,omitempty"`
@@ -329,7 +329,7 @@ type ListProjectsOptions struct {
 
 // ListProjects gets a list of projects accessible by the authenticated user.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#list-projects
+// GitLab API docs: https://docs.gitlab.com/ee/api/projects.html#list-projects
 func (s *ProjectsService) ListProjects(opt *ListProjectsOptions, options ...RequestOptionFunc) ([]*Project, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "projects", opt, options)
 	if err != nil {
@@ -348,7 +348,7 @@ func (s *ProjectsService) ListProjects(opt *ListProjectsOptions, options ...Requ
 // ListUserProjects gets a list of projects for the given user.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#list-user-projects
+// https://docs.gitlab.com/ee/api/projects.html#list-user-projects
 func (s *ProjectsService) ListUserProjects(uid interface{}, opt *ListProjectsOptions, options ...RequestOptionFunc) ([]*Project, *Response, error) {
 	user, err := parseID(uid)
 	if err != nil {
@@ -407,7 +407,7 @@ type ProjectUser struct {
 
 // ListProjectUserOptions represents the available ListProjectsUsers() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#get-project-users
+// GitLab API docs: https://docs.gitlab.com/ee/api/projects.html#get-project-users
 type ListProjectUserOptions struct {
 	ListOptions
 	Search *string `url:"search,omitempty" json:"search,omitempty"`
@@ -416,7 +416,7 @@ type ListProjectUserOptions struct {
 // ListProjectsUsers gets a list of users for the given project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#get-project-users
+// https://docs.gitlab.com/ee/api/projects.html#get-project-users
 func (s *ProjectsService) ListProjectsUsers(pid interface{}, opt *ListProjectUserOptions, options ...RequestOptionFunc) ([]*ProjectUser, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -450,7 +450,7 @@ type ProjectGroup struct {
 
 // ListProjectGroupOptions represents the available ListProjectsGroups() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#list-a-projects-groups
+// GitLab API docs: https://docs.gitlab.com/ee/api/projects.html#list-a-projects-groups
 type ListProjectGroupOptions struct {
 	ListOptions
 	Search               *string           `url:"search,omitempty" json:"search,omitempty"`
@@ -463,7 +463,7 @@ type ListProjectGroupOptions struct {
 // ListProjectsGroups gets a list of groups for the given project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#list-a-projects-groups
+// https://docs.gitlab.com/ee/api/projects.html#list-a-projects-groups
 func (s *ProjectsService) ListProjectsGroups(pid interface{}, opt *ListProjectGroupOptions, options ...RequestOptionFunc) ([]*ProjectGroup, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -487,12 +487,12 @@ func (s *ProjectsService) ListProjectsGroups(pid interface{}, opt *ListProjectGr
 
 // ProjectLanguages is a map of strings because the response is arbitrary
 //
-// Gitlab API docs: https://docs.gitlab.com/ce/api/projects.html#languages
+// Gitlab API docs: https://docs.gitlab.com/ee/api/projects.html#languages
 type ProjectLanguages map[string]float32
 
 // GetProjectLanguages gets a list of languages used by the project
 //
-// GitLab API docs:  https://docs.gitlab.com/ce/api/projects.html#languages
+// GitLab API docs:  https://docs.gitlab.com/ee/api/projects.html#languages
 func (s *ProjectsService) GetProjectLanguages(pid interface{}, options ...RequestOptionFunc) (*ProjectLanguages, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -527,7 +527,7 @@ type GetProjectOptions struct {
 // NAMESPACE/PROJECT_NAME, which is owned by the authenticated user.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#get-single-project
+// https://docs.gitlab.com/ee/api/projects.html#get-single-project
 func (s *ProjectsService) GetProject(pid interface{}, opt *GetProjectOptions, options ...RequestOptionFunc) (*Project, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -552,7 +552,7 @@ func (s *ProjectsService) GetProject(pid interface{}, opt *GetProjectOptions, op
 // ProjectEvent represents a GitLab project event.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#get-project-events
+// https://docs.gitlab.com/ee/api/projects.html#get-project-events
 type ProjectEvent struct {
 	Title          interface{} `json:"title"`
 	ProjectID      int         `json:"project_id"`
@@ -581,14 +581,14 @@ func (s ProjectEvent) String() string {
 // GetProjectEventsOptions represents the available GetProjectEvents() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#get-project-events
+// https://docs.gitlab.com/ee/api/projects.html#get-project-events
 type GetProjectEventsOptions ListOptions
 
 // GetProjectEvents gets the events for the specified project. Sorted from
 // newest to latest.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#get-project-events
+// https://docs.gitlab.com/ee/api/projects.html#get-project-events
 func (s *ProjectsService) GetProjectEvents(pid interface{}, opt *GetProjectEventsOptions, options ...RequestOptionFunc) ([]*ProjectEvent, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -727,7 +727,7 @@ func (a *ProjectAvatar) MarshalJSON() ([]byte, error) {
 
 // CreateProject creates a new project owned by the authenticated user.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#create-project
+// GitLab API docs: https://docs.gitlab.com/ee/api/projects.html#create-project
 func (s *ProjectsService) CreateProject(opt *CreateProjectOptions, options ...RequestOptionFunc) (*Project, *Response, error) {
 	if opt.ContainerExpirationPolicyAttributes != nil {
 		// This is needed to satisfy the API. Should be deleted
@@ -769,14 +769,14 @@ func (s *ProjectsService) CreateProject(opt *CreateProjectOptions, options ...Re
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#create-project-for-user
+// https://docs.gitlab.com/ee/api/projects.html#create-project-for-user
 type CreateProjectForUserOptions CreateProjectOptions
 
 // CreateProjectForUser creates a new project owned by the specified user.
 // Available only for admins.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#create-project-for-user
+// https://docs.gitlab.com/ee/api/projects.html#create-project-for-user
 func (s *ProjectsService) CreateProjectForUser(user int, opt *CreateProjectForUserOptions, options ...RequestOptionFunc) (*Project, *Response, error) {
 	if opt.ContainerExpirationPolicyAttributes != nil {
 		// This is needed to satisfy the API. Should be deleted
@@ -817,7 +817,7 @@ func (s *ProjectsService) CreateProjectForUser(user int, opt *CreateProjectForUs
 
 // EditProjectOptions represents the available EditProject() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#edit-project
+// GitLab API docs: https://docs.gitlab.com/ee/api/projects.html#edit-project
 type EditProjectOptions struct {
 	AllowMergeOnSkippedPipeline               *bool                                `url:"allow_merge_on_skipped_pipeline,omitempty" json:"allow_merge_on_skipped_pipeline,omitempty"`
 	AnalyticsAccessLevel                      *AccessControlValue                  `url:"analytics_access_level,omitempty" json:"analytics_access_level,omitempty"`
@@ -901,7 +901,7 @@ type EditProjectOptions struct {
 
 // EditProject updates an existing project.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#edit-project
+// GitLab API docs: https://docs.gitlab.com/ee/api/projects.html#edit-project
 func (s *ProjectsService) EditProject(pid interface{}, opt *EditProjectOptions, options ...RequestOptionFunc) (*Project, *Response, error) {
 	if opt.ContainerExpirationPolicyAttributes != nil {
 		// This is needed to satisfy the API. Should be deleted
@@ -946,7 +946,7 @@ func (s *ProjectsService) EditProject(pid interface{}, opt *EditProjectOptions, 
 
 // ForkProjectOptions represents the available ForkProject() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#fork-project
+// GitLab API docs: https://docs.gitlab.com/ee/api/projects.html#fork-project
 type ForkProjectOptions struct {
 	Description                   *string          `url:"description,omitempty" json:"description,omitempty"`
 	MergeRequestDefaultTargetSelf *bool            `url:"mr_default_target_self,omitempty" json:"mr_default_target_self,omitempty"`
@@ -963,7 +963,7 @@ type ForkProjectOptions struct {
 // ForkProject forks a project into the user namespace of the authenticated
 // user.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#fork-project
+// GitLab API docs: https://docs.gitlab.com/ee/api/projects.html#fork-project
 func (s *ProjectsService) ForkProject(pid interface{}, opt *ForkProjectOptions, options ...RequestOptionFunc) (*Project, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -988,7 +988,7 @@ func (s *ProjectsService) ForkProject(pid interface{}, opt *ForkProjectOptions, 
 // StarProject stars a given the project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#star-a-project
+// https://docs.gitlab.com/ee/api/projects.html#star-a-project
 func (s *ProjectsService) StarProject(pid interface{}, options ...RequestOptionFunc) (*Project, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -1013,7 +1013,7 @@ func (s *ProjectsService) StarProject(pid interface{}, options ...RequestOptionF
 // UnstarProject unstars a given project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#unstar-a-project
+// https://docs.gitlab.com/ee/api/projects.html#unstar-a-project
 func (s *ProjectsService) UnstarProject(pid interface{}, options ...RequestOptionFunc) (*Project, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -1039,7 +1039,7 @@ func (s *ProjectsService) UnstarProject(pid interface{}, options ...RequestOptio
 // project owner of this project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#archive-a-project
+// https://docs.gitlab.com/ee/api/projects.html#archive-a-project
 func (s *ProjectsService) ArchiveProject(pid interface{}, options ...RequestOptionFunc) (*Project, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -1065,7 +1065,7 @@ func (s *ProjectsService) ArchiveProject(pid interface{}, options ...RequestOpti
 // the project owner of this project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#unarchive-a-project
+// https://docs.gitlab.com/ee/api/projects.html#unarchive-a-project
 func (s *ProjectsService) UnarchiveProject(pid interface{}, options ...RequestOptionFunc) (*Project, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -1090,7 +1090,7 @@ func (s *ProjectsService) UnarchiveProject(pid interface{}, options ...RequestOp
 // DeleteProject removes a project including all associated resources
 // (issues, merge requests etc.)
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#remove-project
+// GitLab API docs: https://docs.gitlab.com/ee/api/projects.html#remove-project
 func (s *ProjectsService) DeleteProject(pid interface{}, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -1108,7 +1108,7 @@ func (s *ProjectsService) DeleteProject(pid interface{}, options ...RequestOptio
 
 // ShareWithGroupOptions represents options to share project with groups
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#share-project-with-group
+// GitLab API docs: https://docs.gitlab.com/ee/api/projects.html#share-project-with-group
 type ShareWithGroupOptions struct {
 	ExpiresAt   *string           `url:"expires_at" json:"expires_at"`
 	GroupAccess *AccessLevelValue `url:"group_access" json:"group_access"`
@@ -1117,7 +1117,7 @@ type ShareWithGroupOptions struct {
 
 // ShareProjectWithGroup allows to share a project with a group.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#share-project-with-group
+// GitLab API docs: https://docs.gitlab.com/ee/api/projects.html#share-project-with-group
 func (s *ProjectsService) ShareProjectWithGroup(pid interface{}, opt *ShareWithGroupOptions, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -1135,7 +1135,7 @@ func (s *ProjectsService) ShareProjectWithGroup(pid interface{}, opt *ShareWithG
 
 // DeleteSharedProjectFromGroup allows to unshare a project from a group.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#delete-a-shared-project-link-within-a-group
+// GitLab API docs: https://docs.gitlab.com/ee/api/projects.html#delete-a-shared-project-link-within-a-group
 func (s *ProjectsService) DeleteSharedProjectFromGroup(pid interface{}, groupID int, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -1154,7 +1154,7 @@ func (s *ProjectsService) DeleteSharedProjectFromGroup(pid interface{}, groupID 
 // ProjectMember represents a project member.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#list-project-team-members
+// https://docs.gitlab.com/ee/api/projects.html#list-project-team-members
 type ProjectMember struct {
 	ID          int              `json:"id"`
 	Username    string           `json:"username"`
@@ -1171,7 +1171,7 @@ type ProjectMember struct {
 // ProjectHook represents a project hook.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#list-project-hooks
+// https://docs.gitlab.com/ee/api/projects.html#list-project-hooks
 type ProjectHook struct {
 	ID                       int        `json:"id"`
 	URL                      string     `json:"url"`
@@ -1195,13 +1195,13 @@ type ProjectHook struct {
 
 // ListProjectHooksOptions represents the available ListProjectHooks() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#list-project-hooks
+// GitLab API docs: https://docs.gitlab.com/ee/api/projects.html#list-project-hooks
 type ListProjectHooksOptions ListOptions
 
 // ListProjectHooks gets a list of project hooks.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#list-project-hooks
+// https://docs.gitlab.com/ee/api/projects.html#list-project-hooks
 func (s *ProjectsService) ListProjectHooks(pid interface{}, opt *ListProjectHooksOptions, options ...RequestOptionFunc) ([]*ProjectHook, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -1226,7 +1226,7 @@ func (s *ProjectsService) ListProjectHooks(pid interface{}, opt *ListProjectHook
 // GetProjectHook gets a specific hook for a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#get-project-hook
+// https://docs.gitlab.com/ee/api/projects.html#get-project-hook
 func (s *ProjectsService) GetProjectHook(pid interface{}, hook int, options ...RequestOptionFunc) (*ProjectHook, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -1251,7 +1251,7 @@ func (s *ProjectsService) GetProjectHook(pid interface{}, hook int, options ...R
 // AddProjectHookOptions represents the available AddProjectHook() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#add-project-hook
+// https://docs.gitlab.com/ee/api/projects.html#add-project-hook
 type AddProjectHookOptions struct {
 	ConfidentialIssuesEvents *bool   `url:"confidential_issues_events,omitempty" json:"confidential_issues_events,omitempty"`
 	ConfidentialNoteEvents   *bool   `url:"confidential_note_events,omitempty" json:"confidential_note_events,omitempty"`
@@ -1274,7 +1274,7 @@ type AddProjectHookOptions struct {
 // AddProjectHook adds a hook to a specified project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#add-project-hook
+// https://docs.gitlab.com/ee/api/projects.html#add-project-hook
 func (s *ProjectsService) AddProjectHook(pid interface{}, opt *AddProjectHookOptions, options ...RequestOptionFunc) (*ProjectHook, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -1299,7 +1299,7 @@ func (s *ProjectsService) AddProjectHook(pid interface{}, opt *AddProjectHookOpt
 // EditProjectHookOptions represents the available EditProjectHook() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#edit-project-hook
+// https://docs.gitlab.com/ee/api/projects.html#edit-project-hook
 type EditProjectHookOptions struct {
 	ConfidentialIssuesEvents *bool   `url:"confidential_issues_events,omitempty" json:"confidential_issues_events,omitempty"`
 	ConfidentialNoteEvents   *bool   `url:"confidential_note_events,omitempty" json:"confidential_note_events,omitempty"`
@@ -1322,7 +1322,7 @@ type EditProjectHookOptions struct {
 // EditProjectHook edits a hook for a specified project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#edit-project-hook
+// https://docs.gitlab.com/ee/api/projects.html#edit-project-hook
 func (s *ProjectsService) EditProjectHook(pid interface{}, hook int, opt *EditProjectHookOptions, options ...RequestOptionFunc) (*ProjectHook, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -1348,7 +1348,7 @@ func (s *ProjectsService) EditProjectHook(pid interface{}, hook int, opt *EditPr
 // method and can be called multiple times. Either the hook is available or not.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#delete-project-hook
+// https://docs.gitlab.com/ee/api/projects.html#delete-project-hook
 func (s *ProjectsService) DeleteProjectHook(pid interface{}, hook int, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -1367,7 +1367,7 @@ func (s *ProjectsService) DeleteProjectHook(pid interface{}, hook int, options .
 // ProjectForkRelation represents a project fork relationship.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#admin-fork-relation
+// https://docs.gitlab.com/ee/api/projects.html#admin-fork-relation
 type ProjectForkRelation struct {
 	ID                  int        `json:"id"`
 	ForkedToProjectID   int        `json:"forked_to_project_id"`
@@ -1380,7 +1380,7 @@ type ProjectForkRelation struct {
 // existing projects.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#create-a-forked-fromto-relation-between-existing-projects.
+// https://docs.gitlab.com/ee/api/projects.html#create-a-forked-fromto-relation-between-existing-projects.
 func (s *ProjectsService) CreateProjectForkRelation(pid interface{}, fork int, options ...RequestOptionFunc) (*ProjectForkRelation, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -1405,7 +1405,7 @@ func (s *ProjectsService) CreateProjectForkRelation(pid interface{}, fork int, o
 // DeleteProjectForkRelation deletes an existing forked from relationship.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#delete-an-existing-forked-from-relationship
+// https://docs.gitlab.com/ee/api/projects.html#delete-an-existing-forked-from-relationship
 func (s *ProjectsService) DeleteProjectForkRelation(pid interface{}, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -1423,7 +1423,7 @@ func (s *ProjectsService) DeleteProjectForkRelation(pid interface{}, options ...
 
 // ProjectFile represents an uploaded project file.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#upload-a-file
+// GitLab API docs: https://docs.gitlab.com/ee/api/projects.html#upload-a-file
 type ProjectFile struct {
 	Alt      string `json:"alt"`
 	URL      string `json:"url"`
@@ -1432,7 +1432,7 @@ type ProjectFile struct {
 
 // UploadFile uploads a file.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#upload-a-file
+// GitLab API docs: https://docs.gitlab.com/ee/api/projects.html#upload-a-file
 func (s *ProjectsService) UploadFile(pid interface{}, content io.Reader, filename string, options ...RequestOptionFunc) (*ProjectFile, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -1498,7 +1498,7 @@ func (s *ProjectsService) UploadAvatar(pid interface{}, avatar io.Reader, filena
 // ListProjectForks gets a list of project forks.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#list-forks-of-a-project
+// https://docs.gitlab.com/ee/api/projects.html#list-forks-of-a-project
 func (s *ProjectsService) ListProjectForks(pid interface{}, opt *ListProjectsOptions, options ...RequestOptionFunc) ([]*Project, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -1965,14 +1965,14 @@ func (s *ProjectsService) StartMirroringProject(pid interface{}, options ...Requ
 
 // TransferProjectOptions represents the available TransferProject() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#transfer-a-project-to-a-new-namespace
+// GitLab API docs: https://docs.gitlab.com/ee/api/projects.html#transfer-a-project-to-a-new-namespace
 type TransferProjectOptions struct {
 	Namespace interface{} `url:"namespace,omitempty" json:"namespace,omitempty"`
 }
 
 // TransferProject transfer a project into the specified namespace
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#transfer-a-project-to-a-new-namespace
+// GitLab API docs: https://docs.gitlab.com/ee/api/projects.html#transfer-a-project-to-a-new-namespace
 func (s *ProjectsService) TransferProject(pid interface{}, opt *TransferProjectOptions, options ...RequestOptionFunc) (*Project, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/protected_branches.go
+++ b/protected_branches.go
@@ -26,7 +26,7 @@ import (
 // related methods of the GitLab API.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/protected_branches.html#protected-branches-api
+// https://docs.gitlab.com/ee/api/protected_branches.html#protected-branches-api
 type ProtectedBranchesService struct {
 	client *Client
 }
@@ -34,7 +34,7 @@ type ProtectedBranchesService struct {
 // ProtectedBranch represents a protected branch.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/protected_branches.html#list-protected-branches
+// https://docs.gitlab.com/ee/api/protected_branches.html#list-protected-branches
 type ProtectedBranch struct {
 	ID                        int                        `json:"id"`
 	Name                      string                     `json:"name"`
@@ -49,7 +49,7 @@ type ProtectedBranch struct {
 // branch.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/protected_branches.html#protected-branches-api
+// https://docs.gitlab.com/ee/api/protected_branches.html#protected-branches-api
 type BranchAccessDescription struct {
 	AccessLevel            AccessLevelValue `json:"access_level"`
 	AccessLevelDescription string           `json:"access_level_description"`
@@ -61,13 +61,13 @@ type BranchAccessDescription struct {
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/protected_branches.html#list-protected-branches
+// https://docs.gitlab.com/ee/api/protected_branches.html#list-protected-branches
 type ListProtectedBranchesOptions ListOptions
 
 // ListProtectedBranches gets a list of protected branches from a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/protected_branches.html#list-protected-branches
+// https://docs.gitlab.com/ee/api/protected_branches.html#list-protected-branches
 func (s *ProtectedBranchesService) ListProtectedBranches(pid interface{}, opt *ListProtectedBranchesOptions, options ...RequestOptionFunc) ([]*ProtectedBranch, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -92,7 +92,7 @@ func (s *ProtectedBranchesService) ListProtectedBranches(pid interface{}, opt *L
 // GetProtectedBranch gets a single protected branch or wildcard protected branch.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/protected_branches.html#get-a-single-protected-branch-or-wildcard-protected-branch
+// https://docs.gitlab.com/ee/api/protected_branches.html#get-a-single-protected-branch-or-wildcard-protected-branch
 func (s *ProtectedBranchesService) GetProtectedBranch(pid interface{}, branch string, options ...RequestOptionFunc) (*ProtectedBranch, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -118,7 +118,7 @@ func (s *ProtectedBranchesService) GetProtectedBranch(pid interface{}, branch st
 // ProtectRepositoryBranches() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/protected_branches.html#protect-repository-branches
+// https://docs.gitlab.com/ee/api/protected_branches.html#protect-repository-branches
 type ProtectRepositoryBranchesOptions struct {
 	Name                      *string                     `url:"name,omitempty" json:"name,omitempty"`
 	PushAccessLevel           *AccessLevelValue           `url:"push_access_level,omitempty" json:"push_access_level,omitempty"`
@@ -134,7 +134,7 @@ type ProtectRepositoryBranchesOptions struct {
 // BranchPermissionOptions represents a branch permission option.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/protected_branches.html#protect-repository-branches
+// https://docs.gitlab.com/ee/api/protected_branches.html#protect-repository-branches
 type BranchPermissionOptions struct {
 	UserID      *int              `url:"user_id,omitempty" json:"user_id,omitempty"`
 	GroupID     *int              `url:"group_id,omitempty" json:"group_id,omitempty"`
@@ -146,7 +146,7 @@ type BranchPermissionOptions struct {
 // project repository branches using a wildcard protected branch.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/protected_branches.html#protect-repository-branches
+// https://docs.gitlab.com/ee/api/protected_branches.html#protect-repository-branches
 func (s *ProtectedBranchesService) ProtectRepositoryBranches(pid interface{}, opt *ProtectRepositoryBranchesOptions, options ...RequestOptionFunc) (*ProtectedBranch, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -172,7 +172,7 @@ func (s *ProtectedBranchesService) ProtectRepositoryBranches(pid interface{}, op
 // protected branch.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/protected_branches.html#unprotect-repository-branches
+// https://docs.gitlab.com/ee/api/protected_branches.html#unprotect-repository-branches
 func (s *ProtectedBranchesService) UnprotectRepositoryBranches(pid interface{}, branch string, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/protected_branches.go
+++ b/protected_branches.go
@@ -26,7 +26,7 @@ import (
 // related methods of the GitLab API.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/protected_branches.html#protected-branches-api
+// https://docs.gitlab.com/ee/api/protected_branches.html
 type ProtectedBranchesService struct {
 	client *Client
 }
@@ -49,7 +49,7 @@ type ProtectedBranch struct {
 // branch.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/protected_branches.html#protected-branches-api
+// https://docs.gitlab.com/ee/api/protected_branches.html#list-protected-branches
 type BranchAccessDescription struct {
 	AccessLevel            AccessLevelValue `json:"access_level"`
 	AccessLevelDescription string           `json:"access_level_description"`
@@ -192,7 +192,7 @@ func (s *ProtectedBranchesService) UnprotectRepositoryBranches(pid interface{}, 
 // RequireCodeOwnerApprovals() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/protected_branches.html#require-code-owner-approvals-for-a-single-branch
+// https://docs.gitlab.com/ee/api/protected_branches.html#update-a-protected-branch
 type RequireCodeOwnerApprovalsOptions struct {
 	CodeOwnerApprovalRequired *bool `url:"code_owner_approval_required,omitempty" json:"code_owner_approval_required,omitempty"`
 }
@@ -200,7 +200,7 @@ type RequireCodeOwnerApprovalsOptions struct {
 // RequireCodeOwnerApprovals updates the code owner approval option.
 //
 // Gitlab API docs:
-// https://docs.gitlab.com/ee/api/protected_branches.html#require-code-owner-approvals-for-a-single-branch
+// https://docs.gitlab.com/ee/api/protected_branches.html#update-a-protected-branch
 func (s *ProtectedBranchesService) RequireCodeOwnerApprovals(pid interface{}, branch string, opt *RequireCodeOwnerApprovalsOptions, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/protected_environments.go
+++ b/protected_environments.go
@@ -89,7 +89,7 @@ func (s *ProtectedEnvironmentsService) ListProtectedEnvironments(pid interface{}
 // protected environment.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/protected_environments.html#get-a-single-protected-environment-or-wildcard-protected-environment
+// https://docs.gitlab.com/ee/api/protected_environments.html#get-a-single-protected-environment
 func (s *ProtectedEnvironmentsService) GetProtectedEnvironment(pid interface{}, environment string, options ...RequestOptionFunc) (*ProtectedEnvironment, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -115,7 +115,7 @@ func (s *ProtectedEnvironmentsService) GetProtectedEnvironment(pid interface{}, 
 // ProtectRepositoryEnvironments() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/protected_environments.html#protect-repository-environments
+// https://docs.gitlab.com/ee/api/protected_environments.html#protect-a-single-environment
 type ProtectRepositoryEnvironmentsOptions struct {
 	Name                  *string                      `url:"name,omitempty" json:"name,omitempty"`
 	DeployAccessLevels    *[]*EnvironmentAccessOptions `url:"deploy_access_levels,omitempty" json:"deploy_access_levels,omitempty"`
@@ -126,7 +126,7 @@ type ProtectRepositoryEnvironmentsOptions struct {
 // a protected environment.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/protected_environments.html#protect-repository-environments
+// https://docs.gitlab.com/ee/api/protected_environments.html#protect-a-single-environment
 type EnvironmentAccessOptions struct {
 	AccessLevel *AccessLevelValue `url:"access_level,omitempty" json:"access_level,omitempty"`
 	UserID      *int              `url:"user_id,omitempty" json:"user_id,omitempty"`
@@ -137,7 +137,7 @@ type EnvironmentAccessOptions struct {
 // several project repository environments using wildcard protected environment.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/protected_environments.html#protect-repository-environments
+// https://docs.gitlab.com/ee/api/protected_environments.html#protect-a-single-environment
 func (s *ProtectedEnvironmentsService) ProtectRepositoryEnvironments(pid interface{}, opt *ProtectRepositoryEnvironmentsOptions, options ...RequestOptionFunc) (*ProtectedEnvironment, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -163,7 +163,7 @@ func (s *ProtectedEnvironmentsService) ProtectRepositoryEnvironments(pid interfa
 // protected environment.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/protected_environments.html#unprotect-repository-environments
+// https://docs.gitlab.com/ee/api/protected_environments.html#unprotect-a-single-environment
 func (s *ProtectedEnvironmentsService) UnprotectEnvironment(pid interface{}, environment string, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/releaselinks.go
+++ b/releaselinks.go
@@ -43,12 +43,12 @@ type ReleaseLink struct {
 
 // ListReleaseLinksOptions represents ListReleaseLinks() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/releases/links.html#get-links
+// GitLab API docs: https://docs.gitlab.com/ee/api/releases/links.html#list-links-of-a-release
 type ListReleaseLinksOptions ListOptions
 
 // ListReleaseLinks gets assets as links from a Release.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/releases/links.html#get-links
+// GitLab API docs: https://docs.gitlab.com/ee/api/releases/links.html#list-links-of-a-release
 func (s *ReleaseLinksService) ListReleaseLinks(pid interface{}, tagName string, opt *ListReleaseLinksOptions, options ...RequestOptionFunc) ([]*ReleaseLink, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -72,7 +72,7 @@ func (s *ReleaseLinksService) ListReleaseLinks(pid interface{}, tagName string, 
 
 // GetReleaseLink returns a link from release assets.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/releases/links.html#get-a-link
+// GitLab API docs: https://docs.gitlab.com/ee/api/releases/links.html#get-a-release-link
 func (s *ReleaseLinksService) GetReleaseLink(pid interface{}, tagName string, link int, options ...RequestOptionFunc) (*ReleaseLink, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -99,7 +99,7 @@ func (s *ReleaseLinksService) GetReleaseLink(pid interface{}, tagName string, li
 
 // CreateReleaseLinkOptions represents CreateReleaseLink() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/releases/links.html#create-a-link
+// GitLab API docs: https://docs.gitlab.com/ee/api/releases/links.html#create-a-release-link
 type CreateReleaseLinkOptions struct {
 	Name     *string        `url:"name,omitempty" json:"name,omitempty"`
 	URL      *string        `url:"url,omitempty" json:"url,omitempty"`
@@ -109,7 +109,7 @@ type CreateReleaseLinkOptions struct {
 
 // CreateReleaseLink creates a link.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/releases/links.html#create-a-link
+// GitLab API docs: https://docs.gitlab.com/ee/api/releases/links.html#create-a-release-link
 func (s *ReleaseLinksService) CreateReleaseLink(pid interface{}, tagName string, opt *CreateReleaseLinkOptions, options ...RequestOptionFunc) (*ReleaseLink, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -135,7 +135,7 @@ func (s *ReleaseLinksService) CreateReleaseLink(pid interface{}, tagName string,
 //
 // You have to specify at least one of Name of URL.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/releases/links.html#update-a-link
+// GitLab API docs: https://docs.gitlab.com/ee/api/releases/links.html#update-a-release-link
 type UpdateReleaseLinkOptions struct {
 	Name     *string        `url:"name,omitempty" json:"name,omitempty"`
 	URL      *string        `url:"url,omitempty" json:"url,omitempty"`
@@ -145,7 +145,7 @@ type UpdateReleaseLinkOptions struct {
 
 // UpdateReleaseLink updates an asset link.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/releases/links.html#update-a-link
+// GitLab API docs: https://docs.gitlab.com/ee/api/releases/links.html#update-a-release-link
 func (s *ReleaseLinksService) UpdateReleaseLink(pid interface{}, tagName string, link int, opt *UpdateReleaseLinkOptions, options ...RequestOptionFunc) (*ReleaseLink, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -172,7 +172,7 @@ func (s *ReleaseLinksService) UpdateReleaseLink(pid interface{}, tagName string,
 
 // DeleteReleaseLink deletes a link from release.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/releases/links.html#delete-a-link
+// GitLab API docs: https://docs.gitlab.com/ee/api/releases/links.html#delete-a-release-link
 func (s *ReleaseLinksService) DeleteReleaseLink(pid interface{}, tagName string, link int, options ...RequestOptionFunc) (*ReleaseLink, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/releases.go
+++ b/releases.go
@@ -25,7 +25,7 @@ import (
 // ReleasesService handles communication with the releases methods
 // of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/releases/index.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/releases/index.html
 type ReleasesService struct {
 	client *Client
 }
@@ -33,7 +33,7 @@ type ReleasesService struct {
 // Release represents a project release.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/releases/index.html#list-releases
+// https://docs.gitlab.com/ee/api/releases/index.html#list-releases
 type Release struct {
 	TagName         string     `json:"tag_name"`
 	Name            string     `json:"name"`
@@ -66,18 +66,18 @@ type Release struct {
 // ListReleasesOptions represents ListReleases() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/releases/index.html#list-releases
+// https://docs.gitlab.com/ee/api/releases/index.html#list-releases
 type ListReleasesOptions struct {
 	ListOptions
 	OrderBy                *string `url:"order_by,omitempty" json:"order_by,omitempty"`
 	Sort                   *string `url:"sort,omitempty" json:"sort,omitempty"`
-	IncludeHTMLDescription *bool   `url:"include_html_description,omitempty" json:"include_html_description,omitempty"`	
+	IncludeHTMLDescription *bool   `url:"include_html_description,omitempty" json:"include_html_description,omitempty"`
 }
 
 // ListReleases gets a pagenated of releases accessible by the authenticated user.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/releases/index.html#list-releases
+// https://docs.gitlab.com/ee/api/releases/index.html#list-releases
 func (s *ReleasesService) ListReleases(pid interface{}, opt *ListReleasesOptions, options ...RequestOptionFunc) ([]*Release, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -102,7 +102,7 @@ func (s *ReleasesService) ListReleases(pid interface{}, opt *ListReleasesOptions
 // GetRelease returns a single release, identified by a tag name.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/releases/index.html#get-a-release-by-a-tag-name
+// https://docs.gitlab.com/ee/api/releases/index.html#get-a-release-by-a-tag-name
 func (s *ReleasesService) GetRelease(pid interface{}, tagName string, options ...RequestOptionFunc) (*Release, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -127,7 +127,7 @@ func (s *ReleasesService) GetRelease(pid interface{}, tagName string, options ..
 // CreateReleaseOptions represents CreateRelease() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/releases/index.html#create-a-release
+// https://docs.gitlab.com/ee/api/releases/index.html#create-a-release
 type CreateReleaseOptions struct {
 	Name        *string               `url:"name,omitempty" json:"name,omitempty"`
 	TagName     *string               `url:"tag_name,omitempty" json:"tag_name,omitempty"`
@@ -142,7 +142,7 @@ type CreateReleaseOptions struct {
 // ReleaseAssetsOptions represents release assets in CreateRelease() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/releases/index.html#create-a-release
+// https://docs.gitlab.com/ee/api/releases/index.html#create-a-release
 type ReleaseAssetsOptions struct {
 	Links []*ReleaseAssetLinkOptions `url:"links,omitempty" json:"links,omitempty"`
 }
@@ -151,7 +151,7 @@ type ReleaseAssetsOptions struct {
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/releases/index.html#create-a-release
+// https://docs.gitlab.com/ee/api/releases/index.html#create-a-release
 type ReleaseAssetLinkOptions struct {
 	Name     *string        `url:"name,omitempty" json:"name,omitempty"`
 	URL      *string        `url:"url,omitempty" json:"url,omitempty"`
@@ -162,7 +162,7 @@ type ReleaseAssetLinkOptions struct {
 // CreateRelease creates a release.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/releases/index.html#create-a-release
+// https://docs.gitlab.com/ee/api/releases/index.html#create-a-release
 func (s *ReleasesService) CreateRelease(pid interface{}, opts *CreateReleaseOptions, options ...RequestOptionFunc) (*Release, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -187,7 +187,7 @@ func (s *ReleasesService) CreateRelease(pid interface{}, opts *CreateReleaseOpti
 // UpdateReleaseOptions represents UpdateRelease() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/releases/index.html#update-a-release
+// https://docs.gitlab.com/ee/api/releases/index.html#update-a-release
 type UpdateReleaseOptions struct {
 	Name        *string    `url:"name" json:"name"`
 	Description *string    `url:"description" json:"description"`
@@ -198,7 +198,7 @@ type UpdateReleaseOptions struct {
 // UpdateRelease updates a release.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/releases/index.html#update-a-release
+// https://docs.gitlab.com/ee/api/releases/index.html#update-a-release
 func (s *ReleasesService) UpdateRelease(pid interface{}, tagName string, opts *UpdateReleaseOptions, options ...RequestOptionFunc) (*Release, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -223,7 +223,7 @@ func (s *ReleasesService) UpdateRelease(pid interface{}, tagName string, opts *U
 // DeleteRelease deletes a release.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/releases/index.html#delete-a-release
+// https://docs.gitlab.com/ee/api/releases/index.html#delete-a-release
 func (s *ReleasesService) DeleteRelease(pid interface{}, tagName string, options ...RequestOptionFunc) (*Release, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/repositories.go
+++ b/repositories.go
@@ -27,14 +27,14 @@ import (
 // RepositoriesService handles communication with the repositories related
 // methods of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/repositories.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/repositories.html
 type RepositoriesService struct {
 	client *Client
 }
 
 // TreeNode represents a GitLab repository file or directory.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/repositories.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/repositories.html
 type TreeNode struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
@@ -50,7 +50,7 @@ func (t TreeNode) String() string {
 // ListTreeOptions represents the available ListTree() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/repositories.html#list-repository-tree
+// https://docs.gitlab.com/ee/api/repositories.html#list-repository-tree
 type ListTreeOptions struct {
 	ListOptions
 	Path      *string `url:"path,omitempty" json:"path,omitempty"`
@@ -61,7 +61,7 @@ type ListTreeOptions struct {
 // ListTree gets a list of repository files and directories in a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/repositories.html#list-repository-tree
+// https://docs.gitlab.com/ee/api/repositories.html#list-repository-tree
 func (s *RepositoriesService) ListTree(pid interface{}, opt *ListTreeOptions, options ...RequestOptionFunc) ([]*TreeNode, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -87,7 +87,7 @@ func (s *RepositoriesService) ListTree(pid interface{}, opt *ListTreeOptions, op
 // that blob content is Base64 encoded.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/repositories.html#get-a-blob-from-repository
+// https://docs.gitlab.com/ee/api/repositories.html#get-a-blob-from-repository
 func (s *RepositoriesService) Blob(pid interface{}, sha string, options ...RequestOptionFunc) ([]byte, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -112,7 +112,7 @@ func (s *RepositoriesService) Blob(pid interface{}, sha string, options ...Reque
 // RawBlobContent gets the raw file contents for a blob by blob SHA.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/repositories.html#raw-blob-content
+// https://docs.gitlab.com/ee/api/repositories.html#raw-blob-content
 func (s *RepositoriesService) RawBlobContent(pid interface{}, sha string, options ...RequestOptionFunc) ([]byte, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -137,7 +137,7 @@ func (s *RepositoriesService) RawBlobContent(pid interface{}, sha string, option
 // ArchiveOptions represents the available Archive() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/repositories.html#get-file-archive
+// https://docs.gitlab.com/ee/api/repositories.html#get-file-archive
 type ArchiveOptions struct {
 	Format *string `url:"-" json:"-"`
 	SHA    *string `url:"sha,omitempty" json:"sha,omitempty"`
@@ -146,7 +146,7 @@ type ArchiveOptions struct {
 // Archive gets an archive of the repository.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/repositories.html#get-file-archive
+// https://docs.gitlab.com/ee/api/repositories.html#get-file-archive
 func (s *RepositoriesService) Archive(pid interface{}, opt *ArchiveOptions, options ...RequestOptionFunc) ([]byte, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -177,7 +177,7 @@ func (s *RepositoriesService) Archive(pid interface{}, opt *ArchiveOptions, opti
 // io.Writer.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/repositories.html#get-file-archive
+// https://docs.gitlab.com/ee/api/repositories.html#get-file-archive
 func (s *RepositoriesService) StreamArchive(pid interface{}, w io.Writer, opt *ArchiveOptions, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -201,7 +201,7 @@ func (s *RepositoriesService) StreamArchive(pid interface{}, w io.Writer, opt *A
 // Compare represents the result of a comparison of branches, tags or commits.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/repositories.html#compare-branches-tags-or-commits
+// https://docs.gitlab.com/ee/api/repositories.html#compare-branches-tags-or-commits
 type Compare struct {
 	Commit         *Commit   `json:"commit"`
 	Commits        []*Commit `json:"commits"`
@@ -217,7 +217,7 @@ func (c Compare) String() string {
 // CompareOptions represents the available Compare() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/repositories.html#compare-branches-tags-or-commits
+// https://docs.gitlab.com/ee/api/repositories.html#compare-branches-tags-or-commits
 type CompareOptions struct {
 	From     *string `url:"from,omitempty" json:"from,omitempty"`
 	To       *string `url:"to,omitempty" json:"to,omitempty"`
@@ -227,7 +227,7 @@ type CompareOptions struct {
 // Compare compares branches, tags or commits.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/repositories.html#compare-branches-tags-or-commits
+// https://docs.gitlab.com/ee/api/repositories.html#compare-branches-tags-or-commits
 func (s *RepositoriesService) Compare(pid interface{}, opt *CompareOptions, options ...RequestOptionFunc) (*Compare, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -251,7 +251,7 @@ func (s *RepositoriesService) Compare(pid interface{}, opt *CompareOptions, opti
 
 // Contributor represents a GitLap contributor.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/repositories.html#contributors
+// GitLab API docs: https://docs.gitlab.com/ee/api/repositories.html#contributors
 type Contributor struct {
 	Name      string `json:"name"`
 	Email     string `json:"email"`
@@ -266,7 +266,7 @@ func (c Contributor) String() string {
 
 // ListContributorsOptions represents the available ListContributors() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/repositories.html#contributors
+// GitLab API docs: https://docs.gitlab.com/ee/api/repositories.html#contributors
 type ListContributorsOptions struct {
 	ListOptions
 	OrderBy *string `url:"order_by,omitempty" json:"order_by,omitempty"`
@@ -275,7 +275,7 @@ type ListContributorsOptions struct {
 
 // Contributors gets the repository contributors list.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/repositories.html#contributors
+// GitLab API docs: https://docs.gitlab.com/ee/api/repositories.html#contributors
 func (s *RepositoriesService) Contributors(pid interface{}, opt *ListContributorsOptions, options ...RequestOptionFunc) ([]*Contributor, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -300,7 +300,7 @@ func (s *RepositoriesService) Contributors(pid interface{}, opt *ListContributor
 // MergeBaseOptions represents the available MergeBase() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/repositories.html#merge-base
+// https://docs.gitlab.com/ee/api/repositories.html#merge-base
 type MergeBaseOptions struct {
 	Ref *[]string `url:"refs[],omitempty" json:"refs,omitempty"`
 }
@@ -309,7 +309,7 @@ type MergeBaseOptions struct {
 // names or tags).
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/repositories.html#merge-base
+// https://docs.gitlab.com/ee/api/repositories.html#merge-base
 func (s *RepositoriesService) MergeBase(pid interface{}, opt *MergeBaseOptions, options ...RequestOptionFunc) (*Commit, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/repository_files.go
+++ b/repository_files.go
@@ -27,14 +27,14 @@ import (
 // RepositoryFilesService handles communication with the repository files
 // related methods of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/repository_files.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/repository_files.html
 type RepositoryFilesService struct {
 	client *Client
 }
 
 // File represents a GitLab repository file.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/repository_files.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/repository_files.html
 type File struct {
 	FileName        string `json:"file_name"`
 	FilePath        string `json:"file_path"`
@@ -56,7 +56,7 @@ func (r File) String() string {
 // GetFileOptions represents the available GetFile() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/repository_files.html#get-file-from-repository
+// https://docs.gitlab.com/ee/api/repository_files.html#get-file-from-repository
 type GetFileOptions struct {
 	Ref *string `url:"ref,omitempty" json:"ref,omitempty"`
 }
@@ -65,7 +65,7 @@ type GetFileOptions struct {
 // name, size, content. Note that file content is Base64 encoded.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/repository_files.html#get-file-from-repository
+// https://docs.gitlab.com/ee/api/repository_files.html#get-file-from-repository
 func (s *RepositoryFilesService) GetFile(pid interface{}, fileName string, opt *GetFileOptions, options ...RequestOptionFunc) (*File, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -94,7 +94,7 @@ func (s *RepositoryFilesService) GetFile(pid interface{}, fileName string, opt *
 // GetFileMetaDataOptions represents the available GetFileMetaData() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/repository_files.html#get-file-from-repository
+// https://docs.gitlab.com/ee/api/repository_files.html#get-file-from-repository
 type GetFileMetaDataOptions struct {
 	Ref *string `url:"ref,omitempty" json:"ref,omitempty"`
 }
@@ -103,7 +103,7 @@ type GetFileMetaDataOptions struct {
 // repository like name, size.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/repository_files.html#get-file-from-repository
+// https://docs.gitlab.com/ee/api/repository_files.html#get-file-from-repository
 func (s *RepositoryFilesService) GetFileMetaData(pid interface{}, fileName string, opt *GetFileMetaDataOptions, options ...RequestOptionFunc) (*File, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -149,7 +149,7 @@ func (s *RepositoryFilesService) GetFileMetaData(pid interface{}, fileName strin
 
 // FileBlameRange represents one item of blame information.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/repository_files.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/repository_files.html
 type FileBlameRange struct {
 	Commit struct {
 		ID             string     `json:"id"`
@@ -172,7 +172,7 @@ func (b FileBlameRange) String() string {
 // GetFileBlameOptions represents the available GetFileBlame() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/repository_files.html#get-file-blame-from-repository
+// https://docs.gitlab.com/ee/api/repository_files.html#get-file-blame-from-repository
 type GetFileBlameOptions struct {
 	Ref *string `url:"ref,omitempty" json:"ref,omitempty"`
 }
@@ -181,7 +181,7 @@ type GetFileBlameOptions struct {
 // contains lines and corresponding commit info.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/repository_files.html#get-file-blame-from-repository
+// https://docs.gitlab.com/ee/api/repository_files.html#get-file-blame-from-repository
 func (s *RepositoryFilesService) GetFileBlame(pid interface{}, file string, opt *GetFileBlameOptions, options ...RequestOptionFunc) ([]*FileBlameRange, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -210,7 +210,7 @@ func (s *RepositoryFilesService) GetFileBlame(pid interface{}, file string, opt 
 // GetRawFileOptions represents the available GetRawFile() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/repository_files.html#get-raw-file-from-repository
+// https://docs.gitlab.com/ee/api/repository_files.html#get-raw-file-from-repository
 type GetRawFileOptions struct {
 	Ref *string `url:"ref,omitempty" json:"ref,omitempty"`
 }
@@ -218,7 +218,7 @@ type GetRawFileOptions struct {
 // GetRawFile allows you to receive the raw file in repository.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/repository_files.html#get-raw-file-from-repository
+// https://docs.gitlab.com/ee/api/repository_files.html#get-raw-file-from-repository
 func (s *RepositoryFilesService) GetRawFile(pid interface{}, fileName string, opt *GetRawFileOptions, options ...RequestOptionFunc) ([]byte, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -246,7 +246,7 @@ func (s *RepositoryFilesService) GetRawFile(pid interface{}, fileName string, op
 
 // FileInfo represents file details of a GitLab repository file.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/repository_files.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/repository_files.html
 type FileInfo struct {
 	FilePath string `json:"file_path"`
 	Branch   string `json:"branch"`
@@ -259,7 +259,7 @@ func (r FileInfo) String() string {
 // CreateFileOptions represents the available CreateFile() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/repository_files.html#create-new-file-in-repository
+// https://docs.gitlab.com/ee/api/repository_files.html#create-new-file-in-repository
 type CreateFileOptions struct {
 	Branch          *string `url:"branch,omitempty" json:"branch,omitempty"`
 	StartBranch     *string `url:"start_branch,omitempty" json:"start_branch,omitempty"`
@@ -274,7 +274,7 @@ type CreateFileOptions struct {
 // CreateFile creates a new file in a repository.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/repository_files.html#create-new-file-in-repository
+// https://docs.gitlab.com/ee/api/repository_files.html#create-new-file-in-repository
 func (s *RepositoryFilesService) CreateFile(pid interface{}, fileName string, opt *CreateFileOptions, options ...RequestOptionFunc) (*FileInfo, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -303,7 +303,7 @@ func (s *RepositoryFilesService) CreateFile(pid interface{}, fileName string, op
 // UpdateFileOptions represents the available UpdateFile() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/repository_files.html#update-existing-file-in-repository
+// https://docs.gitlab.com/ee/api/repository_files.html#update-existing-file-in-repository
 type UpdateFileOptions struct {
 	Branch          *string `url:"branch,omitempty" json:"branch,omitempty"`
 	StartBranch     *string `url:"start_branch,omitempty" json:"start_branch,omitempty"`
@@ -319,7 +319,7 @@ type UpdateFileOptions struct {
 // UpdateFile updates an existing file in a repository
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/repository_files.html#update-existing-file-in-repository
+// https://docs.gitlab.com/ee/api/repository_files.html#update-existing-file-in-repository
 func (s *RepositoryFilesService) UpdateFile(pid interface{}, fileName string, opt *UpdateFileOptions, options ...RequestOptionFunc) (*FileInfo, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -348,7 +348,7 @@ func (s *RepositoryFilesService) UpdateFile(pid interface{}, fileName string, op
 // DeleteFileOptions represents the available DeleteFile() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/repository_files.html#delete-existing-file-in-repository
+// https://docs.gitlab.com/ee/api/repository_files.html#delete-existing-file-in-repository
 type DeleteFileOptions struct {
 	Branch        *string `url:"branch,omitempty" json:"branch,omitempty"`
 	StartBranch   *string `url:"start_branch,omitempty" json:"start_branch,omitempty"`
@@ -361,7 +361,7 @@ type DeleteFileOptions struct {
 // DeleteFile deletes an existing file in a repository
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/repository_files.html#delete-existing-file-in-repository
+// https://docs.gitlab.com/ee/api/repository_files.html#delete-existing-file-in-repository
 func (s *RepositoryFilesService) DeleteFile(pid interface{}, fileName string, opt *DeleteFileOptions, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/runners.go
+++ b/runners.go
@@ -25,14 +25,14 @@ import (
 // RunnersService handles communication with the runner related methods of the
 // GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/runners.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/runners.html
 type RunnersService struct {
 	client *Client
 }
 
 // Runner represents a GitLab CI Runner.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/runners.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/runners.html
 type Runner struct {
 	ID             int        `json:"id"`
 	Description    string     `json:"description"`
@@ -50,7 +50,7 @@ type Runner struct {
 
 // RunnerDetails represents the GitLab CI runner details.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/runners.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/runners.html
 type RunnerDetails struct {
 	Paused       bool       `json:"paused"`
 	Architecture string     `json:"architecture"`
@@ -92,7 +92,7 @@ type RunnerDetails struct {
 // ListRunnersOptions represents the available ListRunners() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/runners.html#list-owned-runners
+// https://docs.gitlab.com/ee/api/runners.html#list-owned-runners
 type ListRunnersOptions struct {
 	ListOptions
 	Type    *string   `url:"type,omitempty" json:"type,omitempty"`
@@ -107,7 +107,7 @@ type ListRunnersOptions struct {
 // ListRunners gets a list of runners accessible by the authenticated user.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/runners.html#list-owned-runners
+// https://docs.gitlab.com/ee/api/runners.html#list-owned-runners
 func (s *RunnersService) ListRunners(opt *ListRunnersOptions, options ...RequestOptionFunc) ([]*Runner, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "runners", opt, options)
 	if err != nil {
@@ -127,7 +127,7 @@ func (s *RunnersService) ListRunners(opt *ListRunnersOptions, options ...Request
 // restricted to users with admin privileges.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/runners.html#list-all-runners
+// https://docs.gitlab.com/ee/api/runners.html#list-all-runners
 func (s *RunnersService) ListAllRunners(opt *ListRunnersOptions, options ...RequestOptionFunc) ([]*Runner, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "runners/all", opt, options)
 	if err != nil {
@@ -146,7 +146,7 @@ func (s *RunnersService) ListAllRunners(opt *ListRunnersOptions, options ...Requ
 // GetRunnerDetails returns details for given runner.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/runners.html#get-runner-39-s-details
+// https://docs.gitlab.com/ee/api/runners.html#get-runner-39-s-details
 func (s *RunnersService) GetRunnerDetails(rid interface{}, options ...RequestOptionFunc) (*RunnerDetails, *Response, error) {
 	runner, err := parseID(rid)
 	if err != nil {
@@ -171,7 +171,7 @@ func (s *RunnersService) GetRunnerDetails(rid interface{}, options ...RequestOpt
 // UpdateRunnerDetailsOptions represents the available UpdateRunnerDetails() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/runners.html#update-runner-39-s-details
+// https://docs.gitlab.com/ee/api/runners.html#update-runner-39-s-details
 type UpdateRunnerDetailsOptions struct {
 	Description    *string   `url:"description,omitempty" json:"description,omitempty"`
 	Paused         *bool     `url:"paused,omitempty" json:"paused,omitempty"`
@@ -188,7 +188,7 @@ type UpdateRunnerDetailsOptions struct {
 // UpdateRunnerDetails updates details for a given runner.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/runners.html#update-runner-39-s-details
+// https://docs.gitlab.com/ee/api/runners.html#update-runner-39-s-details
 func (s *RunnersService) UpdateRunnerDetails(rid interface{}, opt *UpdateRunnerDetailsOptions, options ...RequestOptionFunc) (*RunnerDetails, *Response, error) {
 	runner, err := parseID(rid)
 	if err != nil {
@@ -213,7 +213,7 @@ func (s *RunnersService) UpdateRunnerDetails(rid interface{}, opt *UpdateRunnerD
 // RemoveRunner removes a runner.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/runners.html#remove-a-runner
+// https://docs.gitlab.com/ee/api/runners.html#remove-a-runner
 func (s *RunnersService) RemoveRunner(rid interface{}, options ...RequestOptionFunc) (*Response, error) {
 	runner, err := parseID(rid)
 	if err != nil {
@@ -233,7 +233,7 @@ func (s *RunnersService) RemoveRunner(rid interface{}, options ...RequestOptionF
 // options. Status can be one of: running, success, failed, canceled.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/runners.html#list-runners-jobs
+// https://docs.gitlab.com/ee/api/runners.html#list-runners-jobs
 type ListRunnerJobsOptions struct {
 	ListOptions
 	Status  *string `url:"status,omitempty" json:"status,omitempty"`
@@ -244,7 +244,7 @@ type ListRunnerJobsOptions struct {
 // ListRunnerJobs gets a list of jobs that are being processed or were processed by specified Runner.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/runners.html#list-runner-39-s-jobs
+// https://docs.gitlab.com/ee/api/runners.html#list-runner-39-s-jobs
 func (s *RunnersService) ListRunnerJobs(rid interface{}, opt *ListRunnerJobsOptions, options ...RequestOptionFunc) ([]*Job, *Response, error) {
 	runner, err := parseID(rid)
 	if err != nil {
@@ -270,13 +270,13 @@ func (s *RunnersService) ListRunnerJobs(rid interface{}, opt *ListRunnerJobsOpti
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/runners.html#list-project-s-runners
+// https://docs.gitlab.com/ee/api/runners.html#list-project-s-runners
 type ListProjectRunnersOptions ListRunnersOptions
 
 // ListProjectRunners gets a list of runners accessible by the authenticated user.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/runners.html#list-project-s-runners
+// https://docs.gitlab.com/ee/api/runners.html#list-project-s-runners
 func (s *RunnersService) ListProjectRunners(pid interface{}, opt *ListProjectRunnersOptions, options ...RequestOptionFunc) ([]*Runner, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -302,7 +302,7 @@ func (s *RunnersService) ListProjectRunners(pid interface{}, opt *ListProjectRun
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/runners.html#enable-a-runner-in-project
+// https://docs.gitlab.com/ee/api/runners.html#enable-a-runner-in-project
 type EnableProjectRunnerOptions struct {
 	RunnerID int `json:"runner_id"`
 }
@@ -310,7 +310,7 @@ type EnableProjectRunnerOptions struct {
 // EnableProjectRunner enables an available specific runner in the project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/runners.html#enable-a-runner-in-project
+// https://docs.gitlab.com/ee/api/runners.html#enable-a-runner-in-project
 func (s *RunnersService) EnableProjectRunner(pid interface{}, opt *EnableProjectRunnerOptions, options ...RequestOptionFunc) (*Runner, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -335,7 +335,7 @@ func (s *RunnersService) EnableProjectRunner(pid interface{}, opt *EnableProject
 // DisableProjectRunner disables a specific runner from project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/runners.html#disable-a-runner-from-project
+// https://docs.gitlab.com/ee/api/runners.html#disable-a-runner-from-project
 func (s *RunnersService) DisableProjectRunner(pid interface{}, runner int, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -393,7 +393,7 @@ func (s *RunnersService) ListGroupsRunners(gid interface{}, opt *ListGroupsRunne
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/runners.html#register-a-new-runner
+// https://docs.gitlab.com/ee/api/runners.html#register-a-new-runner
 type RegisterNewRunnerOptions struct {
 	Token           *string                       `url:"token" json:"token"`
 	Description     *string                       `url:"description,omitempty" json:"description,omitempty"`
@@ -412,7 +412,7 @@ type RegisterNewRunnerOptions struct {
 // RegisterNewRunnerOptions.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/runners.html#register-a-new-runner
+// https://docs.gitlab.com/ee/api/runners.html#register-a-new-runner
 type RegisterNewRunnerInfoOptions struct {
 	Name         *string `url:"name,omitempty" json:"name,omitempty"`
 	Version      *string `url:"version,omitempty" json:"version,omitempty"`
@@ -424,7 +424,7 @@ type RegisterNewRunnerInfoOptions struct {
 // RegisterNewRunner registers a new Runner for the instance.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/runners.html#register-a-new-runner
+// https://docs.gitlab.com/ee/api/runners.html#register-a-new-runner
 func (s *RunnersService) RegisterNewRunner(opt *RegisterNewRunnerOptions, options ...RequestOptionFunc) (*Runner, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodPost, "runners", opt, options)
 	if err != nil {
@@ -444,7 +444,7 @@ func (s *RunnersService) RegisterNewRunner(opt *RegisterNewRunnerOptions, option
 // DeleteRegisteredRunner() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/runners.html#delete-a-registered-runner
+// https://docs.gitlab.com/ee/api/runners.html#delete-a-registered-runner
 type DeleteRegisteredRunnerOptions struct {
 	Token *string `url:"token" json:"token"`
 }
@@ -452,7 +452,7 @@ type DeleteRegisteredRunnerOptions struct {
 // DeleteRegisteredRunner deletes a Runner by Token.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/runners.html#delete-a-runner-by-authentication-token
+// https://docs.gitlab.com/ee/api/runners.html#delete-a-runner-by-authentication-token
 func (s *RunnersService) DeleteRegisteredRunner(opt *DeleteRegisteredRunnerOptions, options ...RequestOptionFunc) (*Response, error) {
 	req, err := s.client.NewRequest(http.MethodDelete, "runners", opt, options)
 	if err != nil {
@@ -465,7 +465,7 @@ func (s *RunnersService) DeleteRegisteredRunner(opt *DeleteRegisteredRunnerOptio
 // DeleteRegisteredRunnerByID deletes a runner by ID.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/runners.html#delete-a-runner-by-id
+// https://docs.gitlab.com/ee/api/runners.html#delete-a-runner-by-id
 func (s *RunnersService) DeleteRegisteredRunnerByID(rid int, options ...RequestOptionFunc) (*Response, error) {
 	req, err := s.client.NewRequest(http.MethodDelete, fmt.Sprintf("runners/%d", rid), nil, options)
 	if err != nil {
@@ -479,7 +479,7 @@ func (s *RunnersService) DeleteRegisteredRunnerByID(rid int, options ...RequestO
 // VerifyRegisteredRunner() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/runners.html#verify-authentication-for-a-registered-runner
+// https://docs.gitlab.com/ee/api/runners.html#verify-authentication-for-a-registered-runner
 type VerifyRegisteredRunnerOptions struct {
 	Token *string `url:"token" json:"token"`
 }
@@ -487,7 +487,7 @@ type VerifyRegisteredRunnerOptions struct {
 // VerifyRegisteredRunner registers a new runner for the instance.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/runners.html#verify-authentication-for-a-registered-runner
+// https://docs.gitlab.com/ee/api/runners.html#verify-authentication-for-a-registered-runner
 func (s *RunnersService) VerifyRegisteredRunner(opt *VerifyRegisteredRunnerOptions, options ...RequestOptionFunc) (*Response, error) {
 	req, err := s.client.NewRequest(http.MethodPost, "runners/verify", opt, options)
 	if err != nil {

--- a/runners.go
+++ b/runners.go
@@ -146,7 +146,7 @@ func (s *RunnersService) ListAllRunners(opt *ListRunnersOptions, options ...Requ
 // GetRunnerDetails returns details for given runner.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/runners.html#get-runner-39-s-details
+// https://docs.gitlab.com/ee/api/runners.html#get-runners-details
 func (s *RunnersService) GetRunnerDetails(rid interface{}, options ...RequestOptionFunc) (*RunnerDetails, *Response, error) {
 	runner, err := parseID(rid)
 	if err != nil {
@@ -171,7 +171,7 @@ func (s *RunnersService) GetRunnerDetails(rid interface{}, options ...RequestOpt
 // UpdateRunnerDetailsOptions represents the available UpdateRunnerDetails() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/runners.html#update-runner-39-s-details
+// https://docs.gitlab.com/ee/api/runners.html#update-runners-details
 type UpdateRunnerDetailsOptions struct {
 	Description    *string   `url:"description,omitempty" json:"description,omitempty"`
 	Paused         *bool     `url:"paused,omitempty" json:"paused,omitempty"`
@@ -188,7 +188,7 @@ type UpdateRunnerDetailsOptions struct {
 // UpdateRunnerDetails updates details for a given runner.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/runners.html#update-runner-39-s-details
+// https://docs.gitlab.com/ee/api/runners.html#update-runners-details
 func (s *RunnersService) UpdateRunnerDetails(rid interface{}, opt *UpdateRunnerDetailsOptions, options ...RequestOptionFunc) (*RunnerDetails, *Response, error) {
 	runner, err := parseID(rid)
 	if err != nil {
@@ -213,7 +213,7 @@ func (s *RunnersService) UpdateRunnerDetails(rid interface{}, opt *UpdateRunnerD
 // RemoveRunner removes a runner.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/runners.html#remove-a-runner
+// https://docs.gitlab.com/ee/api/runners.html#delete-a-runner
 func (s *RunnersService) RemoveRunner(rid interface{}, options ...RequestOptionFunc) (*Response, error) {
 	runner, err := parseID(rid)
 	if err != nil {
@@ -244,7 +244,7 @@ type ListRunnerJobsOptions struct {
 // ListRunnerJobs gets a list of jobs that are being processed or were processed by specified Runner.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/runners.html#list-runner-39-s-jobs
+// https://docs.gitlab.com/ee/api/runners.html#list-runners-jobs
 func (s *RunnersService) ListRunnerJobs(rid interface{}, opt *ListRunnerJobsOptions, options ...RequestOptionFunc) ([]*Job, *Response, error) {
 	runner, err := parseID(rid)
 	if err != nil {
@@ -270,13 +270,13 @@ func (s *RunnersService) ListRunnerJobs(rid interface{}, opt *ListRunnerJobsOpti
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/runners.html#list-project-s-runners
+// https://docs.gitlab.com/ee/api/runners.html#list-projects-runners
 type ListProjectRunnersOptions ListRunnersOptions
 
 // ListProjectRunners gets a list of runners accessible by the authenticated user.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/runners.html#list-project-s-runners
+// https://docs.gitlab.com/ee/api/runners.html#list-projects-runners
 func (s *RunnersService) ListProjectRunners(pid interface{}, opt *ListProjectRunnersOptions, options ...RequestOptionFunc) ([]*Runner, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -444,7 +444,7 @@ func (s *RunnersService) RegisterNewRunner(opt *RegisterNewRunnerOptions, option
 // DeleteRegisteredRunner() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/runners.html#delete-a-registered-runner
+// https://docs.gitlab.com/ee/api/runners.html#delete-a-runner-by-authentication-token
 type DeleteRegisteredRunnerOptions struct {
 	Token *string `url:"token" json:"token"`
 }
@@ -579,7 +579,7 @@ type RunnerAuthenticationToken struct {
 // ResetRunnerAuthenticationToken resets a runner's authentication token.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/runners.html#reset-runners-authentication-token
+// https://docs.gitlab.com/ee/api/runners.html#reset-runners-authentication-token-by-using-the-runner-id
 func (s *RunnersService) ResetRunnerAuthenticationToken(rid int, options ...RequestOptionFunc) (*RunnerAuthenticationToken, *Response, error) {
 	u := fmt.Sprintf("runners/%d/reset_authentication_token", rid)
 	req, err := s.client.NewRequest(http.MethodPost, u, nil, options)

--- a/search.go
+++ b/search.go
@@ -24,14 +24,14 @@ import (
 // SearchService handles communication with the search related methods of the
 // GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/search.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/search.html
 type SearchService struct {
 	client *Client
 }
 
 // SearchOptions represents the available options for all search methods.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/search.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/search.html
 type SearchOptions struct {
 	ListOptions
 	Ref *string `url:"ref,omitempty" json:"ref,omitempty"`
@@ -45,7 +45,7 @@ type searchOptions struct {
 
 // Projects searches the expression within projects
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/search.html#scope-projects
+// GitLab API docs: https://docs.gitlab.com/ee/api/search.html#scope-projects
 func (s *SearchService) Projects(query string, opt *SearchOptions, options ...RequestOptionFunc) ([]*Project, *Response, error) {
 	var ps []*Project
 	resp, err := s.search("projects", query, &ps, opt, options...)
@@ -55,7 +55,7 @@ func (s *SearchService) Projects(query string, opt *SearchOptions, options ...Re
 // ProjectsByGroup searches the expression within projects for
 // the specified group
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/search.html#group-search-api
+// GitLab API docs: https://docs.gitlab.com/ee/api/search.html#group-search-api
 func (s *SearchService) ProjectsByGroup(gid interface{}, query string, opt *SearchOptions, options ...RequestOptionFunc) ([]*Project, *Response, error) {
 	var ps []*Project
 	resp, err := s.searchByGroup(gid, "projects", query, &ps, opt, options...)
@@ -64,7 +64,7 @@ func (s *SearchService) ProjectsByGroup(gid interface{}, query string, opt *Sear
 
 // Issues searches the expression within issues
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/search.html#scope-issues
+// GitLab API docs: https://docs.gitlab.com/ee/api/search.html#scope-issues
 func (s *SearchService) Issues(query string, opt *SearchOptions, options ...RequestOptionFunc) ([]*Issue, *Response, error) {
 	var is []*Issue
 	resp, err := s.search("issues", query, &is, opt, options...)
@@ -74,7 +74,7 @@ func (s *SearchService) Issues(query string, opt *SearchOptions, options ...Requ
 // IssuesByGroup searches the expression within issues for
 // the specified group
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/search.html#scope-issues
+// GitLab API docs: https://docs.gitlab.com/ee/api/search.html#scope-issues
 func (s *SearchService) IssuesByGroup(gid interface{}, query string, opt *SearchOptions, options ...RequestOptionFunc) ([]*Issue, *Response, error) {
 	var is []*Issue
 	resp, err := s.searchByGroup(gid, "issues", query, &is, opt, options...)
@@ -84,7 +84,7 @@ func (s *SearchService) IssuesByGroup(gid interface{}, query string, opt *Search
 // IssuesByProject searches the expression within issues for
 // the specified project
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/search.html#scope-issues
+// GitLab API docs: https://docs.gitlab.com/ee/api/search.html#scope-issues
 func (s *SearchService) IssuesByProject(pid interface{}, query string, opt *SearchOptions, options ...RequestOptionFunc) ([]*Issue, *Response, error) {
 	var is []*Issue
 	resp, err := s.searchByProject(pid, "issues", query, &is, opt, options...)
@@ -94,7 +94,7 @@ func (s *SearchService) IssuesByProject(pid interface{}, query string, opt *Sear
 // MergeRequests searches the expression within merge requests
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/search.html#scope-merge_requests
+// https://docs.gitlab.com/ee/api/search.html#scope-merge_requests
 func (s *SearchService) MergeRequests(query string, opt *SearchOptions, options ...RequestOptionFunc) ([]*MergeRequest, *Response, error) {
 	var ms []*MergeRequest
 	resp, err := s.search("merge_requests", query, &ms, opt, options...)
@@ -105,7 +105,7 @@ func (s *SearchService) MergeRequests(query string, opt *SearchOptions, options 
 // the specified group
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/search.html#scope-merge_requests
+// https://docs.gitlab.com/ee/api/search.html#scope-merge_requests
 func (s *SearchService) MergeRequestsByGroup(gid interface{}, query string, opt *SearchOptions, options ...RequestOptionFunc) ([]*MergeRequest, *Response, error) {
 	var ms []*MergeRequest
 	resp, err := s.searchByGroup(gid, "merge_requests", query, &ms, opt, options...)
@@ -116,7 +116,7 @@ func (s *SearchService) MergeRequestsByGroup(gid interface{}, query string, opt 
 // the specified project
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/search.html#scope-merge_requests
+// https://docs.gitlab.com/ee/api/search.html#scope-merge_requests
 func (s *SearchService) MergeRequestsByProject(pid interface{}, query string, opt *SearchOptions, options ...RequestOptionFunc) ([]*MergeRequest, *Response, error) {
 	var ms []*MergeRequest
 	resp, err := s.searchByProject(pid, "merge_requests", query, &ms, opt, options...)
@@ -125,7 +125,7 @@ func (s *SearchService) MergeRequestsByProject(pid interface{}, query string, op
 
 // Milestones searches the expression within milestones
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/search.html#scope-milestones
+// GitLab API docs: https://docs.gitlab.com/ee/api/search.html#scope-milestones
 func (s *SearchService) Milestones(query string, opt *SearchOptions, options ...RequestOptionFunc) ([]*Milestone, *Response, error) {
 	var ms []*Milestone
 	resp, err := s.search("milestones", query, &ms, opt, options...)
@@ -135,7 +135,7 @@ func (s *SearchService) Milestones(query string, opt *SearchOptions, options ...
 // MilestonesByGroup searches the expression within milestones for
 // the specified group
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/search.html#scope-milestones
+// GitLab API docs: https://docs.gitlab.com/ee/api/search.html#scope-milestones
 func (s *SearchService) MilestonesByGroup(gid interface{}, query string, opt *SearchOptions, options ...RequestOptionFunc) ([]*Milestone, *Response, error) {
 	var ms []*Milestone
 	resp, err := s.searchByGroup(gid, "milestones", query, &ms, opt, options...)
@@ -145,7 +145,7 @@ func (s *SearchService) MilestonesByGroup(gid interface{}, query string, opt *Se
 // MilestonesByProject searches the expression within milestones for
 // the specified project
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/search.html#scope-milestones
+// GitLab API docs: https://docs.gitlab.com/ee/api/search.html#scope-milestones
 func (s *SearchService) MilestonesByProject(pid interface{}, query string, opt *SearchOptions, options ...RequestOptionFunc) ([]*Milestone, *Response, error) {
 	var ms []*Milestone
 	resp, err := s.searchByProject(pid, "milestones", query, &ms, opt, options...)
@@ -155,7 +155,7 @@ func (s *SearchService) MilestonesByProject(pid interface{}, query string, opt *
 // SnippetTitles searches the expression within snippet titles
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/search.html#scope-snippet_titles
+// https://docs.gitlab.com/ee/api/search.html#scope-snippet_titles
 func (s *SearchService) SnippetTitles(query string, opt *SearchOptions, options ...RequestOptionFunc) ([]*Snippet, *Response, error) {
 	var ss []*Snippet
 	resp, err := s.search("snippet_titles", query, &ss, opt, options...)
@@ -165,7 +165,7 @@ func (s *SearchService) SnippetTitles(query string, opt *SearchOptions, options 
 // SnippetBlobs searches the expression within snippet blobs
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/search.html#scope-snippet_blobs
+// https://docs.gitlab.com/ee/api/search.html#scope-snippet_blobs
 func (s *SearchService) SnippetBlobs(query string, opt *SearchOptions, options ...RequestOptionFunc) ([]*Snippet, *Response, error) {
 	var ss []*Snippet
 	resp, err := s.search("snippet_blobs", query, &ss, opt, options...)
@@ -175,7 +175,7 @@ func (s *SearchService) SnippetBlobs(query string, opt *SearchOptions, options .
 // NotesByProject searches the expression within notes for the specified
 // project
 //
-// GitLab API docs: // https://docs.gitlab.com/ce/api/search.html#scope-notes
+// GitLab API docs: // https://docs.gitlab.com/ee/api/search.html#scope-notes
 func (s *SearchService) NotesByProject(pid interface{}, query string, opt *SearchOptions, options ...RequestOptionFunc) ([]*Note, *Response, error) {
 	var ns []*Note
 	resp, err := s.searchByProject(pid, "notes", query, &ns, opt, options...)
@@ -185,7 +185,7 @@ func (s *SearchService) NotesByProject(pid interface{}, query string, opt *Searc
 // WikiBlobs searches the expression within all wiki blobs
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/search.html#scope-wiki_blobs
+// https://docs.gitlab.com/ee/api/search.html#scope-wiki_blobs
 func (s *SearchService) WikiBlobs(query string, opt *SearchOptions, options ...RequestOptionFunc) ([]*Wiki, *Response, error) {
 	var ws []*Wiki
 	resp, err := s.search("wiki_blobs", query, &ws, opt, options...)
@@ -196,7 +196,7 @@ func (s *SearchService) WikiBlobs(query string, opt *SearchOptions, options ...R
 // specified group
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/search.html#scope-wiki_blobs
+// https://docs.gitlab.com/ee/api/search.html#scope-wiki_blobs
 func (s *SearchService) WikiBlobsByGroup(gid interface{}, query string, opt *SearchOptions, options ...RequestOptionFunc) ([]*Wiki, *Response, error) {
 	var ws []*Wiki
 	resp, err := s.searchByGroup(gid, "wiki_blobs", query, &ws, opt, options...)
@@ -207,7 +207,7 @@ func (s *SearchService) WikiBlobsByGroup(gid interface{}, query string, opt *Sea
 // the specified project
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/search.html#scope-wiki_blobs
+// https://docs.gitlab.com/ee/api/search.html#scope-wiki_blobs
 func (s *SearchService) WikiBlobsByProject(pid interface{}, query string, opt *SearchOptions, options ...RequestOptionFunc) ([]*Wiki, *Response, error) {
 	var ws []*Wiki
 	resp, err := s.searchByProject(pid, "wiki_blobs", query, &ws, opt, options...)
@@ -216,7 +216,7 @@ func (s *SearchService) WikiBlobsByProject(pid interface{}, query string, opt *S
 
 // Commits searches the expression within all commits
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/search.html#scope-commits
+// GitLab API docs: https://docs.gitlab.com/ee/api/search.html#scope-commits
 func (s *SearchService) Commits(query string, opt *SearchOptions, options ...RequestOptionFunc) ([]*Commit, *Response, error) {
 	var cs []*Commit
 	resp, err := s.search("commits", query, &cs, opt, options...)
@@ -226,7 +226,7 @@ func (s *SearchService) Commits(query string, opt *SearchOptions, options ...Req
 // CommitsByGroup searches the expression within commits for the specified
 // group
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/search.html#scope-commits
+// GitLab API docs: https://docs.gitlab.com/ee/api/search.html#scope-commits
 func (s *SearchService) CommitsByGroup(gid interface{}, query string, opt *SearchOptions, options ...RequestOptionFunc) ([]*Commit, *Response, error) {
 	var cs []*Commit
 	resp, err := s.searchByGroup(gid, "commits", query, &cs, opt, options...)
@@ -236,7 +236,7 @@ func (s *SearchService) CommitsByGroup(gid interface{}, query string, opt *Searc
 // CommitsByProject searches the expression within commits for the
 // specified project
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/search.html#scope-commits
+// GitLab API docs: https://docs.gitlab.com/ee/api/search.html#scope-commits
 func (s *SearchService) CommitsByProject(pid interface{}, query string, opt *SearchOptions, options ...RequestOptionFunc) ([]*Commit, *Response, error) {
 	var cs []*Commit
 	resp, err := s.searchByProject(pid, "commits", query, &cs, opt, options...)
@@ -256,7 +256,7 @@ type Blob struct {
 
 // Blobs searches the expression within all blobs
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/search.html#scope-blobs
+// GitLab API docs: https://docs.gitlab.com/ee/api/search.html#scope-blobs
 func (s *SearchService) Blobs(query string, opt *SearchOptions, options ...RequestOptionFunc) ([]*Blob, *Response, error) {
 	var bs []*Blob
 	resp, err := s.search("blobs", query, &bs, opt, options...)
@@ -266,7 +266,7 @@ func (s *SearchService) Blobs(query string, opt *SearchOptions, options ...Reque
 // BlobsByGroup searches the expression within blobs for the specified
 // group
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/search.html#scope-blobs
+// GitLab API docs: https://docs.gitlab.com/ee/api/search.html#scope-blobs
 func (s *SearchService) BlobsByGroup(gid interface{}, query string, opt *SearchOptions, options ...RequestOptionFunc) ([]*Blob, *Response, error) {
 	var bs []*Blob
 	resp, err := s.searchByGroup(gid, "blobs", query, &bs, opt, options...)
@@ -276,7 +276,7 @@ func (s *SearchService) BlobsByGroup(gid interface{}, query string, opt *SearchO
 // BlobsByProject searches the expression within blobs for the specified
 // project
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/search.html#scope-blobs
+// GitLab API docs: https://docs.gitlab.com/ee/api/search.html#scope-blobs
 func (s *SearchService) BlobsByProject(pid interface{}, query string, opt *SearchOptions, options ...RequestOptionFunc) ([]*Blob, *Response, error) {
 	var bs []*Blob
 	resp, err := s.searchByProject(pid, "blobs", query, &bs, opt, options...)

--- a/search.go
+++ b/search.go
@@ -74,7 +74,7 @@ func (s *SearchService) Issues(query string, opt *SearchOptions, options ...Requ
 // IssuesByGroup searches the expression within issues for
 // the specified group
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/search.html#scope-issues
+// GitLab API docs: https://docs.gitlab.com/ee/api/search.html#scope-issues-1
 func (s *SearchService) IssuesByGroup(gid interface{}, query string, opt *SearchOptions, options ...RequestOptionFunc) ([]*Issue, *Response, error) {
 	var is []*Issue
 	resp, err := s.searchByGroup(gid, "issues", query, &is, opt, options...)
@@ -84,7 +84,7 @@ func (s *SearchService) IssuesByGroup(gid interface{}, query string, opt *Search
 // IssuesByProject searches the expression within issues for
 // the specified project
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/search.html#scope-issues
+// GitLab API docs: https://docs.gitlab.com/ee/api/search.html#scope-issues-2
 func (s *SearchService) IssuesByProject(pid interface{}, query string, opt *SearchOptions, options ...RequestOptionFunc) ([]*Issue, *Response, error) {
 	var is []*Issue
 	resp, err := s.searchByProject(pid, "issues", query, &is, opt, options...)
@@ -105,7 +105,7 @@ func (s *SearchService) MergeRequests(query string, opt *SearchOptions, options 
 // the specified group
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/search.html#scope-merge_requests
+// https://docs.gitlab.com/ee/api/search.html#scope-merge_requests-1
 func (s *SearchService) MergeRequestsByGroup(gid interface{}, query string, opt *SearchOptions, options ...RequestOptionFunc) ([]*MergeRequest, *Response, error) {
 	var ms []*MergeRequest
 	resp, err := s.searchByGroup(gid, "merge_requests", query, &ms, opt, options...)
@@ -116,7 +116,7 @@ func (s *SearchService) MergeRequestsByGroup(gid interface{}, query string, opt 
 // the specified project
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/search.html#scope-merge_requests
+// https://docs.gitlab.com/ee/api/search.html#scope-merge_requests-2
 func (s *SearchService) MergeRequestsByProject(pid interface{}, query string, opt *SearchOptions, options ...RequestOptionFunc) ([]*MergeRequest, *Response, error) {
 	var ms []*MergeRequest
 	resp, err := s.searchByProject(pid, "merge_requests", query, &ms, opt, options...)
@@ -135,7 +135,7 @@ func (s *SearchService) Milestones(query string, opt *SearchOptions, options ...
 // MilestonesByGroup searches the expression within milestones for
 // the specified group
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/search.html#scope-milestones
+// GitLab API docs: https://docs.gitlab.com/ee/api/search.html#scope-milestones-1
 func (s *SearchService) MilestonesByGroup(gid interface{}, query string, opt *SearchOptions, options ...RequestOptionFunc) ([]*Milestone, *Response, error) {
 	var ms []*Milestone
 	resp, err := s.searchByGroup(gid, "milestones", query, &ms, opt, options...)
@@ -145,7 +145,7 @@ func (s *SearchService) MilestonesByGroup(gid interface{}, query string, opt *Se
 // MilestonesByProject searches the expression within milestones for
 // the specified project
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/search.html#scope-milestones
+// GitLab API docs: https://docs.gitlab.com/ee/api/search.html#scope-milestones-2
 func (s *SearchService) MilestonesByProject(pid interface{}, query string, opt *SearchOptions, options ...RequestOptionFunc) ([]*Milestone, *Response, error) {
 	var ms []*Milestone
 	resp, err := s.searchByProject(pid, "milestones", query, &ms, opt, options...)
@@ -196,7 +196,7 @@ func (s *SearchService) WikiBlobs(query string, opt *SearchOptions, options ...R
 // specified group
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/search.html#scope-wiki_blobs
+// https://docs.gitlab.com/ee/api/search.html#scope-wiki_blobs-premium-1
 func (s *SearchService) WikiBlobsByGroup(gid interface{}, query string, opt *SearchOptions, options ...RequestOptionFunc) ([]*Wiki, *Response, error) {
 	var ws []*Wiki
 	resp, err := s.searchByGroup(gid, "wiki_blobs", query, &ws, opt, options...)
@@ -207,7 +207,7 @@ func (s *SearchService) WikiBlobsByGroup(gid interface{}, query string, opt *Sea
 // the specified project
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/search.html#scope-wiki_blobs
+// https://docs.gitlab.com/ee/api/search.html#scope-wiki_blobs-premium-2
 func (s *SearchService) WikiBlobsByProject(pid interface{}, query string, opt *SearchOptions, options ...RequestOptionFunc) ([]*Wiki, *Response, error) {
 	var ws []*Wiki
 	resp, err := s.searchByProject(pid, "wiki_blobs", query, &ws, opt, options...)
@@ -226,7 +226,7 @@ func (s *SearchService) Commits(query string, opt *SearchOptions, options ...Req
 // CommitsByGroup searches the expression within commits for the specified
 // group
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/search.html#scope-commits
+// GitLab API docs: https://docs.gitlab.com/ee/api/search.html#scope-commits-premium-1
 func (s *SearchService) CommitsByGroup(gid interface{}, query string, opt *SearchOptions, options ...RequestOptionFunc) ([]*Commit, *Response, error) {
 	var cs []*Commit
 	resp, err := s.searchByGroup(gid, "commits", query, &cs, opt, options...)
@@ -236,7 +236,7 @@ func (s *SearchService) CommitsByGroup(gid interface{}, query string, opt *Searc
 // CommitsByProject searches the expression within commits for the
 // specified project
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/search.html#scope-commits
+// GitLab API docs: https://docs.gitlab.com/ee/api/search.html#scope-commits-premium-2
 func (s *SearchService) CommitsByProject(pid interface{}, query string, opt *SearchOptions, options ...RequestOptionFunc) ([]*Commit, *Response, error) {
 	var cs []*Commit
 	resp, err := s.searchByProject(pid, "commits", query, &cs, opt, options...)
@@ -266,7 +266,7 @@ func (s *SearchService) Blobs(query string, opt *SearchOptions, options ...Reque
 // BlobsByGroup searches the expression within blobs for the specified
 // group
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/search.html#scope-blobs
+// GitLab API docs: https://docs.gitlab.com/ee/api/search.html#scope-blobs-premium-1
 func (s *SearchService) BlobsByGroup(gid interface{}, query string, opt *SearchOptions, options ...RequestOptionFunc) ([]*Blob, *Response, error) {
 	var bs []*Blob
 	resp, err := s.searchByGroup(gid, "blobs", query, &bs, opt, options...)
@@ -276,7 +276,7 @@ func (s *SearchService) BlobsByGroup(gid interface{}, query string, opt *SearchO
 // BlobsByProject searches the expression within blobs for the specified
 // project
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/search.html#scope-blobs
+// GitLab API docs: https://docs.gitlab.com/ee/api/search.html#scope-blobs-premium-2
 func (s *SearchService) BlobsByProject(pid interface{}, query string, opt *SearchOptions, options ...RequestOptionFunc) ([]*Blob, *Response, error) {
 	var bs []*Blob
 	resp, err := s.searchByProject(pid, "blobs", query, &bs, opt, options...)

--- a/services.go
+++ b/services.go
@@ -27,14 +27,14 @@ import (
 // ServicesService handles communication with the services related methods of
 // the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/services.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/services.html
 type ServicesService struct {
 	client *Client
 }
 
 // Service represents a GitLab service.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/services.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/services.html
 type Service struct {
 	ID                       int        `json:"id"`
 	Title                    string     `json:"title"`
@@ -59,7 +59,7 @@ type Service struct {
 
 // ListServices gets a list of all active services.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/services.html#list-all-active-services
+// GitLab API docs: https://docs.gitlab.com/ee/api/services.html#list-all-active-services
 func (s *ServicesService) ListServices(pid interface{}, options ...RequestOptionFunc) ([]*Service, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -84,7 +84,7 @@ func (s *ServicesService) ListServices(pid interface{}, options ...RequestOption
 // CustomIssueTrackerService represents Custom Issue Tracker service settings.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#custom-issue-tracker
+// https://docs.gitlab.com/ee/api/services.html#custom-issue-tracker
 type CustomIssueTrackerService struct {
 	Service
 	Properties *CustomIssueTrackerServiceProperties `json:"properties"`
@@ -93,7 +93,7 @@ type CustomIssueTrackerService struct {
 // CustomIssueTrackerServiceProperties represents Custom Issue Tracker specific properties.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#custom-issue-tracker
+// https://docs.gitlab.com/ee/api/services.html#custom-issue-tracker
 type CustomIssueTrackerServiceProperties struct {
 	ProjectURL  string `json:"project_url,omitempty"`
 	IssuesURL   string `json:"issues_url,omitempty"`
@@ -103,7 +103,7 @@ type CustomIssueTrackerServiceProperties struct {
 // GetCustomIssueTrackerService gets Custom Issue Tracker service settings for a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#get-custom-issue-tracker-service-settings
+// https://docs.gitlab.com/ee/api/services.html#get-custom-issue-tracker-service-settings
 func (s *ServicesService) GetCustomIssueTrackerService(pid interface{}, options ...RequestOptionFunc) (*CustomIssueTrackerService, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -129,7 +129,7 @@ func (s *ServicesService) GetCustomIssueTrackerService(pid interface{}, options 
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#createedit-custom-issue-tracker-service
+// https://docs.gitlab.com/ee/api/services.html#createedit-custom-issue-tracker-service
 type SetCustomIssueTrackerServiceOptions struct {
 	NewIssueURL *string `url:"new_issue_url,omitempty" json:"new_issue_url,omitempty"`
 	IssuesURL   *string `url:"issues_url,omitempty" json:"issues_url,omitempty"`
@@ -142,7 +142,7 @@ type SetCustomIssueTrackerServiceOptions struct {
 // SetCustomIssueTrackerService sets Custom Issue Tracker service for a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#createedit-custom-issue-tracker-service
+// https://docs.gitlab.com/ee/api/services.html#createedit-custom-issue-tracker-service
 func (s *ServicesService) SetCustomIssueTrackerService(pid interface{}, opt *SetCustomIssueTrackerServiceOptions, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -161,7 +161,7 @@ func (s *ServicesService) SetCustomIssueTrackerService(pid interface{}, opt *Set
 // DeleteCustomIssueTrackerService deletes Custom Issue Tracker service settings for a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#delete-custom-issue-tracker-service
+// https://docs.gitlab.com/ee/api/services.html#delete-custom-issue-tracker-service
 func (s *ServicesService) DeleteCustomIssueTrackerService(pid interface{}, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -180,7 +180,7 @@ func (s *ServicesService) DeleteCustomIssueTrackerService(pid interface{}, optio
 // DroneCIService represents Drone CI service settings.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#drone-ci
+// https://docs.gitlab.com/ee/api/services.html#drone-ci
 type DroneCIService struct {
 	Service
 	Properties *DroneCIServiceProperties `json:"properties"`
@@ -189,7 +189,7 @@ type DroneCIService struct {
 // DroneCIServiceProperties represents Drone CI specific properties.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#drone-ci
+// https://docs.gitlab.com/ee/api/services.html#drone-ci
 type DroneCIServiceProperties struct {
 	Token                 string `json:"token"`
 	DroneURL              string `json:"drone_url"`
@@ -199,7 +199,7 @@ type DroneCIServiceProperties struct {
 // GetDroneCIService gets Drone CI service settings for a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#get-drone-ci-service-settings
+// https://docs.gitlab.com/ee/api/services.html#get-drone-ci-service-settings
 func (s *ServicesService) GetDroneCIService(pid interface{}, options ...RequestOptionFunc) (*DroneCIService, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -225,7 +225,7 @@ func (s *ServicesService) GetDroneCIService(pid interface{}, options ...RequestO
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#createedit-drone-ci-service
+// https://docs.gitlab.com/ee/api/services.html#createedit-drone-ci-service
 type SetDroneCIServiceOptions struct {
 	Token                 *string `url:"token,omitempty" json:"token,omitempty"`
 	DroneURL              *string `url:"drone_url,omitempty" json:"drone_url,omitempty"`
@@ -235,7 +235,7 @@ type SetDroneCIServiceOptions struct {
 // SetDroneCIService sets Drone CI service for a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#createedit-drone-ci-service
+// https://docs.gitlab.com/ee/api/services.html#createedit-drone-ci-service
 func (s *ServicesService) SetDroneCIService(pid interface{}, opt *SetDroneCIServiceOptions, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -254,7 +254,7 @@ func (s *ServicesService) SetDroneCIService(pid interface{}, opt *SetDroneCIServ
 // DeleteDroneCIService deletes Drone CI service settings for a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#delete-drone-ci-service
+// https://docs.gitlab.com/ee/api/services.html#delete-drone-ci-service
 func (s *ServicesService) DeleteDroneCIService(pid interface{}, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -372,7 +372,7 @@ func (s *ServicesService) DeleteEmailsOnPushService(pid interface{}, options ...
 // ExternalWikiService represents External Wiki service settings.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#external-wiki
+// https://docs.gitlab.com/ee/api/services.html#external-wiki
 type ExternalWikiService struct {
 	Service
 	Properties *ExternalWikiServiceProperties `json:"properties"`
@@ -381,7 +381,7 @@ type ExternalWikiService struct {
 // ExternalWikiServiceProperties represents External Wiki specific properties.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#external-wiki
+// https://docs.gitlab.com/ee/api/services.html#external-wiki
 type ExternalWikiServiceProperties struct {
 	ExternalWikiURL string `json:"external_wiki_url"`
 }
@@ -389,7 +389,7 @@ type ExternalWikiServiceProperties struct {
 // GetExternalWikiService gets External Wiki service settings for a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#get-external-wiki-service-settings
+// https://docs.gitlab.com/ee/api/services.html#get-external-wiki-service-settings
 func (s *ServicesService) GetExternalWikiService(pid interface{}, options ...RequestOptionFunc) (*ExternalWikiService, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -415,7 +415,7 @@ func (s *ServicesService) GetExternalWikiService(pid interface{}, options ...Req
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#createedit-external-wiki-service
+// https://docs.gitlab.com/ee/api/services.html#createedit-external-wiki-service
 type SetExternalWikiServiceOptions struct {
 	ExternalWikiURL *string `url:"external_wiki_url,omitempty" json:"external_wiki_url,omitempty"`
 }
@@ -423,7 +423,7 @@ type SetExternalWikiServiceOptions struct {
 // SetExternalWikiService sets External Wiki service for a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#createedit-external-wiki-service
+// https://docs.gitlab.com/ee/api/services.html#createedit-external-wiki-service
 func (s *ServicesService) SetExternalWikiService(pid interface{}, opt *SetExternalWikiServiceOptions, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -442,7 +442,7 @@ func (s *ServicesService) SetExternalWikiService(pid interface{}, opt *SetExtern
 // DeleteExternalWikiService deletes External Wiki service for project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#delete-external-wiki-service
+// https://docs.gitlab.com/ee/api/services.html#delete-external-wiki-service
 func (s *ServicesService) DeleteExternalWikiService(pid interface{}, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -461,7 +461,7 @@ func (s *ServicesService) DeleteExternalWikiService(pid interface{}, options ...
 // GithubService represents Github service settings.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#github-premium
+// https://docs.gitlab.com/ee/api/services.html#github-premium
 type GithubService struct {
 	Service
 	Properties *GithubServiceProperties `json:"properties"`
@@ -470,7 +470,7 @@ type GithubService struct {
 // GithubServiceProperties represents Github specific properties.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#github-premium
+// https://docs.gitlab.com/ee/api/services.html#github-premium
 type GithubServiceProperties struct {
 	RepositoryURL string `json:"repository_url"`
 	StaticContext bool   `json:"static_context"`
@@ -479,7 +479,7 @@ type GithubServiceProperties struct {
 // GetGithubService gets Github service settings for a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#get-github-service-settings
+// https://docs.gitlab.com/ee/api/services.html#get-github-service-settings
 func (s *ServicesService) GetGithubService(pid interface{}, options ...RequestOptionFunc) (*GithubService, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -505,7 +505,7 @@ func (s *ServicesService) GetGithubService(pid interface{}, options ...RequestOp
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#createedit-github-service
+// https://docs.gitlab.com/ee/api/services.html#createedit-github-service
 type SetGithubServiceOptions struct {
 	Token         *string `url:"token,omitempty" json:"token,omitempty"`
 	RepositoryURL *string `url:"repository_url,omitempty" json:"repository_url,omitempty"`
@@ -515,7 +515,7 @@ type SetGithubServiceOptions struct {
 // SetGithubService sets Github service for a project
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#createedit-github-service
+// https://docs.gitlab.com/ee/api/services.html#createedit-github-service
 func (s *ServicesService) SetGithubService(pid interface{}, opt *SetGithubServiceOptions, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -534,7 +534,7 @@ func (s *ServicesService) SetGithubService(pid interface{}, opt *SetGithubServic
 // DeleteGithubService deletes Github service for a project
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#delete-github-service
+// https://docs.gitlab.com/ee/api/services.html#delete-github-service
 func (s *ServicesService) DeleteGithubService(pid interface{}, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -554,7 +554,7 @@ func (s *ServicesService) DeleteGithubService(pid interface{}, options ...Reques
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#edit-gitlab-ci-service
+// https://docs.gitlab.com/ee/api/services.html#edit-gitlab-ci-service
 type SetGitLabCIServiceOptions struct {
 	Token      *string `url:"token,omitempty" json:"token,omitempty"`
 	ProjectURL *string `url:"project_url,omitempty" json:"project_url,omitempty"`
@@ -563,7 +563,7 @@ type SetGitLabCIServiceOptions struct {
 // SetGitLabCIService sets GitLab CI service for a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#edit-gitlab-ci-service
+// https://docs.gitlab.com/ee/api/services.html#edit-gitlab-ci-service
 func (s *ServicesService) SetGitLabCIService(pid interface{}, opt *SetGitLabCIServiceOptions, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -582,7 +582,7 @@ func (s *ServicesService) SetGitLabCIService(pid interface{}, opt *SetGitLabCISe
 // DeleteGitLabCIService deletes GitLab CI service settings for a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#delete-gitlab-ci-service
+// https://docs.gitlab.com/ee/api/services.html#delete-gitlab-ci-service
 func (s *ServicesService) DeleteGitLabCIService(pid interface{}, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -602,7 +602,7 @@ func (s *ServicesService) DeleteGitLabCIService(pid interface{}, options ...Requ
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#edit-hipchat-service
+// https://docs.gitlab.com/ee/api/services.html#edit-hipchat-service
 type SetHipChatServiceOptions struct {
 	Token *string `url:"token,omitempty" json:"token,omitempty" `
 	Room  *string `url:"room,omitempty" json:"room,omitempty"`
@@ -611,7 +611,7 @@ type SetHipChatServiceOptions struct {
 // SetHipChatService sets HipChat service for a project
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#edit-hipchat-service
+// https://docs.gitlab.com/ee/api/services.html#edit-hipchat-service
 func (s *ServicesService) SetHipChatService(pid interface{}, opt *SetHipChatServiceOptions, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -630,7 +630,7 @@ func (s *ServicesService) SetHipChatService(pid interface{}, opt *SetHipChatServ
 // DeleteHipChatService deletes HipChat service for project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#delete-hipchat-service
+// https://docs.gitlab.com/ee/api/services.html#delete-hipchat-service
 func (s *ServicesService) DeleteHipChatService(pid interface{}, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -727,7 +727,7 @@ func (s *ServicesService) SetJenkinsCIService(pid interface{}, opt *SetJenkinsCI
 // DeleteJenkinsCIService deletes Jenkins CI service for project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#delete-jira-service
+// https://docs.gitlab.com/ee/api/services.html#delete-jira-service
 func (s *ServicesService) DeleteJenkinsCIService(pid interface{}, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -746,7 +746,7 @@ func (s *ServicesService) DeleteJenkinsCIService(pid interface{}, options ...Req
 // JiraService represents Jira service settings.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#jira
+// https://docs.gitlab.com/ee/api/services.html#jira
 type JiraService struct {
 	Service
 	Properties *JiraServiceProperties `json:"properties"`
@@ -755,7 +755,7 @@ type JiraService struct {
 // JiraServiceProperties represents Jira specific properties.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#jira
+// https://docs.gitlab.com/ee/api/services.html#jira
 type JiraServiceProperties struct {
 	URL                   string `json:"url"`
 	APIURL                string `json:"api_url"`
@@ -798,7 +798,7 @@ func (p *JiraServiceProperties) UnmarshalJSON(b []byte) error {
 // GetJiraService gets Jira service settings for a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#get-jira-service-settings
+// https://docs.gitlab.com/ee/api/services.html#get-jira-service-settings
 func (s *ServicesService) GetJiraService(pid interface{}, options ...RequestOptionFunc) (*JiraService, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -824,7 +824,7 @@ func (s *ServicesService) GetJiraService(pid interface{}, options ...RequestOpti
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#edit-jira-service
+// https://docs.gitlab.com/ee/api/services.html#edit-jira-service
 type SetJiraServiceOptions struct {
 	URL                   *string `url:"url,omitempty" json:"url,omitempty"`
 	APIURL                *string `url:"api_url,omitempty" json:"api_url,omitempty"`
@@ -841,7 +841,7 @@ type SetJiraServiceOptions struct {
 // SetJiraService sets Jira service for a project
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#edit-jira-service
+// https://docs.gitlab.com/ee/api/services.html#edit-jira-service
 func (s *ServicesService) SetJiraService(pid interface{}, opt *SetJiraServiceOptions, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -860,7 +860,7 @@ func (s *ServicesService) SetJiraService(pid interface{}, opt *SetJiraServiceOpt
 // DeleteJiraService deletes Jira service for project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#delete-jira-service
+// https://docs.gitlab.com/ee/api/services.html#delete-jira-service
 func (s *ServicesService) DeleteJiraService(pid interface{}, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -879,7 +879,7 @@ func (s *ServicesService) DeleteJiraService(pid interface{}, options ...RequestO
 // MattermostService represents Mattermost service settings.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#mattermost-notifications
+// https://docs.gitlab.com/ee/api/services.html#mattermost-notifications
 type MattermostService struct {
 	Service
 	Properties *MattermostServiceProperties `json:"properties"`
@@ -888,7 +888,7 @@ type MattermostService struct {
 // MattermostServiceProperties represents Mattermost specific properties.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#mattermost-notifications
+// https://docs.gitlab.com/ee/api/services.html#mattermost-notifications
 type MattermostServiceProperties struct {
 	WebHook                   string    `json:"webhook"`
 	Username                  string    `json:"username"`
@@ -909,7 +909,7 @@ type MattermostServiceProperties struct {
 // GetMattermostService gets Mattermost service settings for a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#get-slack-service-settings
+// https://docs.gitlab.com/ee/api/services.html#get-slack-service-settings
 func (s *ServicesService) GetMattermostService(pid interface{}, options ...RequestOptionFunc) (*MattermostService, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -935,7 +935,7 @@ func (s *ServicesService) GetMattermostService(pid interface{}, options ...Reque
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#createedit-mattermost-notifications-service
+// https://docs.gitlab.com/ee/api/services.html#createedit-mattermost-notifications-service
 type SetMattermostServiceOptions struct {
 	WebHook                   *string `url:"webhook,omitempty" json:"webhook,omitempty"`
 	Username                  *string `url:"username,omitempty" json:"username,omitempty"`
@@ -965,7 +965,7 @@ type SetMattermostServiceOptions struct {
 // SetMattermostService sets Mattermost service for a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#createedit-mattermost-notifications-service
+// https://docs.gitlab.com/ee/api/services.html#createedit-mattermost-notifications-service
 func (s *ServicesService) SetMattermostService(pid interface{}, opt *SetMattermostServiceOptions, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -984,7 +984,7 @@ func (s *ServicesService) SetMattermostService(pid interface{}, opt *SetMattermo
 // DeleteMattermostService deletes Mattermost service for project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#delete-mattermost-notifications-service
+// https://docs.gitlab.com/ee/api/services.html#delete-mattermost-notifications-service
 func (s *ServicesService) DeleteMattermostService(pid interface{}, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -1003,7 +1003,7 @@ func (s *ServicesService) DeleteMattermostService(pid interface{}, options ...Re
 // MicrosoftTeamsService represents Microsoft Teams service settings.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#microsoft-teams
+// https://docs.gitlab.com/ee/api/services.html#microsoft-teams
 type MicrosoftTeamsService struct {
 	Service
 	Properties *MicrosoftTeamsServiceProperties `json:"properties"`
@@ -1012,7 +1012,7 @@ type MicrosoftTeamsService struct {
 // MicrosoftTeamsServiceProperties represents Microsoft Teams specific properties.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#microsoft-teams
+// https://docs.gitlab.com/ee/api/services.html#microsoft-teams
 type MicrosoftTeamsServiceProperties struct {
 	WebHook                   string    `json:"webhook"`
 	NotifyOnlyBrokenPipelines BoolValue `json:"notify_only_broken_pipelines"`
@@ -1030,7 +1030,7 @@ type MicrosoftTeamsServiceProperties struct {
 // GetMicrosoftTeamsService gets MicrosoftTeams service settings for a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#get-microsoft-teams-service-settings
+// https://docs.gitlab.com/ee/api/services.html#get-microsoft-teams-service-settings
 func (s *ServicesService) GetMicrosoftTeamsService(pid interface{}, options ...RequestOptionFunc) (*MicrosoftTeamsService, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -1056,7 +1056,7 @@ func (s *ServicesService) GetMicrosoftTeamsService(pid interface{}, options ...R
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#create-edit-microsoft-teams-service
+// https://docs.gitlab.com/ee/api/services.html#create-edit-microsoft-teams-service
 type SetMicrosoftTeamsServiceOptions struct {
 	WebHook                   *string `url:"webhook,omitempty" json:"webhook,omitempty"`
 	NotifyOnlyBrokenPipelines *bool   `url:"notify_only_broken_pipelines,omitempty" json:"notify_only_broken_pipelines,omitempty"`
@@ -1075,7 +1075,7 @@ type SetMicrosoftTeamsServiceOptions struct {
 // SetMicrosoftTeamsService sets Microsoft Teams service for a project
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#create-edit-microsoft-teams-service
+// https://docs.gitlab.com/ee/api/services.html#create-edit-microsoft-teams-service
 func (s *ServicesService) SetMicrosoftTeamsService(pid interface{}, opt *SetMicrosoftTeamsServiceOptions, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -1093,7 +1093,7 @@ func (s *ServicesService) SetMicrosoftTeamsService(pid interface{}, opt *SetMicr
 // DeleteMicrosoftTeamsService deletes Microsoft Teams service for project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#delete-microsoft-teams-service
+// https://docs.gitlab.com/ee/api/services.html#delete-microsoft-teams-service
 func (s *ServicesService) DeleteMicrosoftTeamsService(pid interface{}, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -1302,7 +1302,7 @@ func (s *ServicesService) DeletePrometheusService(pid interface{}, options ...Re
 // SlackService represents Slack service settings.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#slack
+// https://docs.gitlab.com/ee/api/services.html#slack
 type SlackService struct {
 	Service
 	Properties *SlackServiceProperties `json:"properties"`
@@ -1311,7 +1311,7 @@ type SlackService struct {
 // SlackServiceProperties represents Slack specific properties.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#slack
+// https://docs.gitlab.com/ee/api/services.html#slack
 type SlackServiceProperties struct {
 	WebHook                   string    `json:"webhook"`
 	Username                  string    `json:"username"`
@@ -1334,7 +1334,7 @@ type SlackServiceProperties struct {
 // GetSlackService gets Slack service settings for a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#get-slack-service-settings
+// https://docs.gitlab.com/ee/api/services.html#get-slack-service-settings
 func (s *ServicesService) GetSlackService(pid interface{}, options ...RequestOptionFunc) (*SlackService, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -1360,7 +1360,7 @@ func (s *ServicesService) GetSlackService(pid interface{}, options ...RequestOpt
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#edit-slack-service
+// https://docs.gitlab.com/ee/api/services.html#edit-slack-service
 type SetSlackServiceOptions struct {
 	WebHook                   *string `url:"webhook,omitempty" json:"webhook,omitempty"`
 	Username                  *string `url:"username,omitempty" json:"username,omitempty"`
@@ -1396,7 +1396,7 @@ type SetSlackServiceOptions struct {
 // SetSlackService sets Slack service for a project
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#edit-slack-service
+// https://docs.gitlab.com/ee/api/services.html#edit-slack-service
 func (s *ServicesService) SetSlackService(pid interface{}, opt *SetSlackServiceOptions, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -1415,7 +1415,7 @@ func (s *ServicesService) SetSlackService(pid interface{}, opt *SetSlackServiceO
 // DeleteSlackService deletes Slack service for project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#delete-slack-service
+// https://docs.gitlab.com/ee/api/services.html#delete-slack-service
 func (s *ServicesService) DeleteSlackService(pid interface{}, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -1614,7 +1614,7 @@ func (s *ServicesService) DeleteMattermostSlashCommandsService(pid interface{}, 
 // YouTrackService represents YouTrack service settings.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#youtrack
+// https://docs.gitlab.com/ee/api/services.html#youtrack
 type YouTrackService struct {
 	Service
 	Properties *YouTrackServiceProperties `json:"properties"`
@@ -1623,7 +1623,7 @@ type YouTrackService struct {
 // YouTrackServiceProperties represents YouTrack specific properties.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#youtrack
+// https://docs.gitlab.com/ee/api/services.html#youtrack
 type YouTrackServiceProperties struct {
 	IssuesURL   string `json:"issues_url"`
 	ProjectURL  string `json:"project_url"`
@@ -1634,7 +1634,7 @@ type YouTrackServiceProperties struct {
 // GetYouTrackService gets YouTrack service settings for a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#get-youtrack-service-settings
+// https://docs.gitlab.com/ee/api/services.html#get-youtrack-service-settings
 func (s *ServicesService) GetYouTrackService(pid interface{}, options ...RequestOptionFunc) (*YouTrackService, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -1660,7 +1660,7 @@ func (s *ServicesService) GetYouTrackService(pid interface{}, options ...Request
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#createedit-youtrack-service
+// https://docs.gitlab.com/ee/api/services.html#createedit-youtrack-service
 type SetYouTrackServiceOptions struct {
 	IssuesURL   *string `url:"issues_url,omitempty" json:"issues_url,omitempty"`
 	ProjectURL  *string `url:"project_url,omitempty" json:"project_url,omitempty"`
@@ -1671,7 +1671,7 @@ type SetYouTrackServiceOptions struct {
 // SetYouTrackService sets YouTrack service for a project
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#createedit-youtrack-service
+// https://docs.gitlab.com/ee/api/services.html#createedit-youtrack-service
 func (s *ServicesService) SetYouTrackService(pid interface{}, opt *SetYouTrackServiceOptions, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -1690,7 +1690,7 @@ func (s *ServicesService) SetYouTrackService(pid interface{}, opt *SetYouTrackSe
 // DeleteYouTrackService deletes YouTrack service settings for a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#delete-youtrack-service
+// https://docs.gitlab.com/ee/api/services.html#delete-youtrack-service
 func (s *ServicesService) DeleteYouTrackService(pid interface{}, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/settings.go
+++ b/settings.go
@@ -24,14 +24,14 @@ import (
 // SettingsService handles communication with the application SettingsService
 // related methods of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/settings.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/settings.html
 type SettingsService struct {
 	client *Client
 }
 
 // Settings represents the GitLab application settings.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/settings.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/settings.html
 //
 // The available parameters have been modeled directly after the code, as the
 // documentation seems to be inaccurate.
@@ -390,7 +390,7 @@ func (s Settings) String() string {
 // GetSettings gets the current application settings.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/settings.html#get-current-application.settings
+// https://docs.gitlab.com/ee/api/settings.html#get-current-application.settings
 func (s *SettingsService) GetSettings(options ...RequestOptionFunc) (*Settings, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "application/settings", nil, options)
 	if err != nil {
@@ -409,7 +409,7 @@ func (s *SettingsService) GetSettings(options ...RequestOptionFunc) (*Settings, 
 // UpdateSettingsOptions represents the available UpdateSettings() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/settings.html#change-application.settings
+// https://docs.gitlab.com/ee/api/settings.html#change-application.settings
 type UpdateSettingsOptions struct {
 	AbuseNotificationEmail                                *string            `url:"abuse_notification_email,omitempty" json:"abuse_notification_email,omitempty"`
 	AdminMode                                             *bool              `url:"admin_mode,omitempty" json:"admin_mode,omitempty"`
@@ -752,7 +752,7 @@ type UpdateSettingsOptions struct {
 // UpdateSettings updates the application settings.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/settings.html#change-application.settings
+// https://docs.gitlab.com/ee/api/settings.html#change-application.settings
 func (s *SettingsService) UpdateSettings(opt *UpdateSettingsOptions, options ...RequestOptionFunc) (*Settings, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodPut, "application/settings", opt, options)
 	if err != nil {

--- a/settings.go
+++ b/settings.go
@@ -390,7 +390,7 @@ func (s Settings) String() string {
 // GetSettings gets the current application settings.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/settings.html#get-current-application.settings
+// https://docs.gitlab.com/ee/api/settings.html#get-current-application-settings
 func (s *SettingsService) GetSettings(options ...RequestOptionFunc) (*Settings, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "application/settings", nil, options)
 	if err != nil {
@@ -409,7 +409,7 @@ func (s *SettingsService) GetSettings(options ...RequestOptionFunc) (*Settings, 
 // UpdateSettingsOptions represents the available UpdateSettings() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/settings.html#change-application.settings
+// https://docs.gitlab.com/ee/api/settings.html#change-application-settings
 type UpdateSettingsOptions struct {
 	AbuseNotificationEmail                                *string            `url:"abuse_notification_email,omitempty" json:"abuse_notification_email,omitempty"`
 	AdminMode                                             *bool              `url:"admin_mode,omitempty" json:"admin_mode,omitempty"`
@@ -752,7 +752,7 @@ type UpdateSettingsOptions struct {
 // UpdateSettings updates the application settings.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/settings.html#change-application.settings
+// https://docs.gitlab.com/ee/api/settings.html#change-application-settings
 func (s *SettingsService) UpdateSettings(opt *UpdateSettingsOptions, options ...RequestOptionFunc) (*Settings, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodPut, "application/settings", opt, options)
 	if err != nil {

--- a/sidekiq_metrics.go
+++ b/sidekiq_metrics.go
@@ -23,7 +23,7 @@ import (
 
 // SidekiqService handles communication with the sidekiq service
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/sidekiq_metrics.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/sidekiq_metrics.html
 type SidekiqService struct {
 	client *Client
 }
@@ -31,7 +31,7 @@ type SidekiqService struct {
 // QueueMetrics represents the GitLab sidekiq queue metrics.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/sidekiq_metrics.html#get-the-current-queue-metrics
+// https://docs.gitlab.com/ee/api/sidekiq_metrics.html#get-the-current-queue-metrics
 type QueueMetrics struct {
 	Queues map[string]struct {
 		Backlog int `json:"backlog"`
@@ -43,7 +43,7 @@ type QueueMetrics struct {
 // their backlog and their latency.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/sidekiq_metrics.html#get-the-current-queue-metrics
+// https://docs.gitlab.com/ee/api/sidekiq_metrics.html#get-the-current-queue-metrics
 func (s *SidekiqService) GetQueueMetrics(options ...RequestOptionFunc) (*QueueMetrics, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "/sidekiq/queue_metrics", nil, options)
 	if err != nil {
@@ -62,7 +62,7 @@ func (s *SidekiqService) GetQueueMetrics(options ...RequestOptionFunc) (*QueueMe
 // ProcessMetrics represents the GitLab sidekiq process metrics.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/sidekiq_metrics.html#get-the-current-process-metrics
+// https://docs.gitlab.com/ee/api/sidekiq_metrics.html#get-the-current-process-metrics
 type ProcessMetrics struct {
 	Processes []struct {
 		Hostname    string     `json:"hostname"`
@@ -80,7 +80,7 @@ type ProcessMetrics struct {
 // to process your queues.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/sidekiq_metrics.html#get-the-current-process-metrics
+// https://docs.gitlab.com/ee/api/sidekiq_metrics.html#get-the-current-process-metrics
 func (s *SidekiqService) GetProcessMetrics(options ...RequestOptionFunc) (*ProcessMetrics, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "/sidekiq/process_metrics", nil, options)
 	if err != nil {
@@ -99,7 +99,7 @@ func (s *SidekiqService) GetProcessMetrics(options ...RequestOptionFunc) (*Proce
 // JobStats represents the GitLab sidekiq job stats.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/sidekiq_metrics.html#get-the-current-job-statistics
+// https://docs.gitlab.com/ee/api/sidekiq_metrics.html#get-the-current-job-statistics
 type JobStats struct {
 	Jobs struct {
 		Processed int `json:"processed"`
@@ -111,7 +111,7 @@ type JobStats struct {
 // GetJobStats list information about the jobs that Sidekiq has performed.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/sidekiq_metrics.html#get-the-current-job-statistics
+// https://docs.gitlab.com/ee/api/sidekiq_metrics.html#get-the-current-job-statistics
 func (s *SidekiqService) GetJobStats(options ...RequestOptionFunc) (*JobStats, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "/sidekiq/job_stats", nil, options)
 	if err != nil {
@@ -130,7 +130,7 @@ func (s *SidekiqService) GetJobStats(options ...RequestOptionFunc) (*JobStats, *
 // CompoundMetrics represents the GitLab sidekiq compounded stats.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/sidekiq_metrics.html#get-a-compound-response-of-all-the-previously-mentioned-metrics
+// https://docs.gitlab.com/ee/api/sidekiq_metrics.html#get-a-compound-response-of-all-the-previously-mentioned-metrics
 type CompoundMetrics struct {
 	QueueMetrics
 	ProcessMetrics
@@ -140,7 +140,7 @@ type CompoundMetrics struct {
 // GetCompoundMetrics lists all the currently available information about Sidekiq.
 // Get a compound response of all the previously mentioned metrics
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/sidekiq_metrics.html#get-the-current-job-statistics
+// GitLab API docs: https://docs.gitlab.com/ee/api/sidekiq_metrics.html#get-the-current-job-statistics
 func (s *SidekiqService) GetCompoundMetrics(options ...RequestOptionFunc) (*CompoundMetrics, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "/sidekiq/compound_metrics", nil, options)
 	if err != nil {

--- a/sidekiq_metrics.go
+++ b/sidekiq_metrics.go
@@ -140,7 +140,7 @@ type CompoundMetrics struct {
 // GetCompoundMetrics lists all the currently available information about Sidekiq.
 // Get a compound response of all the previously mentioned metrics
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/sidekiq_metrics.html#get-the-current-job-statistics
+// GitLab API docs: https://docs.gitlab.com/ee/api/sidekiq_metrics.html#get-a-compound-response-of-all-the-previously-mentioned-metrics
 func (s *SidekiqService) GetCompoundMetrics(options ...RequestOptionFunc) (*CompoundMetrics, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "/sidekiq/compound_metrics", nil, options)
 	if err != nil {

--- a/snippets.go
+++ b/snippets.go
@@ -63,12 +63,12 @@ func (s Snippet) String() string {
 
 // ListSnippetsOptions represents the available ListSnippets() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/snippets.html#list-snippets
+// GitLab API docs: https://docs.gitlab.com/ee/api/snippets.html#list-all-snippets-for-a-user
 type ListSnippetsOptions ListOptions
 
 // ListSnippets gets a list of snippets.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/snippets.html#list-snippets
+// GitLab API docs: https://docs.gitlab.com/ee/api/snippets.html#list-all-snippets-for-a-user
 func (s *SnippetsService) ListSnippets(opt *ListSnippetsOptions, options ...RequestOptionFunc) ([]*Snippet, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "snippets", opt, options)
 	if err != nil {
@@ -87,7 +87,7 @@ func (s *SnippetsService) ListSnippets(opt *ListSnippetsOptions, options ...Requ
 // GetSnippet gets a single snippet
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/snippets.html#single-snippet
+// https://docs.gitlab.com/ee/api/snippets.html#get-a-single-snippet
 func (s *SnippetsService) GetSnippet(snippet int, options ...RequestOptionFunc) (*Snippet, *Response, error) {
 	u := fmt.Sprintf("snippets/%d", snippet)
 
@@ -201,7 +201,7 @@ func (s *SnippetsService) DeleteSnippet(snippet int, options ...RequestOptionFun
 // SnippetContent returns the raw snippet as plain text.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/snippets.html#snippet-content
+// https://docs.gitlab.com/ee/api/snippets.html#single-snippet-contents
 func (s *SnippetsService) SnippetContent(snippet int, options ...RequestOptionFunc) ([]byte, *Response, error) {
 	u := fmt.Sprintf("snippets/%d/raw", snippet)
 
@@ -222,13 +222,13 @@ func (s *SnippetsService) SnippetContent(snippet int, options ...RequestOptionFu
 // ExploreSnippetsOptions represents the available ExploreSnippets() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/snippets.html#explore-all-public-snippets
+// https://docs.gitlab.com/ee/api/snippets.html#list-all-public-snippets
 type ExploreSnippetsOptions ListOptions
 
 // ExploreSnippets gets the list of public snippets.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/snippets.html#explore-all-public-snippets
+// https://docs.gitlab.com/ee/api/snippets.html#list-all-public-snippets
 func (s *SnippetsService) ExploreSnippets(opt *ExploreSnippetsOptions, options ...RequestOptionFunc) ([]*Snippet, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "snippets/public", opt, options)
 	if err != nil {

--- a/snippets.go
+++ b/snippets.go
@@ -26,14 +26,14 @@ import (
 // SnippetsService handles communication with the snippets
 // related methods of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/snippets.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/snippets.html
 type SnippetsService struct {
 	client *Client
 }
 
 // Snippet represents a GitLab snippet.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/snippets.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/snippets.html
 type Snippet struct {
 	ID          int    `json:"id"`
 	Title       string `json:"title"`
@@ -63,12 +63,12 @@ func (s Snippet) String() string {
 
 // ListSnippetsOptions represents the available ListSnippets() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/snippets.html#list-snippets
+// GitLab API docs: https://docs.gitlab.com/ee/api/snippets.html#list-snippets
 type ListSnippetsOptions ListOptions
 
 // ListSnippets gets a list of snippets.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/snippets.html#list-snippets
+// GitLab API docs: https://docs.gitlab.com/ee/api/snippets.html#list-snippets
 func (s *SnippetsService) ListSnippets(opt *ListSnippetsOptions, options ...RequestOptionFunc) ([]*Snippet, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "snippets", opt, options)
 	if err != nil {
@@ -87,7 +87,7 @@ func (s *SnippetsService) ListSnippets(opt *ListSnippetsOptions, options ...Requ
 // GetSnippet gets a single snippet
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/snippets.html#single-snippet
+// https://docs.gitlab.com/ee/api/snippets.html#single-snippet
 func (s *SnippetsService) GetSnippet(snippet int, options ...RequestOptionFunc) (*Snippet, *Response, error) {
 	u := fmt.Sprintf("snippets/%d", snippet)
 
@@ -108,7 +108,7 @@ func (s *SnippetsService) GetSnippet(snippet int, options ...RequestOptionFunc) 
 // SnippetFile represents the object that is used to create snippets
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/snippets.html#create-new-snippet
+// https://docs.gitlab.com/ee/api/snippets.html#create-new-snippet
 type SnippetFile struct {
 	FilePath *string `url:"file_path,omitempty" json:"file_path,omitempty"`
 	Content  *string `url:"content,omitempty" json:"content,omitempty"`
@@ -117,7 +117,7 @@ type SnippetFile struct {
 // CreateSnippetOptions represents the available CreateSnippet() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/snippets.html#create-new-snippet
+// https://docs.gitlab.com/ee/api/snippets.html#create-new-snippet
 type CreateSnippetOptions struct {
 	Title       *string          `url:"title,omitempty" json:"title,omitempty"`
 	FileName    *string          `url:"file_name,omitempty" json:"file_name,omitempty"`
@@ -131,7 +131,7 @@ type CreateSnippetOptions struct {
 // to create new snippets.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/snippets.html#create-new-snippet
+// https://docs.gitlab.com/ee/api/snippets.html#create-new-snippet
 func (s *SnippetsService) CreateSnippet(opt *CreateSnippetOptions, options ...RequestOptionFunc) (*Snippet, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodPost, "snippets", opt, options)
 	if err != nil {
@@ -150,7 +150,7 @@ func (s *SnippetsService) CreateSnippet(opt *CreateSnippetOptions, options ...Re
 // UpdateSnippetOptions represents the available UpdateSnippet() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/snippets.html#update-snippet
+// https://docs.gitlab.com/ee/api/snippets.html#update-snippet
 type UpdateSnippetOptions struct {
 	Title       *string          `url:"title,omitempty" json:"title,omitempty"`
 	FileName    *string          `url:"file_name,omitempty" json:"file_name,omitempty"`
@@ -163,7 +163,7 @@ type UpdateSnippetOptions struct {
 // permission to change an existing snippet.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/snippets.html#update-snippet
+// https://docs.gitlab.com/ee/api/snippets.html#update-snippet
 func (s *SnippetsService) UpdateSnippet(snippet int, opt *UpdateSnippetOptions, options ...RequestOptionFunc) (*Snippet, *Response, error) {
 	u := fmt.Sprintf("snippets/%d", snippet)
 
@@ -186,7 +186,7 @@ func (s *SnippetsService) UpdateSnippet(snippet int, opt *UpdateSnippetOptions, 
 // code.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/snippets.html#delete-snippet
+// https://docs.gitlab.com/ee/api/snippets.html#delete-snippet
 func (s *SnippetsService) DeleteSnippet(snippet int, options ...RequestOptionFunc) (*Response, error) {
 	u := fmt.Sprintf("snippets/%d", snippet)
 
@@ -201,7 +201,7 @@ func (s *SnippetsService) DeleteSnippet(snippet int, options ...RequestOptionFun
 // SnippetContent returns the raw snippet as plain text.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/snippets.html#snippet-content
+// https://docs.gitlab.com/ee/api/snippets.html#snippet-content
 func (s *SnippetsService) SnippetContent(snippet int, options ...RequestOptionFunc) ([]byte, *Response, error) {
 	u := fmt.Sprintf("snippets/%d/raw", snippet)
 
@@ -222,13 +222,13 @@ func (s *SnippetsService) SnippetContent(snippet int, options ...RequestOptionFu
 // ExploreSnippetsOptions represents the available ExploreSnippets() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/snippets.html#explore-all-public-snippets
+// https://docs.gitlab.com/ee/api/snippets.html#explore-all-public-snippets
 type ExploreSnippetsOptions ListOptions
 
 // ExploreSnippets gets the list of public snippets.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/snippets.html#explore-all-public-snippets
+// https://docs.gitlab.com/ee/api/snippets.html#explore-all-public-snippets
 func (s *SnippetsService) ExploreSnippets(opt *ExploreSnippetsOptions, options ...RequestOptionFunc) ([]*Snippet, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "snippets/public", opt, options)
 	if err != nil {

--- a/system_hooks.go
+++ b/system_hooks.go
@@ -91,7 +91,7 @@ func (s *SystemHooksService) GetHook(hook int, options ...RequestOptionFunc) (*H
 // AddHookOptions represents the available AddHook() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/system_hooks.html#add-new-system-hook-hook
+// https://docs.gitlab.com/ee/api/system_hooks.html#add-new-system-hook
 type AddHookOptions struct {
 	URL                    *string `url:"url,omitempty" json:"url,omitempty"`
 	Token                  *string `url:"token,omitempty" json:"token,omitempty"`
@@ -105,7 +105,7 @@ type AddHookOptions struct {
 // AddHook adds a new system hook hook.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/system_hooks.html#add-new-system-hook-hook
+// https://docs.gitlab.com/ee/api/system_hooks.html#add-new-system-hook
 func (s *SystemHooksService) AddHook(opt *AddHookOptions, options ...RequestOptionFunc) (*Hook, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodPost, "hooks", opt, options)
 	if err != nil {

--- a/system_hooks.go
+++ b/system_hooks.go
@@ -25,14 +25,14 @@ import (
 // SystemHooksService handles communication with the system hooks related
 // methods of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/system_hooks.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/system_hooks.html
 type SystemHooksService struct {
 	client *Client
 }
 
 // Hook represents a GitLap system hook.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/system_hooks.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/system_hooks.html
 type Hook struct {
 	ID                     int        `json:"id"`
 	URL                    string     `json:"url"`
@@ -51,7 +51,7 @@ func (h Hook) String() string {
 // ListHooks gets a list of system hooks.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/system_hooks.html#list-system-hooks
+// https://docs.gitlab.com/ee/api/system_hooks.html#list-system-hooks
 func (s *SystemHooksService) ListHooks(options ...RequestOptionFunc) ([]*Hook, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "hooks", nil, options)
 	if err != nil {
@@ -70,7 +70,7 @@ func (s *SystemHooksService) ListHooks(options ...RequestOptionFunc) ([]*Hook, *
 // GetHook get a single system hook.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/system_hooks.html#get-system-hook
+// https://docs.gitlab.com/ee/api/system_hooks.html#get-system-hook
 func (s *SystemHooksService) GetHook(hook int, options ...RequestOptionFunc) (*Hook, *Response, error) {
 	u := fmt.Sprintf("hooks/%d", hook)
 
@@ -91,7 +91,7 @@ func (s *SystemHooksService) GetHook(hook int, options ...RequestOptionFunc) (*H
 // AddHookOptions represents the available AddHook() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/system_hooks.html#add-new-system-hook-hook
+// https://docs.gitlab.com/ee/api/system_hooks.html#add-new-system-hook-hook
 type AddHookOptions struct {
 	URL                    *string `url:"url,omitempty" json:"url,omitempty"`
 	Token                  *string `url:"token,omitempty" json:"token,omitempty"`
@@ -105,7 +105,7 @@ type AddHookOptions struct {
 // AddHook adds a new system hook hook.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/system_hooks.html#add-new-system-hook-hook
+// https://docs.gitlab.com/ee/api/system_hooks.html#add-new-system-hook-hook
 func (s *SystemHooksService) AddHook(opt *AddHookOptions, options ...RequestOptionFunc) (*Hook, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodPost, "hooks", opt, options)
 	if err != nil {
@@ -123,7 +123,7 @@ func (s *SystemHooksService) AddHook(opt *AddHookOptions, options ...RequestOpti
 
 // HookEvent represents an event trigger by a GitLab system hook.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/system_hooks.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/system_hooks.html
 type HookEvent struct {
 	EventName  string `json:"event_name"`
 	Name       string `json:"name"`
@@ -140,7 +140,7 @@ func (h HookEvent) String() string {
 // TestHook tests a system hook.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/system_hooks.html#test-system-hook
+// https://docs.gitlab.com/ee/api/system_hooks.html#test-system-hook
 func (s *SystemHooksService) TestHook(hook int, options ...RequestOptionFunc) (*HookEvent, *Response, error) {
 	u := fmt.Sprintf("hooks/%d", hook)
 
@@ -163,7 +163,7 @@ func (s *SystemHooksService) TestHook(hook int, options ...RequestOptionFunc) (*
 // is also returned as JSON.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/system_hooks.html#delete-system-hook
+// https://docs.gitlab.com/ee/api/system_hooks.html#delete-system-hook
 func (s *SystemHooksService) DeleteHook(hook int, options ...RequestOptionFunc) (*Response, error) {
 	u := fmt.Sprintf("hooks/%d", hook)
 

--- a/tags.go
+++ b/tags.go
@@ -25,14 +25,14 @@ import (
 // TagsService handles communication with the tags related methods
 // of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/tags.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/tags.html
 type TagsService struct {
 	client *Client
 }
 
 // Tag represents a GitLab tag.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/tags.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/tags.html
 type Tag struct {
 	Commit    *Commit      `json:"commit"`
 	Release   *ReleaseNote `json:"release"`
@@ -44,7 +44,7 @@ type Tag struct {
 
 // ReleaseNote represents a GitLab version release.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/tags.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/tags.html
 type ReleaseNote struct {
 	TagName     string `json:"tag_name"`
 	Description string `json:"description"`
@@ -57,7 +57,7 @@ func (t Tag) String() string {
 // ListTagsOptions represents the available ListTags() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/tags.html#list-project-repository-tags
+// https://docs.gitlab.com/ee/api/tags.html#list-project-repository-tags
 type ListTagsOptions struct {
 	ListOptions
 	OrderBy *string `url:"order_by,omitempty" json:"order_by,omitempty"`
@@ -69,7 +69,7 @@ type ListTagsOptions struct {
 // alphabetical order.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/tags.html#list-project-repository-tags
+// https://docs.gitlab.com/ee/api/tags.html#list-project-repository-tags
 func (s *TagsService) ListTags(pid interface{}, opt *ListTagsOptions, options ...RequestOptionFunc) ([]*Tag, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -95,7 +95,7 @@ func (s *TagsService) ListTags(pid interface{}, opt *ListTagsOptions, options ..
 // with the tag information if the tag exists. It returns 404 if the tag does not exist.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/tags.html#get-a-single-repository-tag
+// https://docs.gitlab.com/ee/api/tags.html#get-a-single-repository-tag
 func (s *TagsService) GetTag(pid interface{}, tag string, options ...RequestOptionFunc) (*Tag, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -120,7 +120,7 @@ func (s *TagsService) GetTag(pid interface{}, tag string, options ...RequestOpti
 // CreateTagOptions represents the available CreateTag() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/tags.html#create-a-new-tag
+// https://docs.gitlab.com/ee/api/tags.html#create-a-new-tag
 type CreateTagOptions struct {
 	TagName *string `url:"tag_name,omitempty" json:"tag_name,omitempty"`
 	Ref     *string `url:"ref,omitempty" json:"ref,omitempty"`
@@ -133,7 +133,7 @@ type CreateTagOptions struct {
 // CreateTag creates a new tag in the repository that points to the supplied ref.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/tags.html#create-a-new-tag
+// https://docs.gitlab.com/ee/api/tags.html#create-a-new-tag
 func (s *TagsService) CreateTag(pid interface{}, opt *CreateTagOptions, options ...RequestOptionFunc) (*Tag, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -158,7 +158,7 @@ func (s *TagsService) CreateTag(pid interface{}, opt *CreateTagOptions, options 
 // DeleteTag deletes a tag of a repository with given name.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/tags.html#delete-a-tag
+// https://docs.gitlab.com/ee/api/tags.html#delete-a-tag
 func (s *TagsService) DeleteTag(pid interface{}, tag string, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -179,7 +179,7 @@ func (s *TagsService) DeleteTag(pid interface{}, tag string, options ...RequestO
 // Deprecated: This feature was deprecated in GitLab 11.7.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/tags.html#create-a-new-release
+// https://docs.gitlab.com/ee/api/tags.html#create-a-new-release
 type CreateReleaseNoteOptions struct {
 	Description *string `url:"description:omitempty" json:"description,omitempty"`
 }
@@ -190,7 +190,7 @@ type CreateReleaseNoteOptions struct {
 // Deprecated: This feature was deprecated in GitLab 11.7.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/tags.html#create-a-new-release
+// https://docs.gitlab.com/ee/api/tags.html#create-a-new-release
 func (s *TagsService) CreateReleaseNote(pid interface{}, tag string, opt *CreateReleaseNoteOptions, options ...RequestOptionFunc) (*ReleaseNote, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -215,7 +215,7 @@ func (s *TagsService) CreateReleaseNote(pid interface{}, tag string, opt *Create
 // UpdateReleaseNoteOptions represents the available UpdateReleaseNote() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/tags.html#update-a-release
+// https://docs.gitlab.com/ee/api/tags.html#update-a-release
 type UpdateReleaseNoteOptions struct {
 	Description *string `url:"description:omitempty" json:"description,omitempty"`
 }
@@ -225,7 +225,7 @@ type UpdateReleaseNoteOptions struct {
 // Deprecated: This feature was deprecated in GitLab 11.7.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/tags.html#update-a-release
+// https://docs.gitlab.com/ee/api/tags.html#update-a-release
 func (s *TagsService) UpdateReleaseNote(pid interface{}, tag string, opt *UpdateReleaseNoteOptions, options ...RequestOptionFunc) (*ReleaseNote, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/time_stats.go
+++ b/time_stats.go
@@ -24,14 +24,14 @@ import (
 // timeStatsService handles communication with the time tracking related
 // methods of the GitLab API.
 //
-// GitLab docs: https://docs.gitlab.com/ce/workflow/time_tracking.html
+// GitLab docs: https://docs.gitlab.com/ee/workflow/time_tracking.html
 type timeStatsService struct {
 	client *Client
 }
 
 // TimeStats represents the time estimates and time spent for an issue.
 //
-// GitLab docs: https://docs.gitlab.com/ce/workflow/time_tracking.html
+// GitLab docs: https://docs.gitlab.com/ee/workflow/time_tracking.html
 type TimeStats struct {
 	HumanTimeEstimate   string `json:"human_time_estimate"`
 	HumanTotalTimeSpent string `json:"human_total_time_spent"`
@@ -46,14 +46,14 @@ func (t TimeStats) String() string {
 // SetTimeEstimateOptions represents the available SetTimeEstimate()
 // options.
 //
-// GitLab docs: https://docs.gitlab.com/ce/workflow/time_tracking.html
+// GitLab docs: https://docs.gitlab.com/ee/workflow/time_tracking.html
 type SetTimeEstimateOptions struct {
 	Duration *string `url:"duration,omitempty" json:"duration,omitempty"`
 }
 
 // setTimeEstimate sets the time estimate for a single project issue.
 //
-// GitLab docs: https://docs.gitlab.com/ce/workflow/time_tracking.html
+// GitLab docs: https://docs.gitlab.com/ee/workflow/time_tracking.html
 func (s *timeStatsService) setTimeEstimate(pid interface{}, entity string, issue int, opt *SetTimeEstimateOptions, options ...RequestOptionFunc) (*TimeStats, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -77,7 +77,7 @@ func (s *timeStatsService) setTimeEstimate(pid interface{}, entity string, issue
 
 // resetTimeEstimate resets the time estimate for a single project issue.
 //
-// GitLab docs: https://docs.gitlab.com/ce/workflow/time_tracking.html
+// GitLab docs: https://docs.gitlab.com/ee/workflow/time_tracking.html
 func (s *timeStatsService) resetTimeEstimate(pid interface{}, entity string, issue int, options ...RequestOptionFunc) (*TimeStats, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -101,14 +101,14 @@ func (s *timeStatsService) resetTimeEstimate(pid interface{}, entity string, iss
 
 // AddSpentTimeOptions represents the available AddSpentTime() options.
 //
-// GitLab docs: https://docs.gitlab.com/ce/workflow/time_tracking.html
+// GitLab docs: https://docs.gitlab.com/ee/workflow/time_tracking.html
 type AddSpentTimeOptions struct {
 	Duration *string `url:"duration,omitempty" json:"duration,omitempty"`
 }
 
 // addSpentTime adds spent time for a single project issue.
 //
-// GitLab docs: https://docs.gitlab.com/ce/workflow/time_tracking.html
+// GitLab docs: https://docs.gitlab.com/ee/workflow/time_tracking.html
 func (s *timeStatsService) addSpentTime(pid interface{}, entity string, issue int, opt *AddSpentTimeOptions, options ...RequestOptionFunc) (*TimeStats, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -132,7 +132,7 @@ func (s *timeStatsService) addSpentTime(pid interface{}, entity string, issue in
 
 // resetSpentTime resets the spent time for a single project issue.
 //
-// GitLab docs: https://docs.gitlab.com/ce/workflow/time_tracking.html
+// GitLab docs: https://docs.gitlab.com/ee/workflow/time_tracking.html
 func (s *timeStatsService) resetSpentTime(pid interface{}, entity string, issue int, options ...RequestOptionFunc) (*TimeStats, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -156,7 +156,7 @@ func (s *timeStatsService) resetSpentTime(pid interface{}, entity string, issue 
 
 // getTimeSpent gets the spent time for a single project issue.
 //
-// GitLab docs: https://docs.gitlab.com/ce/workflow/time_tracking.html
+// GitLab docs: https://docs.gitlab.com/ee/workflow/time_tracking.html
 func (s *timeStatsService) getTimeSpent(pid interface{}, entity string, issue int, options ...RequestOptionFunc) (*TimeStats, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/todos.go
+++ b/todos.go
@@ -25,14 +25,14 @@ import (
 // TodosService handles communication with the todos related methods of
 // the Gitlab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/todos.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/todos.html
 type TodosService struct {
 	client *Client
 }
 
 // Todo represents a GitLab todo.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/todos.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/todos.html
 type Todo struct {
 	ID         int            `json:"id"`
 	Project    *BasicProject  `json:"project"`
@@ -105,7 +105,7 @@ type TodoTarget struct {
 
 // ListTodosOptions represents the available ListTodos() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/todos.html#get-a-list-of-todos
+// GitLab API docs: https://docs.gitlab.com/ee/api/todos.html#get-a-list-of-todos
 type ListTodosOptions struct {
 	ListOptions
 	Action    *TodoAction `url:"action,omitempty" json:"action,omitempty"`
@@ -119,7 +119,7 @@ type ListTodosOptions struct {
 // When no filter is applied, it returns all pending todos for the current user.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/todos.html#get-a-list-of-todos
+// https://docs.gitlab.com/ee/api/todos.html#get-a-list-of-todos
 func (s *TodosService) ListTodos(opt *ListTodosOptions, options ...RequestOptionFunc) ([]*Todo, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "todos", opt, options)
 	if err != nil {
@@ -137,7 +137,7 @@ func (s *TodosService) ListTodos(opt *ListTodosOptions, options ...RequestOption
 
 // MarkTodoAsDone marks a single pending todo given by its ID for the current user as done.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/todos.html#mark-a-todo-as-done
+// GitLab API docs: https://docs.gitlab.com/ee/api/todos.html#mark-a-todo-as-done
 func (s *TodosService) MarkTodoAsDone(id int, options ...RequestOptionFunc) (*Response, error) {
 	u := fmt.Sprintf("todos/%d/mark_as_done", id)
 
@@ -151,7 +151,7 @@ func (s *TodosService) MarkTodoAsDone(id int, options ...RequestOptionFunc) (*Re
 
 // MarkAllTodosAsDone marks all pending todos for the current user as done.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/todos.html#mark-all-todos-as-done
+// GitLab API docs: https://docs.gitlab.com/ee/api/todos.html#mark-all-todos-as-done
 func (s *TodosService) MarkAllTodosAsDone(options ...RequestOptionFunc) (*Response, error) {
 	req, err := s.client.NewRequest(http.MethodPost, "todos/mark_as_done", nil, options)
 	if err != nil {

--- a/todos.go
+++ b/todos.go
@@ -105,7 +105,7 @@ type TodoTarget struct {
 
 // ListTodosOptions represents the available ListTodos() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/todos.html#get-a-list-of-todos
+// GitLab API docs: https://docs.gitlab.com/ee/api/todos.html#get-a-list-of-to-do-items
 type ListTodosOptions struct {
 	ListOptions
 	Action    *TodoAction `url:"action,omitempty" json:"action,omitempty"`
@@ -119,7 +119,7 @@ type ListTodosOptions struct {
 // When no filter is applied, it returns all pending todos for the current user.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/todos.html#get-a-list-of-todos
+// https://docs.gitlab.com/ee/api/todos.html#get-a-list-of-to-do-items
 func (s *TodosService) ListTodos(opt *ListTodosOptions, options ...RequestOptionFunc) ([]*Todo, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "todos", opt, options)
 	if err != nil {
@@ -137,7 +137,7 @@ func (s *TodosService) ListTodos(opt *ListTodosOptions, options ...RequestOption
 
 // MarkTodoAsDone marks a single pending todo given by its ID for the current user as done.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/todos.html#mark-a-todo-as-done
+// GitLab API docs: https://docs.gitlab.com/ee/api/todos.html#mark-a-to-do-item-as-done
 func (s *TodosService) MarkTodoAsDone(id int, options ...RequestOptionFunc) (*Response, error) {
 	u := fmt.Sprintf("todos/%d/mark_as_done", id)
 
@@ -151,7 +151,7 @@ func (s *TodosService) MarkTodoAsDone(id int, options ...RequestOptionFunc) (*Re
 
 // MarkAllTodosAsDone marks all pending todos for the current user as done.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/todos.html#mark-all-todos-as-done
+// GitLab API docs: https://docs.gitlab.com/ee/api/todos.html#mark-all-to-do-items-as-done
 func (s *TodosService) MarkAllTodosAsDone(options ...RequestOptionFunc) (*Response, error) {
 	req, err := s.client.NewRequest(http.MethodPost, "todos/mark_as_done", nil, options)
 	if err != nil {

--- a/types.go
+++ b/types.go
@@ -52,12 +52,12 @@ func AccessControl(v AccessControlValue) *AccessControlValue {
 
 // AccessLevelValue represents a permission level within GitLab.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/permissions/permissions.html
+// GitLab API docs: https://docs.gitlab.com/ee/user/permissions.html
 type AccessLevelValue int
 
 // List of available access levels
 //
-// GitLab API docs: https://docs.gitlab.com/ee/permissions/permissions.html
+// GitLab API docs: https://docs.gitlab.com/ee/user/permissions.html
 const (
 	NoPermissions            AccessLevelValue = 0
 	MinimalAccessPermissions AccessLevelValue = 5
@@ -269,7 +269,7 @@ type EventTypeValue string
 
 // List of available action type
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/events.html#action-types
+// GitLab API docs: https://docs.gitlab.com/ee/user/profile/contributions_calendar.html#user-contribution-events
 const (
 	CreatedEventType   EventTypeValue = "created"
 	UpdatedEventType   EventTypeValue = "updated"
@@ -413,7 +413,7 @@ type LinkTypeValue string
 // List of available release link types
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/releases/links.html#create-a-link
+// https://docs.gitlab.com/ee/api/releases/links.html#create-a-release-link
 const (
 	ImageLinkType   LinkTypeValue = "image"
 	OtherLinkType   LinkTypeValue = "other"

--- a/types.go
+++ b/types.go
@@ -29,12 +29,12 @@ import (
 // AccessControlValue represents an access control value within GitLab,
 // used for managing access to certain project features.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/projects.html
 type AccessControlValue string
 
 // List of available access control values.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/projects.html
 const (
 	DisabledAccessControl AccessControlValue = "disabled"
 	EnabledAccessControl  AccessControlValue = "enabled"
@@ -52,12 +52,12 @@ func AccessControl(v AccessControlValue) *AccessControlValue {
 
 // AccessLevelValue represents a permission level within GitLab.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/permissions/permissions.html
+// GitLab API docs: https://docs.gitlab.com/ee/permissions/permissions.html
 type AccessLevelValue int
 
 // List of available access levels
 //
-// GitLab API docs: https://docs.gitlab.com/ce/permissions/permissions.html
+// GitLab API docs: https://docs.gitlab.com/ee/permissions/permissions.html
 const (
 	NoPermissions            AccessLevelValue = 0
 	MinimalAccessPermissions AccessLevelValue = 5
@@ -269,7 +269,7 @@ type EventTypeValue string
 
 // List of available action type
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/events.html#action-types
+// GitLab API docs: https://docs.gitlab.com/ee/api/events.html#action-types
 const (
 	CreatedEventType   EventTypeValue = "created"
 	UpdatedEventType   EventTypeValue = "updated"
@@ -289,7 +289,7 @@ type EventTargetTypeValue string
 
 // List of available action type
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/events.html#target-types
+// GitLab API docs: https://docs.gitlab.com/ee/api/events.html#target-types
 const (
 	IssueEventTargetType        EventTargetTypeValue = "issue"
 	MilestoneEventTargetType    EventTargetTypeValue = "milestone"
@@ -302,7 +302,7 @@ const (
 
 // FileActionValue represents the available actions that can be performed on a file.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/commits.html#create-a-commit-with-multiple-files-and-actions
+// GitLab API docs: https://docs.gitlab.com/ee/api/commits.html#create-a-commit-with-multiple-files-and-actions
 type FileActionValue string
 
 // The available file actions.
@@ -452,12 +452,12 @@ func LicenseApprovalStatus(v LicenseApprovalStatusValue) *LicenseApprovalStatusV
 
 // MergeMethodValue represents a project merge type within GitLab.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#project-merge-method
+// GitLab API docs: https://docs.gitlab.com/ee/api/projects.html#project-merge-method
 type MergeMethodValue string
 
 // List of available merge type
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#project-merge-method
+// GitLab API docs: https://docs.gitlab.com/ee/api/projects.html#project-merge-method
 const (
 	NoFastForwardMerge MergeMethodValue = "merge"
 	FastForwardMerge   MergeMethodValue = "ff"
@@ -563,12 +563,12 @@ func NotificationLevel(v NotificationLevelValue) *NotificationLevelValue {
 
 // ProjectCreationLevelValue represents a project creation level within GitLab.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/
+// GitLab API docs: https://docs.gitlab.com/ee/api/
 type ProjectCreationLevelValue string
 
 // List of available project creation levels.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/
+// GitLab API docs: https://docs.gitlab.com/ee/api/
 const (
 	NoOneProjectCreation      ProjectCreationLevelValue = "noone"
 	MaintainerProjectCreation ProjectCreationLevelValue = "maintainer"
@@ -610,12 +610,12 @@ func SharedRunnersSetting(v SharedRunnersSettingValue) *SharedRunnersSettingValu
 
 // SubGroupCreationLevelValue represents a sub group creation level within GitLab.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/
+// GitLab API docs: https://docs.gitlab.com/ee/api/
 type SubGroupCreationLevelValue string
 
 // List of available sub group creation levels.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/
+// GitLab API docs: https://docs.gitlab.com/ee/api/
 const (
 	OwnerSubGroupCreationLevelValue      SubGroupCreationLevelValue = "owner"
 	MaintainerSubGroupCreationLevelValue SubGroupCreationLevelValue = "maintainer"
@@ -660,7 +660,7 @@ type TasksCompletionStatus struct {
 
 // TodoAction represents the available actions that can be performed on a todo.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/todos.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/todos.html
 type TodoAction string
 
 // The available todo actions.
@@ -675,7 +675,7 @@ const (
 
 // TodoTargetType represents the available target that can be linked to a todo.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/todos.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/todos.html
 type TodoTargetType string
 
 const (
@@ -696,12 +696,12 @@ const (
 
 // VariableTypeValue represents a variable type within GitLab.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/
+// GitLab API docs: https://docs.gitlab.com/ee/api/
 type VariableTypeValue string
 
 // List of available variable types.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/
+// GitLab API docs: https://docs.gitlab.com/ee/api/
 const (
 	EnvVariableType  VariableTypeValue = "env_var"
 	FileVariableType VariableTypeValue = "file"
@@ -717,12 +717,12 @@ func VariableType(v VariableTypeValue) *VariableTypeValue {
 
 // VisibilityValue represents a visibility level within GitLab.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/
+// GitLab API docs: https://docs.gitlab.com/ee/api/
 type VisibilityValue string
 
 // List of available visibility levels.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/
+// GitLab API docs: https://docs.gitlab.com/ee/api/
 const (
 	PrivateVisibility  VisibilityValue = "private"
 	InternalVisibility VisibilityValue = "internal"
@@ -739,7 +739,7 @@ func Visibility(v VisibilityValue) *VisibilityValue {
 
 // WikiFormatValue represents the available wiki formats.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/wikis.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/wikis.html
 type WikiFormatValue string
 
 // The available wiki formats.

--- a/users.go
+++ b/users.go
@@ -41,7 +41,7 @@ var (
 // UsersService handles communication with the user related methods of
 // the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/users.html
 type UsersService struct {
 	client *Client
 }
@@ -113,7 +113,7 @@ type UserIdentity struct {
 
 // ListUsersOptions represents the available ListUsers() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#list-users
+// GitLab API docs: https://docs.gitlab.com/ee/api/users.html#list-users
 type ListUsersOptions struct {
 	ListOptions
 	Active          *bool `url:"active,omitempty" json:"active,omitempty"`
@@ -140,7 +140,7 @@ type ListUsersOptions struct {
 
 // ListUsers gets a list of users.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#list-users
+// GitLab API docs: https://docs.gitlab.com/ee/api/users.html#list-users
 func (s *UsersService) ListUsers(opt *ListUsersOptions, options ...RequestOptionFunc) ([]*User, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "users", opt, options)
 	if err != nil {
@@ -158,14 +158,14 @@ func (s *UsersService) ListUsers(opt *ListUsersOptions, options ...RequestOption
 
 // GetUsersOptions represents the available GetUser() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#single-user
+// GitLab API docs: https://docs.gitlab.com/ee/api/users.html#single-user
 type GetUsersOptions struct {
 	WithCustomAttributes *bool `url:"with_custom_attributes,omitempty" json:"with_custom_attributes,omitempty"`
 }
 
 // GetUser gets a single user.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#single-user
+// GitLab API docs: https://docs.gitlab.com/ee/api/users.html#single-user
 func (s *UsersService) GetUser(user int, opt GetUsersOptions, options ...RequestOptionFunc) (*User, *Response, error) {
 	u := fmt.Sprintf("users/%d", user)
 
@@ -185,7 +185,7 @@ func (s *UsersService) GetUser(user int, opt GetUsersOptions, options ...Request
 
 // CreateUserOptions represents the available CreateUser() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#user-creation
+// GitLab API docs: https://docs.gitlab.com/ee/api/users.html#user-creation
 type CreateUserOptions struct {
 	Email               *string `url:"email,omitempty" json:"email,omitempty"`
 	Password            *string `url:"password,omitempty" json:"password,omitempty"`
@@ -215,7 +215,7 @@ type CreateUserOptions struct {
 
 // CreateUser creates a new user. Note only administrators can create new users.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#user-creation
+// GitLab API docs: https://docs.gitlab.com/ee/api/users.html#user-creation
 func (s *UsersService) CreateUser(opt *CreateUserOptions, options ...RequestOptionFunc) (*User, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodPost, "users", opt, options)
 	if err != nil {
@@ -233,7 +233,7 @@ func (s *UsersService) CreateUser(opt *CreateUserOptions, options ...RequestOpti
 
 // ModifyUserOptions represents the available ModifyUser() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#user-modification
+// GitLab API docs: https://docs.gitlab.com/ee/api/users.html#user-modification
 type ModifyUserOptions struct {
 	Email              *string `url:"email,omitempty" json:"email,omitempty"`
 	Password           *string `url:"password,omitempty" json:"password,omitempty"`
@@ -264,7 +264,7 @@ type ModifyUserOptions struct {
 // ModifyUser modifies an existing user. Only administrators can change attributes
 // of a user.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#user-modification
+// GitLab API docs: https://docs.gitlab.com/ee/api/users.html#user-modification
 func (s *UsersService) ModifyUser(user int, opt *ModifyUserOptions, options ...RequestOptionFunc) (*User, *Response, error) {
 	u := fmt.Sprintf("users/%d", user)
 
@@ -288,7 +288,7 @@ func (s *UsersService) ModifyUser(user int, opt *ModifyUserOptions, options ...R
 // actually deleted or not. In the former the user is returned and in the
 // latter not.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#user-deletion
+// GitLab API docs: https://docs.gitlab.com/ee/api/users.html#user-deletion
 func (s *UsersService) DeleteUser(user int, options ...RequestOptionFunc) (*Response, error) {
 	u := fmt.Sprintf("users/%d", user)
 
@@ -302,7 +302,7 @@ func (s *UsersService) DeleteUser(user int, options ...RequestOptionFunc) (*Resp
 
 // CurrentUser gets currently authenticated user.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#current-user
+// GitLab API docs: https://docs.gitlab.com/ee/api/users.html#current-user
 func (s *UsersService) CurrentUser(options ...RequestOptionFunc) (*User, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "user", nil, options)
 	if err != nil {
@@ -321,7 +321,7 @@ func (s *UsersService) CurrentUser(options ...RequestOptionFunc) (*User, *Respon
 // UserStatus represents the current status of a user
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/users.html#user-status
+// https://docs.gitlab.com/ee/api/users.html#user-status
 type UserStatus struct {
 	Emoji        string            `json:"emoji"`
 	Availability AvailabilityValue `json:"availability"`
@@ -332,7 +332,7 @@ type UserStatus struct {
 // CurrentUserStatus retrieves the user status
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/users.html#user-status
+// https://docs.gitlab.com/ee/api/users.html#user-status
 func (s *UsersService) CurrentUserStatus(options ...RequestOptionFunc) (*UserStatus, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "user/status", nil, options)
 	if err != nil {
@@ -351,7 +351,7 @@ func (s *UsersService) CurrentUserStatus(options ...RequestOptionFunc) (*UserSta
 // GetUserStatus retrieves a user's status
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/users.html#get-the-status-of-a-user
+// https://docs.gitlab.com/ee/api/users.html#get-the-status-of-a-user
 func (s *UsersService) GetUserStatus(user int, options ...RequestOptionFunc) (*UserStatus, *Response, error) {
 	u := fmt.Sprintf("users/%d/status", user)
 
@@ -372,7 +372,7 @@ func (s *UsersService) GetUserStatus(user int, options ...RequestOptionFunc) (*U
 // UserStatusOptions represents the options required to set the status
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/users.html#set-user-status
+// https://docs.gitlab.com/ee/api/users.html#set-user-status
 type UserStatusOptions struct {
 	Emoji        *string            `url:"emoji,omitempty" json:"emoji,omitempty"`
 	Availability *AvailabilityValue `url:"availability,omitempty" json:"availability,omitempty"`
@@ -382,7 +382,7 @@ type UserStatusOptions struct {
 // SetUserStatus sets the user's status
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/users.html#set-user-status
+// https://docs.gitlab.com/ee/api/users.html#set-user-status
 func (s *UsersService) SetUserStatus(opt *UserStatusOptions, options ...RequestOptionFunc) (*UserStatus, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodPut, "user/status", opt, options)
 	if err != nil {
@@ -400,7 +400,7 @@ func (s *UsersService) SetUserStatus(opt *UserStatusOptions, options ...RequestO
 
 // SSHKey represents a SSH key.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#list-ssh-keys
+// GitLab API docs: https://docs.gitlab.com/ee/api/users.html#list-ssh-keys
 type SSHKey struct {
 	ID        int        `json:"id"`
 	Title     string     `json:"title"`
@@ -411,7 +411,7 @@ type SSHKey struct {
 
 // ListSSHKeys gets a list of currently authenticated user's SSH keys.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#list-ssh-keys
+// GitLab API docs: https://docs.gitlab.com/ee/api/users.html#list-ssh-keys
 func (s *UsersService) ListSSHKeys(options ...RequestOptionFunc) ([]*SSHKey, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "user/keys", nil, options)
 	if err != nil {
@@ -430,13 +430,13 @@ func (s *UsersService) ListSSHKeys(options ...RequestOptionFunc) ([]*SSHKey, *Re
 // ListSSHKeysForUserOptions represents the available ListSSHKeysForUser() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/users.html#list-ssh-keys-for-user
+// https://docs.gitlab.com/ee/api/users.html#list-ssh-keys-for-user
 type ListSSHKeysForUserOptions ListOptions
 
 // ListSSHKeysForUser gets a list of a specified user's SSH keys.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/users.html#list-ssh-keys-for-user
+// https://docs.gitlab.com/ee/api/users.html#list-ssh-keys-for-user
 func (s *UsersService) ListSSHKeysForUser(uid interface{}, opt *ListSSHKeysForUserOptions, options ...RequestOptionFunc) ([]*SSHKey, *Response, error) {
 	user, err := parseID(uid)
 	if err != nil {
@@ -460,7 +460,7 @@ func (s *UsersService) ListSSHKeysForUser(uid interface{}, opt *ListSSHKeysForUs
 
 // GetSSHKey gets a single key.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#single-ssh-key
+// GitLab API docs: https://docs.gitlab.com/ee/api/users.html#single-ssh-key
 func (s *UsersService) GetSSHKey(key int, options ...RequestOptionFunc) (*SSHKey, *Response, error) {
 	u := fmt.Sprintf("user/keys/%d", key)
 
@@ -500,7 +500,7 @@ func (s *UsersService) GetSSHKeyForUser(user int, key int, options ...RequestOpt
 
 // AddSSHKeyOptions represents the available AddSSHKey() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#add-ssh-key
+// GitLab API docs: https://docs.gitlab.com/ee/api/projects.html#add-ssh-key
 type AddSSHKeyOptions struct {
 	Title     *string  `url:"title,omitempty" json:"title,omitempty"`
 	Key       *string  `url:"key,omitempty" json:"key,omitempty"`
@@ -509,7 +509,7 @@ type AddSSHKeyOptions struct {
 
 // AddSSHKey creates a new key owned by the currently authenticated user.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#add-ssh-key
+// GitLab API docs: https://docs.gitlab.com/ee/api/users.html#add-ssh-key
 func (s *UsersService) AddSSHKey(opt *AddSSHKeyOptions, options ...RequestOptionFunc) (*SSHKey, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodPost, "user/keys", opt, options)
 	if err != nil {
@@ -528,7 +528,7 @@ func (s *UsersService) AddSSHKey(opt *AddSSHKeyOptions, options ...RequestOption
 // AddSSHKeyForUser creates new key owned by specified user. Available only for
 // admin.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#add-ssh-key-for-user
+// GitLab API docs: https://docs.gitlab.com/ee/api/users.html#add-ssh-key-for-user
 func (s *UsersService) AddSSHKeyForUser(user int, opt *AddSSHKeyOptions, options ...RequestOptionFunc) (*SSHKey, *Response, error) {
 	u := fmt.Sprintf("users/%d/keys", user)
 
@@ -551,7 +551,7 @@ func (s *UsersService) AddSSHKeyForUser(user int, opt *AddSSHKeyOptions, options
 // available results in 200 OK.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/users.html#delete-ssh-key-for-current-owner
+// https://docs.gitlab.com/ee/api/users.html#delete-ssh-key-for-current-owner
 func (s *UsersService) DeleteSSHKey(key int, options ...RequestOptionFunc) (*Response, error) {
 	u := fmt.Sprintf("user/keys/%d", key)
 
@@ -567,7 +567,7 @@ func (s *UsersService) DeleteSSHKey(key int, options ...RequestOptionFunc) (*Res
 // for admin.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/users.html#delete-ssh-key-for-given-user
+// https://docs.gitlab.com/ee/api/users.html#delete-ssh-key-for-given-user
 func (s *UsersService) DeleteSSHKeyForUser(user, key int, options ...RequestOptionFunc) (*Response, error) {
 	u := fmt.Sprintf("users/%d/keys/%d", user, key)
 
@@ -581,7 +581,7 @@ func (s *UsersService) DeleteSSHKeyForUser(user, key int, options ...RequestOpti
 
 // GPGKey represents a GPG key.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#list-all-gpg-keys
+// GitLab API docs: https://docs.gitlab.com/ee/api/users.html#list-all-gpg-keys
 type GPGKey struct {
 	ID        int        `json:"id"`
 	Key       string     `json:"key"`
@@ -590,7 +590,7 @@ type GPGKey struct {
 
 // ListGPGKeys gets a list of currently authenticated user’s GPG keys.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#list-all-gpg-keys
+// GitLab API docs: https://docs.gitlab.com/ee/api/users.html#list-all-gpg-keys
 func (s *UsersService) ListGPGKeys(options ...RequestOptionFunc) ([]*GPGKey, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "user/gpg_keys", nil, options)
 	if err != nil {
@@ -608,7 +608,7 @@ func (s *UsersService) ListGPGKeys(options ...RequestOptionFunc) ([]*GPGKey, *Re
 
 // GetGPGKey gets a specific GPG key of currently authenticated user.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#get-a-specific-gpg-key
+// GitLab API docs: https://docs.gitlab.com/ee/api/users.html#get-a-specific-gpg-key
 func (s *UsersService) GetGPGKey(key int, options ...RequestOptionFunc) (*GPGKey, *Response, error) {
 	u := fmt.Sprintf("user/gpg_keys/%d", key)
 
@@ -628,14 +628,14 @@ func (s *UsersService) GetGPGKey(key int, options ...RequestOptionFunc) (*GPGKey
 
 // AddGPGKeyOptions represents the available AddGPGKey() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#add-a-gpg-key
+// GitLab API docs: https://docs.gitlab.com/ee/api/users.html#add-a-gpg-key
 type AddGPGKeyOptions struct {
 	Key *string `url:"key,omitempty" json:"key,omitempty"`
 }
 
 // AddGPGKey creates a new GPG key owned by the currently authenticated user.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#add-a-gpg-key
+// GitLab API docs: https://docs.gitlab.com/ee/api/users.html#add-a-gpg-key
 func (s *UsersService) AddGPGKey(opt *AddGPGKeyOptions, options ...RequestOptionFunc) (*GPGKey, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodPost, "user/gpg_keys", opt, options)
 	if err != nil {
@@ -653,7 +653,7 @@ func (s *UsersService) AddGPGKey(opt *AddGPGKeyOptions, options ...RequestOption
 
 // DeleteGPGKey deletes a GPG key owned by currently authenticated user.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#delete-a-gpg-key
+// GitLab API docs: https://docs.gitlab.com/ee/api/users.html#delete-a-gpg-key
 func (s *UsersService) DeleteGPGKey(key int, options ...RequestOptionFunc) (*Response, error) {
 	u := fmt.Sprintf("user/gpg_keys/%d", key)
 
@@ -668,7 +668,7 @@ func (s *UsersService) DeleteGPGKey(key int, options ...RequestOptionFunc) (*Res
 // ListGPGKeysForUser gets a list of a specified user’s GPG keys.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/users.html#list-all-gpg-keys-for-given-user
+// https://docs.gitlab.com/ee/api/users.html#list-all-gpg-keys-for-given-user
 func (s *UsersService) ListGPGKeysForUser(user int, options ...RequestOptionFunc) ([]*GPGKey, *Response, error) {
 	u := fmt.Sprintf("users/%d/gpg_keys", user)
 
@@ -688,7 +688,7 @@ func (s *UsersService) ListGPGKeysForUser(user int, options ...RequestOptionFunc
 
 // GetGPGKeyForUser gets a specific GPG key for a given user.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#get-a-specific-gpg-key-for-a-given-user
+// GitLab API docs: https://docs.gitlab.com/ee/api/users.html#get-a-specific-gpg-key-for-a-given-user
 func (s *UsersService) GetGPGKeyForUser(user, key int, options ...RequestOptionFunc) (*GPGKey, *Response, error) {
 	u := fmt.Sprintf("users/%d/gpg_keys/%d", user, key)
 
@@ -709,7 +709,7 @@ func (s *UsersService) GetGPGKeyForUser(user, key int, options ...RequestOptionF
 // AddGPGKeyForUser creates new GPG key owned by the specified user.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/users.html#add-a-gpg-key-for-a-given-user
+// https://docs.gitlab.com/ee/api/users.html#add-a-gpg-key-for-a-given-user
 func (s *UsersService) AddGPGKeyForUser(user int, opt *AddGPGKeyOptions, options ...RequestOptionFunc) (*GPGKey, *Response, error) {
 	u := fmt.Sprintf("users/%d/gpg_keys", user)
 
@@ -730,7 +730,7 @@ func (s *UsersService) AddGPGKeyForUser(user int, opt *AddGPGKeyOptions, options
 // DeleteGPGKeyForUser deletes a GPG key owned by a specified user.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/users.html#delete-a-gpg-key-for-a-given-user
+// https://docs.gitlab.com/ee/api/users.html#delete-a-gpg-key-for-a-given-user
 func (s *UsersService) DeleteGPGKeyForUser(user, key int, options ...RequestOptionFunc) (*Response, error) {
 	u := fmt.Sprintf("users/%d/gpg_keys/%d", user, key)
 
@@ -744,7 +744,7 @@ func (s *UsersService) DeleteGPGKeyForUser(user, key int, options ...RequestOpti
 
 // Email represents an Email.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#list-emails
+// GitLab API docs: https://docs.gitlab.com/ee/api/users.html#list-emails
 type Email struct {
 	ID          int        `json:"id"`
 	Email       string     `json:"email"`
@@ -753,7 +753,7 @@ type Email struct {
 
 // ListEmails gets a list of currently authenticated user's Emails.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#list-emails
+// GitLab API docs: https://docs.gitlab.com/ee/api/users.html#list-emails
 func (s *UsersService) ListEmails(options ...RequestOptionFunc) ([]*Email, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "user/emails", nil, options)
 	if err != nil {
@@ -772,14 +772,14 @@ func (s *UsersService) ListEmails(options ...RequestOptionFunc) ([]*Email, *Resp
 // ListEmailsForUserOptions represents the available ListEmailsForUser() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/users.html#list-emails-for-user
+// https://docs.gitlab.com/ee/api/users.html#list-emails-for-user
 type ListEmailsForUserOptions ListOptions
 
 // ListEmailsForUser gets a list of a specified user's Emails. Available
 // only for admin
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/users.html#list-emails-for-user
+// https://docs.gitlab.com/ee/api/users.html#list-emails-for-user
 func (s *UsersService) ListEmailsForUser(user int, opt *ListEmailsForUserOptions, options ...RequestOptionFunc) ([]*Email, *Response, error) {
 	u := fmt.Sprintf("users/%d/emails", user)
 
@@ -799,7 +799,7 @@ func (s *UsersService) ListEmailsForUser(user int, opt *ListEmailsForUserOptions
 
 // GetEmail gets a single email.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#single-email
+// GitLab API docs: https://docs.gitlab.com/ee/api/users.html#single-email
 func (s *UsersService) GetEmail(email int, options ...RequestOptionFunc) (*Email, *Response, error) {
 	u := fmt.Sprintf("user/emails/%d", email)
 
@@ -819,7 +819,7 @@ func (s *UsersService) GetEmail(email int, options ...RequestOptionFunc) (*Email
 
 // AddEmailOptions represents the available AddEmail() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#add-email
+// GitLab API docs: https://docs.gitlab.com/ee/api/users.html#add-email
 type AddEmailOptions struct {
 	Email            *string `url:"email,omitempty" json:"email,omitempty"`
 	SkipConfirmation *bool   `url:"skip_confirmation,omitempty" json:"skip_confirmation,omitempty"`
@@ -827,7 +827,7 @@ type AddEmailOptions struct {
 
 // AddEmail creates a new email owned by the currently authenticated user.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#add-email
+// GitLab API docs: https://docs.gitlab.com/ee/api/users.html#add-email
 func (s *UsersService) AddEmail(opt *AddEmailOptions, options ...RequestOptionFunc) (*Email, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodPost, "user/emails", opt, options)
 	if err != nil {
@@ -846,7 +846,7 @@ func (s *UsersService) AddEmail(opt *AddEmailOptions, options ...RequestOptionFu
 // AddEmailForUser creates new email owned by specified user. Available only for
 // admin.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#add-email-for-user
+// GitLab API docs: https://docs.gitlab.com/ee/api/users.html#add-email-for-user
 func (s *UsersService) AddEmailForUser(user int, opt *AddEmailOptions, options ...RequestOptionFunc) (*Email, *Response, error) {
 	u := fmt.Sprintf("users/%d/emails", user)
 
@@ -869,7 +869,7 @@ func (s *UsersService) AddEmailForUser(user int, opt *AddEmailOptions, options .
 // available results in 200 OK.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/users.html#delete-email-for-current-owner
+// https://docs.gitlab.com/ee/api/users.html#delete-email-for-current-owner
 func (s *UsersService) DeleteEmail(email int, options ...RequestOptionFunc) (*Response, error) {
 	u := fmt.Sprintf("user/emails/%d", email)
 
@@ -885,7 +885,7 @@ func (s *UsersService) DeleteEmail(email int, options ...RequestOptionFunc) (*Re
 // for admin.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/users.html#delete-email-for-given-user
+// https://docs.gitlab.com/ee/api/users.html#delete-email-for-given-user
 func (s *UsersService) DeleteEmailForUser(user, email int, options ...RequestOptionFunc) (*Response, error) {
 	u := fmt.Sprintf("users/%d/emails/%d", user, email)
 
@@ -899,7 +899,7 @@ func (s *UsersService) DeleteEmailForUser(user, email int, options ...RequestOpt
 
 // BlockUser blocks the specified user. Available only for admin.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#block-user
+// GitLab API docs: https://docs.gitlab.com/ee/api/users.html#block-user
 func (s *UsersService) BlockUser(user int, options ...RequestOptionFunc) error {
 	u := fmt.Sprintf("users/%d/block", user)
 
@@ -927,7 +927,7 @@ func (s *UsersService) BlockUser(user int, options ...RequestOptionFunc) error {
 
 // UnblockUser unblocks the specified user. Available only for admin.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#unblock-user
+// GitLab API docs: https://docs.gitlab.com/ee/api/users.html#unblock-user
 func (s *UsersService) UnblockUser(user int, options ...RequestOptionFunc) error {
 	u := fmt.Sprintf("users/%d/unblock", user)
 
@@ -955,7 +955,7 @@ func (s *UsersService) UnblockUser(user int, options ...RequestOptionFunc) error
 
 // BanUser bans the specified user. Available only for admin.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#ban-user
+// GitLab API docs: https://docs.gitlab.com/ee/api/users.html#ban-user
 func (s *UsersService) BanUser(user int, options ...RequestOptionFunc) error {
 	u := fmt.Sprintf("users/%d/ban", user)
 
@@ -981,7 +981,7 @@ func (s *UsersService) BanUser(user int, options ...RequestOptionFunc) error {
 
 // UnbanUser unbans the specified user. Available only for admin.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#unban-user
+// GitLab API docs: https://docs.gitlab.com/ee/api/users.html#unban-user
 func (s *UsersService) UnbanUser(user int, options ...RequestOptionFunc) error {
 	u := fmt.Sprintf("users/%d/unban", user)
 
@@ -1007,7 +1007,7 @@ func (s *UsersService) UnbanUser(user int, options ...RequestOptionFunc) error {
 
 // DeactivateUser deactivate the specified user. Available only for admin.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#deactivate-user
+// GitLab API docs: https://docs.gitlab.com/ee/api/users.html#deactivate-user
 func (s *UsersService) DeactivateUser(user int, options ...RequestOptionFunc) error {
 	u := fmt.Sprintf("users/%d/deactivate", user)
 
@@ -1035,7 +1035,7 @@ func (s *UsersService) DeactivateUser(user int, options ...RequestOptionFunc) er
 
 // ActivateUser activate the specified user. Available only for admin.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#activate-user
+// GitLab API docs: https://docs.gitlab.com/ee/api/users.html#activate-user
 func (s *UsersService) ActivateUser(user int, options ...RequestOptionFunc) error {
 	u := fmt.Sprintf("users/%d/activate", user)
 
@@ -1063,7 +1063,7 @@ func (s *UsersService) ActivateUser(user int, options ...RequestOptionFunc) erro
 
 // ApproveUser approve the specified user. Available only for admin.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#approve-user
+// GitLab API docs: https://docs.gitlab.com/ee/api/users.html#approve-user
 func (s *UsersService) ApproveUser(user int, options ...RequestOptionFunc) error {
 	u := fmt.Sprintf("users/%d/approve", user)
 
@@ -1091,7 +1091,7 @@ func (s *UsersService) ApproveUser(user int, options ...RequestOptionFunc) error
 
 // RejectUser reject the specified user. Available only for admin.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#reject-user
+// GitLab API docs: https://docs.gitlab.com/ee/api/users.html#reject-user
 func (s *UsersService) RejectUser(user int, options ...RequestOptionFunc) error {
 	u := fmt.Sprintf("users/%d/reject", user)
 
@@ -1122,7 +1122,7 @@ func (s *UsersService) RejectUser(user int, options ...RequestOptionFunc) error 
 // ImpersonationToken represents an impersonation token.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/users.html#get-all-impersonation-tokens-of-a-user
+// https://docs.gitlab.com/ee/api/users.html#get-all-impersonation-tokens-of-a-user
 type ImpersonationToken struct {
 	ID        int        `json:"id"`
 	Name      string     `json:"name"`
@@ -1138,7 +1138,7 @@ type ImpersonationToken struct {
 // GetAllImpersonationTokens() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/users.html#get-all-impersonation-tokens-of-a-user
+// https://docs.gitlab.com/ee/api/users.html#get-all-impersonation-tokens-of-a-user
 type GetAllImpersonationTokensOptions struct {
 	ListOptions
 	State *string `url:"state,omitempty" json:"state,omitempty"`
@@ -1147,7 +1147,7 @@ type GetAllImpersonationTokensOptions struct {
 // GetAllImpersonationTokens retrieves all impersonation tokens of a user.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/users.html#get-all-impersonation-tokens-of-a-user
+// https://docs.gitlab.com/ee/api/users.html#get-all-impersonation-tokens-of-a-user
 func (s *UsersService) GetAllImpersonationTokens(user int, opt *GetAllImpersonationTokensOptions, options ...RequestOptionFunc) ([]*ImpersonationToken, *Response, error) {
 	u := fmt.Sprintf("users/%d/impersonation_tokens", user)
 
@@ -1168,7 +1168,7 @@ func (s *UsersService) GetAllImpersonationTokens(user int, opt *GetAllImpersonat
 // GetImpersonationToken retrieves an impersonation token of a user.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/users.html#get-an-impersonation-token-of-a-user
+// https://docs.gitlab.com/ee/api/users.html#get-an-impersonation-token-of-a-user
 func (s *UsersService) GetImpersonationToken(user, token int, options ...RequestOptionFunc) (*ImpersonationToken, *Response, error) {
 	u := fmt.Sprintf("users/%d/impersonation_tokens/%d", user, token)
 
@@ -1190,7 +1190,7 @@ func (s *UsersService) GetImpersonationToken(user, token int, options ...Request
 // CreateImpersonationToken() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/users.html#create-an-impersonation-token
+// https://docs.gitlab.com/ee/api/users.html#create-an-impersonation-token
 type CreateImpersonationTokenOptions struct {
 	Name      *string    `url:"name,omitempty" json:"name,omitempty"`
 	Scopes    *[]string  `url:"scopes,omitempty" json:"scopes,omitempty"`
@@ -1200,7 +1200,7 @@ type CreateImpersonationTokenOptions struct {
 // CreateImpersonationToken creates an impersonation token.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/users.html#create-an-impersonation-token
+// https://docs.gitlab.com/ee/api/users.html#create-an-impersonation-token
 func (s *UsersService) CreateImpersonationToken(user int, opt *CreateImpersonationTokenOptions, options ...RequestOptionFunc) (*ImpersonationToken, *Response, error) {
 	u := fmt.Sprintf("users/%d/impersonation_tokens", user)
 
@@ -1221,7 +1221,7 @@ func (s *UsersService) CreateImpersonationToken(user int, opt *CreateImpersonati
 // RevokeImpersonationToken revokes an impersonation token.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/users.html#revoke-an-impersonation-token
+// https://docs.gitlab.com/ee/api/users.html#revoke-an-impersonation-token
 func (s *UsersService) RevokeImpersonationToken(user, token int, options ...RequestOptionFunc) (*Response, error) {
 	u := fmt.Sprintf("users/%d/impersonation_tokens/%d", user, token)
 
@@ -1268,7 +1268,7 @@ func (s *UsersService) CreatePersonalAccessToken(user int, opt *CreatePersonalAc
 // UserActivity represents an entry in the user/activities response
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/users.html#get-user-activities-admin-only
+// https://docs.gitlab.com/ee/api/users.html#get-user-activities-admin-only
 type UserActivity struct {
 	Username       string   `json:"username"`
 	LastActivityOn *ISOTime `json:"last_activity_on"`
@@ -1277,7 +1277,7 @@ type UserActivity struct {
 // GetUserActivitiesOptions represents the options for GetUserActivities
 //
 // GitLap API docs:
-// https://docs.gitlab.com/ce/api/users.html#get-user-activities-admin-only
+// https://docs.gitlab.com/ee/api/users.html#get-user-activities-admin-only
 type GetUserActivitiesOptions struct {
 	ListOptions
 	From *ISOTime `url:"from,omitempty" json:"from,omitempty"`
@@ -1286,7 +1286,7 @@ type GetUserActivitiesOptions struct {
 // GetUserActivities retrieves user activities (admin only)
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/users.html#get-user-activities-admin-only
+// https://docs.gitlab.com/ee/api/users.html#get-user-activities-admin-only
 func (s *UsersService) GetUserActivities(opt *GetUserActivitiesOptions, options ...RequestOptionFunc) ([]*UserActivity, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "user/activities", opt, options)
 	if err != nil {

--- a/users.go
+++ b/users.go
@@ -302,7 +302,7 @@ func (s *UsersService) DeleteUser(user int, options ...RequestOptionFunc) (*Resp
 
 // CurrentUser gets currently authenticated user.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/users.html#current-user
+// GitLab API docs: https://docs.gitlab.com/ee/api/users.html#list-current-user
 func (s *UsersService) CurrentUser(options ...RequestOptionFunc) (*User, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "user", nil, options)
 	if err != nil {
@@ -500,7 +500,7 @@ func (s *UsersService) GetSSHKeyForUser(user int, key int, options ...RequestOpt
 
 // AddSSHKeyOptions represents the available AddSSHKey() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/projects.html#add-ssh-key
+// GitLab API docs: https://docs.gitlab.com/ee/api/users.html#add-ssh-key
 type AddSSHKeyOptions struct {
 	Title     *string  `url:"title,omitempty" json:"title,omitempty"`
 	Key       *string  `url:"key,omitempty" json:"key,omitempty"`
@@ -551,7 +551,7 @@ func (s *UsersService) AddSSHKeyForUser(user int, opt *AddSSHKeyOptions, options
 // available results in 200 OK.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/users.html#delete-ssh-key-for-current-owner
+// https://docs.gitlab.com/ee/api/users.html#delete-ssh-key-for-current-user
 func (s *UsersService) DeleteSSHKey(key int, options ...RequestOptionFunc) (*Response, error) {
 	u := fmt.Sprintf("user/keys/%d", key)
 
@@ -869,7 +869,7 @@ func (s *UsersService) AddEmailForUser(user int, opt *AddEmailOptions, options .
 // available results in 200 OK.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/users.html#delete-email-for-current-owner
+// https://docs.gitlab.com/ee/api/users.html#delete-email-for-current-user
 func (s *UsersService) DeleteEmail(email int, options ...RequestOptionFunc) (*Response, error) {
 	u := fmt.Sprintf("user/emails/%d", email)
 
@@ -1268,7 +1268,7 @@ func (s *UsersService) CreatePersonalAccessToken(user int, opt *CreatePersonalAc
 // UserActivity represents an entry in the user/activities response
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/users.html#get-user-activities-admin-only
+// https://docs.gitlab.com/ee/api/users.html#get-user-activities
 type UserActivity struct {
 	Username       string   `json:"username"`
 	LastActivityOn *ISOTime `json:"last_activity_on"`
@@ -1277,7 +1277,7 @@ type UserActivity struct {
 // GetUserActivitiesOptions represents the options for GetUserActivities
 //
 // GitLap API docs:
-// https://docs.gitlab.com/ee/api/users.html#get-user-activities-admin-only
+// https://docs.gitlab.com/ee/api/users.html#get-user-activities
 type GetUserActivitiesOptions struct {
 	ListOptions
 	From *ISOTime `url:"from,omitempty" json:"from,omitempty"`
@@ -1286,7 +1286,7 @@ type GetUserActivitiesOptions struct {
 // GetUserActivities retrieves user activities (admin only)
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/users.html#get-user-activities-admin-only
+// https://docs.gitlab.com/ee/api/users.html#get-user-activities
 func (s *UsersService) GetUserActivities(opt *GetUserActivitiesOptions, options ...RequestOptionFunc) ([]*UserActivity, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "user/activities", opt, options)
 	if err != nil {
@@ -1305,7 +1305,7 @@ func (s *UsersService) GetUserActivities(opt *GetUserActivitiesOptions, options 
 // UserMembership represents a membership of the user in a namespace or project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/users.html#user-memberships-admin-only
+// https://docs.gitlab.com/ee/api/users.html#user-memberships
 type UserMembership struct {
 	SourceID    int              `json:"source_id"`
 	SourceName  string           `json:"source_name"`
@@ -1316,7 +1316,7 @@ type UserMembership struct {
 // GetUserMembershipOptions represents the options available to query user memberships.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/users.html#user-memberships-admin-only
+// ohttps://docs.gitlab.com/ee/api/users.html#user-memberships
 type GetUserMembershipOptions struct {
 	ListOptions
 	Type *string `url:"type,omitempty" json:"type,omitempty"`
@@ -1325,7 +1325,7 @@ type GetUserMembershipOptions struct {
 // GetUserMemberships retrieves a list of the user's memberships.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/users.html#user-memberships-admin-only
+// https://docs.gitlab.com/ee/api/users.html#user-memberships
 func (s *UsersService) GetUserMemberships(user int, opt *GetUserMembershipOptions, options ...RequestOptionFunc) ([]*UserMembership, *Response, error) {
 	u := fmt.Sprintf("users/%d/memberships", user)
 

--- a/validate.go
+++ b/validate.go
@@ -24,14 +24,14 @@ import (
 // ValidateService handles communication with the validation related methods of
 // the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/lint.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/lint.html
 type ValidateService struct {
 	client *Client
 }
 
 // LintResult represents the linting results.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/lint.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/lint.html
 type LintResult struct {
 	Status     string   `json:"status"`
 	Errors     []string `json:"errors"`

--- a/version.go
+++ b/version.go
@@ -21,14 +21,14 @@ import "net/http"
 // VersionService handles communication with the GitLab server instance to
 // retrieve its version information via the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/version.md
+// GitLab API docs: https://docs.gitlab.com/ee/api/version.html
 type VersionService struct {
 	client *Client
 }
 
 // Version represents a GitLab instance version.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/version.md
+// GitLab API docs: https://docs.gitlab.com/ee/api/version.html
 type Version struct {
 	Version  string `json:"version"`
 	Revision string `json:"revision"`
@@ -41,7 +41,7 @@ func (s Version) String() string {
 // GetVersion gets a GitLab server instance version; it is only available to
 // authenticated users.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/version.md
+// GitLab API docs: https://docs.gitlab.com/ee/api/version.html
 func (s *VersionService) GetVersion(options ...RequestOptionFunc) (*Version, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "version", nil, options)
 	if err != nil {

--- a/version.go
+++ b/version.go
@@ -21,14 +21,14 @@ import "net/http"
 // VersionService handles communication with the GitLab server instance to
 // retrieve its version information via the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/version.md
+// GitLab API docs: https://docs.gitlab.com/ee/api/version.md
 type VersionService struct {
 	client *Client
 }
 
 // Version represents a GitLab instance version.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/version.md
+// GitLab API docs: https://docs.gitlab.com/ee/api/version.md
 type Version struct {
 	Version  string `json:"version"`
 	Revision string `json:"revision"`
@@ -41,7 +41,7 @@ func (s Version) String() string {
 // GetVersion gets a GitLab server instance version; it is only available to
 // authenticated users.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/version.md
+// GitLab API docs: https://docs.gitlab.com/ee/api/version.md
 func (s *VersionService) GetVersion(options ...RequestOptionFunc) (*Version, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "version", nil, options)
 	if err != nil {

--- a/wikis.go
+++ b/wikis.go
@@ -24,14 +24,14 @@ import (
 // WikisService handles communication with the wikis related methods of
 // the Gitlab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/wikis.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/wikis.html
 type WikisService struct {
 	client *Client
 }
 
 // Wiki represents a GitLab wiki.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/wikis.html
+// GitLab API docs: https://docs.gitlab.com/ee/api/wikis.html
 type Wiki struct {
 	Content  string          `json:"content"`
 	Encoding string          `json:"encoding"`
@@ -47,7 +47,7 @@ func (w Wiki) String() string {
 // ListWikisOptions represents the available ListWikis options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/wikis.html#list-wiki-pages
+// https://docs.gitlab.com/ee/api/wikis.html#list-wiki-pages
 type ListWikisOptions struct {
 	WithContent *bool `url:"with_content,omitempty" json:"with_content,omitempty"`
 }
@@ -56,7 +56,7 @@ type ListWikisOptions struct {
 // When with_content is set, it also returns the content of the pages.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/wikis.html#list-wiki-pages
+// https://docs.gitlab.com/ee/api/wikis.html#list-wiki-pages
 func (s *WikisService) ListWikis(pid interface{}, opt *ListWikisOptions, options ...RequestOptionFunc) ([]*Wiki, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -90,7 +90,7 @@ type GetWikiPageOptions struct {
 // GetWikiPage gets a wiki page for a given project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/wikis.html#get-a-wiki-page
+// https://docs.gitlab.com/ee/api/wikis.html#get-a-wiki-page
 func (s *WikisService) GetWikiPage(pid interface{}, slug string, opt *GetWikiPageOptions, options ...RequestOptionFunc) (*Wiki, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -115,7 +115,7 @@ func (s *WikisService) GetWikiPage(pid interface{}, slug string, opt *GetWikiPag
 // CreateWikiPageOptions represents options to CreateWikiPage.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/wikis.html#create-a-new-wiki-page
+// https://docs.gitlab.com/ee/api/wikis.html#create-a-new-wiki-page
 type CreateWikiPageOptions struct {
 	Content *string          `url:"content,omitempty" json:"content,omitempty"`
 	Title   *string          `url:"title,omitempty" json:"title,omitempty"`
@@ -126,7 +126,7 @@ type CreateWikiPageOptions struct {
 // the given title, slug, and content.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/wikis.html#create-a-new-wiki-page
+// https://docs.gitlab.com/ee/api/wikis.html#create-a-new-wiki-page
 func (s *WikisService) CreateWikiPage(pid interface{}, opt *CreateWikiPageOptions, options ...RequestOptionFunc) (*Wiki, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -151,7 +151,7 @@ func (s *WikisService) CreateWikiPage(pid interface{}, opt *CreateWikiPageOption
 // EditWikiPageOptions represents options to EditWikiPage.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/wikis.html#edit-an-existing-wiki-page
+// https://docs.gitlab.com/ee/api/wikis.html#edit-an-existing-wiki-page
 type EditWikiPageOptions struct {
 	Content *string          `url:"content,omitempty" json:"content,omitempty"`
 	Title   *string          `url:"title,omitempty" json:"title,omitempty"`
@@ -162,7 +162,7 @@ type EditWikiPageOptions struct {
 // required to update the wiki page.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/wikis.html#edit-an-existing-wiki-page
+// https://docs.gitlab.com/ee/api/wikis.html#edit-an-existing-wiki-page
 func (s *WikisService) EditWikiPage(pid interface{}, slug string, opt *EditWikiPageOptions, options ...RequestOptionFunc) (*Wiki, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -187,7 +187,7 @@ func (s *WikisService) EditWikiPage(pid interface{}, slug string, opt *EditWikiP
 // DeleteWikiPage deletes a wiki page with a given slug.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/wikis.html#delete-a-wiki-page
+// https://docs.gitlab.com/ee/api/wikis.html#delete-a-wiki-page
 func (s *WikisService) DeleteWikiPage(pid interface{}, slug string, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {


### PR DESCRIPTION
All URLs to https://docs.gitlab.com/ce have been replaced by links to https://docs.gitlab.com/ee, since they redirected there anyways.

Furthermore, there were a few broken documentation links and several broken anchor links.