### PR TITLE
Update the protected branches API

### DIFF
--- a/branches.go
+++ b/branches.go
@@ -122,7 +122,8 @@ type ProtectBranchOptions struct {
 // idempotent function, protecting an already protected repository branch
 // still returns a 200 OK status code.
 //
-// Deprecated: This endpoint has been replaced by ProtectedBranchesService.ProtectRepositoryBranches()
+// Deprecated: This endpoint has been replaced by
+// ProtectedBranchesService.ProtectRepositoryBranches()
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/branches.html#protect-repository-branch
@@ -151,7 +152,8 @@ func (s *BranchesService) ProtectBranch(pid interface{}, branch string, opts *Pr
 // idempotent function, unprotecting an already unprotected repository branch
 // still returns a 200 OK status code.
 //
-// Deprecated: This endpoint has been replaced by ProtectedBranchesService.UnprotectRepositoryBranches()
+// Deprecated: This endpoint has been replaced by
+// ProtectedBranchesService.UnprotectRepositoryBranches()
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/branches.html#unprotect-repository-branch

--- a/branches.go
+++ b/branches.go
@@ -122,6 +122,8 @@ type ProtectBranchOptions struct {
 // idempotent function, protecting an already protected repository branch
 // still returns a 200 OK status code.
 //
+// Deprecated: This endpoint has been replaced by ProtectedBranchesService.ProtectRepositoryBranches()
+//
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/branches.html#protect-repository-branch
 func (s *BranchesService) ProtectBranch(pid interface{}, branch string, opts *ProtectBranchOptions, options ...RequestOptionFunc) (*Branch, *Response, error) {
@@ -148,6 +150,8 @@ func (s *BranchesService) ProtectBranch(pid interface{}, branch string, opts *Pr
 // UnprotectBranch unprotects a single project repository branch. This is an
 // idempotent function, unprotecting an already unprotected repository branch
 // still returns a 200 OK status code.
+//
+// Deprecated: This endpoint has been replaced by ProtectedBranchesService.UnprotectRepositoryBranches()
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/branches.html#unprotect-repository-branch

--- a/protected_branches.go
+++ b/protected_branches.go
@@ -247,6 +247,9 @@ type RequireCodeOwnerApprovalsOptions struct {
 // Gitlab API docs:
 // https://docs.gitlab.com/ee/api/protected_branches.html#update-a-protected-branch
 func (s *ProtectedBranchesService) RequireCodeOwnerApprovals(pid interface{}, branch string, opt *RequireCodeOwnerApprovalsOptions, options ...RequestOptionFunc) (*Response, error) {
-	_, req, err := s.UpdateProtectedBranch(pid, branch, &UpdateProtectedBranchOptions{CodeOwnerApprovalRequired: opt.CodeOwnerApprovalRequired}, options...)
+	updateOptions := &UpdateProtectedBranchOptions{
+		CodeOwnerApprovalRequired: opt.CodeOwnerApprovalRequired,
+	}
+	_, req, err := s.UpdateProtectedBranch(pid, branch, updateOptions, options...)
 	return req, err
 }

--- a/protected_branches_test.go
+++ b/protected_branches_test.go
@@ -33,10 +33,12 @@ func TestListProtectedBranches(t *testing.T) {
 		"id":1,
 		"name":"master",
 		"push_access_levels":[{
+			"id":1,
 			"access_level":40,
 			"access_level_description":"Maintainers"
 		}],
 		"merge_access_levels":[{
+			"id":1,
 			"access_level":40,
 			"access_level_description":"Maintainers"
 		}],
@@ -55,12 +57,14 @@ func TestListProtectedBranches(t *testing.T) {
 			Name: "master",
 			PushAccessLevels: []*BranchAccessDescription{
 				{
+					ID:                     1,
 					AccessLevel:            40,
 					AccessLevelDescription: "Maintainers",
 				},
 			},
 			MergeAccessLevels: []*BranchAccessDescription{
 				{
+					ID:                     1,
 					AccessLevel:            40,
 					AccessLevelDescription: "Maintainers",
 				},
@@ -188,12 +192,25 @@ func TestUpdateRepositoryBranches(t *testing.T) {
 		if codeApprovalQueryParam != "true" {
 			t.Errorf("query param code_owner_approval_required should be true but was %s", codeApprovalQueryParam)
 		}
+		fmt.Fprintf(w, `{
+			"name": "master",
+			"code_owner_approval_required": true
+		}`)
 	})
-	opt := &RequireCodeOwnerApprovalsOptions{
+	opt := &UpdateProtectedBranchOptions{
 		CodeOwnerApprovalRequired: Bool(true),
 	}
-	_, err := client.ProtectedBranches.RequireCodeOwnerApprovals("1", "master", opt)
+	protectedBranch, _, err := client.ProtectedBranches.UpdateProtectedBranch("1", "master", opt)
 	if err != nil {
-		t.Errorf("ProtectedBranches.UpdateRepositoryBranchesOptions returned error: %v", err)
+		t.Errorf("ProtectedBranches.UpdateProtectedBranch returned error: %v", err)
+	}
+
+	want := &ProtectedBranch{
+		Name:                      "master",
+		CodeOwnerApprovalRequired: true,
+	}
+
+	if !reflect.DeepEqual(want, protectedBranch) {
+		t.Errorf("ProtectedBranches.UpdateProtectedBranch returned %+v, want %+v", protectedBranch, want)
 	}
 }


### PR DESCRIPTION
I marked the two functions `BranchesService.ProtectBranch()` & `BranchesService.UnprotectBranch()` as deprecated, since they are replaced by the protected branches API.

In the `ProtectedBranchesService` I added some missing options, and renamed the `RequireCodeOwnerApprovals()` function to `UpdateProtectedBranch()` which has some additional options. (I kept the `RequireCodeOwnerApprovals()` function and marked it as deprecated.)