### PR TITLE
Add "raw" option to group/project variable managment

### DIFF
--- a/group_variables.go
+++ b/group_variables.go
@@ -41,8 +41,8 @@ type GroupVariable struct {
 	VariableType     VariableTypeValue `json:"variable_type"`
 	Protected        bool              `json:"protected"`
 	Masked           bool              `json:"masked"`
-	EnvironmentScope string            `json:"environment_scope"`
 	Raw              bool              `json:"raw"`
+	EnvironmentScope string            `json:"environment_scope"`
 }
 
 func (v GroupVariable) String() string {
@@ -117,8 +117,8 @@ type CreateGroupVariableOptions struct {
 	VariableType     *VariableTypeValue `url:"variable_type,omitempty" json:"variable_type,omitempty"`
 	Protected        *bool              `url:"protected,omitempty" json:"protected,omitempty"`
 	Masked           *bool              `url:"masked,omitempty" json:"masked,omitempty"`
-	EnvironmentScope *string            `url:"environment_scope,omitempty" json:"environment_scope,omitempty"`
 	Raw              *bool              `url:"raw,omitempty" json:"raw,omitempty"`
+	EnvironmentScope *string            `url:"environment_scope,omitempty" json:"environment_scope,omitempty"`
 }
 
 // CreateVariable creates a new group variable.
@@ -156,8 +156,8 @@ type UpdateGroupVariableOptions struct {
 	VariableType     *VariableTypeValue `url:"variable_type,omitempty" json:"variable_type,omitempty"`
 	Protected        *bool              `url:"protected,omitempty" json:"protected,omitempty"`
 	Masked           *bool              `url:"masked,omitempty" json:"masked,omitempty"`
-	EnvironmentScope *string            `url:"environment_scope,omitempty" json:"environment_scope,omitempty"`
 	Raw              *bool              `url:"raw,omitempty" json:"raw,omitempty"`
+	EnvironmentScope *string            `url:"environment_scope,omitempty" json:"environment_scope,omitempty"`
 }
 
 // UpdateVariable updates the position of an existing

--- a/group_variables.go
+++ b/group_variables.go
@@ -42,6 +42,7 @@ type GroupVariable struct {
 	Protected        bool              `json:"protected"`
 	Masked           bool              `json:"masked"`
 	EnvironmentScope string            `json:"environment_scope"`
+	Raw              bool              `json:"raw"`
 }
 
 func (v GroupVariable) String() string {
@@ -117,6 +118,7 @@ type CreateGroupVariableOptions struct {
 	Protected        *bool              `url:"protected,omitempty" json:"protected,omitempty"`
 	Masked           *bool              `url:"masked,omitempty" json:"masked,omitempty"`
 	EnvironmentScope *string            `url:"environment_scope,omitempty" json:"environment_scope,omitempty"`
+	Raw              *bool              `url:"raw,omitempty" json:"raw,omitempty"`
 }
 
 // CreateVariable creates a new group variable.
@@ -155,6 +157,7 @@ type UpdateGroupVariableOptions struct {
 	Protected        *bool              `url:"protected,omitempty" json:"protected,omitempty"`
 	Masked           *bool              `url:"masked,omitempty" json:"masked,omitempty"`
 	EnvironmentScope *string            `url:"environment_scope,omitempty" json:"environment_scope,omitempty"`
+	Raw              *bool              `url:"raw,omitempty" json:"raw,omitempty"`
 }
 
 // UpdateVariable updates the position of an existing

--- a/project_variables.go
+++ b/project_variables.go
@@ -42,6 +42,7 @@ type ProjectVariable struct {
 	Protected        bool              `json:"protected"`
 	Masked           bool              `json:"masked"`
 	EnvironmentScope string            `json:"environment_scope"`
+	Raw              bool              `json:"raw"`
 }
 
 func (v ProjectVariable) String() string {
@@ -131,6 +132,7 @@ type CreateProjectVariableOptions struct {
 	Protected        *bool              `url:"protected,omitempty" json:"protected,omitempty"`
 	Masked           *bool              `url:"masked,omitempty" json:"masked,omitempty"`
 	EnvironmentScope *string            `url:"environment_scope,omitempty" json:"environment_scope,omitempty"`
+	Raw              *bool              `url:"raw,omitempty" json:"raw,omitempty"`
 }
 
 // CreateVariable creates a new project variable.
@@ -170,6 +172,7 @@ type UpdateProjectVariableOptions struct {
 	Masked           *bool              `url:"masked,omitempty" json:"masked,omitempty"`
 	EnvironmentScope *string            `url:"environment_scope,omitempty" json:"environment_scope,omitempty"`
 	Filter           *VariableFilter    `url:"filter,omitempty" json:"filter,omitempty"`
+	Raw              *bool              `url:"raw,omitempty" json:"raw,omitempty"`
 }
 
 // UpdateVariable updates a project's variable.

--- a/project_variables.go
+++ b/project_variables.go
@@ -41,8 +41,8 @@ type ProjectVariable struct {
 	VariableType     VariableTypeValue `json:"variable_type"`
 	Protected        bool              `json:"protected"`
 	Masked           bool              `json:"masked"`
-	EnvironmentScope string            `json:"environment_scope"`
 	Raw              bool              `json:"raw"`
+	EnvironmentScope string            `json:"environment_scope"`
 }
 
 func (v ProjectVariable) String() string {
@@ -131,8 +131,8 @@ type CreateProjectVariableOptions struct {
 	VariableType     *VariableTypeValue `url:"variable_type,omitempty" json:"variable_type,omitempty"`
 	Protected        *bool              `url:"protected,omitempty" json:"protected,omitempty"`
 	Masked           *bool              `url:"masked,omitempty" json:"masked,omitempty"`
-	EnvironmentScope *string            `url:"environment_scope,omitempty" json:"environment_scope,omitempty"`
 	Raw              *bool              `url:"raw,omitempty" json:"raw,omitempty"`
+	EnvironmentScope *string            `url:"environment_scope,omitempty" json:"environment_scope,omitempty"`
 }
 
 // CreateVariable creates a new project variable.
@@ -170,9 +170,9 @@ type UpdateProjectVariableOptions struct {
 	VariableType     *VariableTypeValue `url:"variable_type,omitempty" json:"variable_type,omitempty"`
 	Protected        *bool              `url:"protected,omitempty" json:"protected,omitempty"`
 	Masked           *bool              `url:"masked,omitempty" json:"masked,omitempty"`
+	Raw              *bool              `url:"raw,omitempty" json:"raw,omitempty"`
 	EnvironmentScope *string            `url:"environment_scope,omitempty" json:"environment_scope,omitempty"`
 	Filter           *VariableFilter    `url:"filter,omitempty" json:"filter,omitempty"`
-	Raw              *bool              `url:"raw,omitempty" json:"raw,omitempty"`
 }
 
 // UpdateVariable updates a project's variable.


### PR DESCRIPTION
Corresponding to the documentation:

- https://docs.gitlab.com/ee/api/group_level_variables.html
- https://docs.gitlab.com/ee/api/project_level_variables.html

there is now a `raw` setting in API variable definition to determine whether the variable is expandable.