### PR TITLE
add a new method that allow to get an issue by id instead of iid

### DIFF
--- a/issues.go
+++ b/issues.go
@@ -387,6 +387,26 @@ func (s *IssuesService) ListProjectIssues(pid interface{}, opt *ListProjectIssue
 	return i, resp, err
 }
 
+// GetIssueByID gets a single issue.
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/issues.html#single-issue
+func (s *IssuesService) GetIssueByID(issue int, options ...RequestOptionFunc) (*Issue, *Response, error) {
+	u := fmt.Sprintf("issues/%d", issue)
+
+	req, err := s.client.NewRequest(http.MethodGet, u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	i := new(Issue)
+	resp, err := s.client.Do(req, i)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return i, resp, err
+}
+
 // GetIssue gets a single project issue.
 //
 // GitLab API docs: https://docs.gitlab.com/ee/api/issues.html#single-project-issue

--- a/issues_test.go
+++ b/issues_test.go
@@ -52,6 +52,32 @@ func TestGetIssue(t *testing.T) {
 	}
 }
 
+func TestGetIssueByID(t *testing.T) {
+	mux, client := setup(t)
+
+	mux.HandleFunc("/api/v4/issues/5", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, `{"id":5, "description": "This is test project", "author" : {"id" : 1, "name": "snehal"}, "assignees":[{"id":1}],"merge_requests_count": 1}`)
+	})
+
+	issue, _, err := client.Issues.GetIssueByID(5)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	want := &Issue{
+		ID:                5,
+		Description:       "This is test project",
+		Author:            &IssueAuthor{ID: 1, Name: "snehal"},
+		Assignees:         []*IssueAssignee{{ID: 1}},
+		MergeRequestCount: 1,
+	}
+
+	if !reflect.DeepEqual(want, issue) {
+		t.Errorf("Issues.GetIssueByID returned %+v, want %+v", issue, want)
+	}
+}
+
 func TestDeleteIssue(t *testing.T) {
 	mux, client := setup(t)
 


### PR DESCRIPTION
in issues.go there's no method that wrap https://docs.gitlab.com/ee/api/issues.html#single-issue .
It's not possible to Get an issue by id (whole instance id and not project id aka iid).

This PR add this method and to keep BC, I've name it GetIssueByID but a imho a better name would be GetIssue and we could replace the actual GetIssue by GetProjectIssue, but anyway, both possibilities are fine.
Added tests too.