### PR TITLE
fix: Tags in Package as complex object

### DIFF
--- a/packages.go
+++ b/packages.go
@@ -41,7 +41,7 @@ type Package struct {
 	Status      string        `json:"status"`
 	Links       *PackageLinks `json:"_links"`
 	CreatedAt   *time.Time    `json:"created_at"`
-	Tags        []string      `json:"tags"`
+	Tags        []PackageTag  `json:"tags"`
 }
 
 func (s Package) String() string {
@@ -68,6 +68,19 @@ type PackageLinks struct {
 }
 
 func (s PackageLinks) String() string {
+	return Stringify(s)
+}
+
+// PackageTag holds label information about the package
+type PackageTag struct {
+	ID        int       `json:"id"`
+	PackageID int       `json:"package_id"`
+	Name      string    `json:"name"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+func (s PackageTag) String() string {
 	return Stringify(s)
 }
 

--- a/packages_test.go
+++ b/packages_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -25,12 +26,21 @@ func TestPackagesService_ListProjectPackages(t *testing.T) {
 				  "web_path": "/foo/bar/-/packages/3",
 				  "delete_api_path": "https://gitlab.example.com/api/v4/projects/1/packages/3"
 				},
-				"tags": []
+				"tags": [
+					{
+						"id": 1,
+						"package_id": 37,
+						"name": "Some Label",
+						"created_at": "2023-01-04T20:00:00.000Z",
+						"updated_at": "2023-01-04T20:00:00.000Z"
+					}
+				]
 			  }
 			]
 		`)
 	})
 
+	timestamp := time.Date(2023, 1, 4, 20, 0, 0, 0, time.UTC)
 	want := []*Package{{
 		ID:          3,
 		Name:        "Hello/0.1@mycompany/stable",
@@ -40,7 +50,14 @@ func TestPackagesService_ListProjectPackages(t *testing.T) {
 			WebPath:       "/foo/bar/-/packages/3",
 			DeleteAPIPath: "https://gitlab.example.com/api/v4/projects/1/packages/3",
 		},
-		Tags: []string{},
+		Tags: []PackageTag{
+			{
+				ID:        1,
+				PackageID: 37,
+				Name:      "Some Label",
+				CreatedAt: timestamp,
+				UpdatedAt: timestamp,
+			}},
 	}}
 
 	ps, resp, err := client.Packages.ListProjectPackages(3, nil)


### PR DESCRIPTION
This Pull Request fixes #1578 

Basically, I just exchanged the string array with a complex array. An example response from GitLab could look like this:
```json
"tags": [
            {
                "id": 2,
                "package_id": 37,
                "name": "Label1,Label2,Label3",
                "created_at": "2023-01-04T18:48:40.109Z",
                "updated_at": "2023-01-04T18:48:40.109Z"
            }
        ]
```