### PR TITLE
Add requestOptions to Client

### DIFF
--- a/client_options.go
+++ b/client_options.go
@@ -134,10 +134,10 @@ func WithoutRetries() ClientOptionFunc {
 	}
 }
 
-// WithRequestOptions can be used to configure options that are applied to every request to the GitLab API.
+// WithRequestOptions can be used to configure default request options applied to every request.
 func WithRequestOptions(options ...RequestOptionFunc) ClientOptionFunc {
 	return func(c *Client) error {
-		c.requestOptions = append(c.requestOptions, options...)
+		c.defaultRequestOptions = append(c.defaultRequestOptions, options...)
 		return nil
 	}
 }

--- a/client_options.go
+++ b/client_options.go
@@ -133,3 +133,11 @@ func WithoutRetries() ClientOptionFunc {
 		return nil
 	}
 }
+
+// WithRequestOptions can be used to configure options that are applied to every request to the GitLab API.
+func WithRequestOptions(options ...RequestOptionFunc) ClientOptionFunc {
+	return func(c *Client) error {
+		c.requestOptions = append(c.requestOptions, options...)
+		return nil
+	}
+}

--- a/gitlab.go
+++ b/gitlab.go
@@ -99,6 +99,9 @@ type Client struct {
 	// User agent used when communicating with the GitLab API.
 	UserAgent string
 
+	// Request options that are applied to every request to the GitLab API.
+	requestOptions []RequestOptionFunc
+
 	// Services used for talking to different parts of the GitLab API.
 	AccessRequests          *AccessRequestsService
 	Applications            *ApplicationsService
@@ -595,6 +598,14 @@ func (c *Client) NewRequest(method, path string, opt interface{}, options []Requ
 		return nil, err
 	}
 
+	for _, fn := range c.requestOptions {
+		if fn == nil {
+			continue
+		}
+		if err := fn(req); err != nil {
+			return nil, err
+		}
+	}
 	for _, fn := range options {
 		if fn == nil {
 			continue
@@ -671,6 +682,14 @@ func (c *Client) UploadRequest(method, path string, content io.Reader, filename 
 		return nil, err
 	}
 
+	for _, fn := range c.requestOptions {
+		if fn == nil {
+			continue
+		}
+		if err := fn(req); err != nil {
+			return nil, err
+		}
+	}
 	for _, fn := range options {
 		if fn == nil {
 			continue

--- a/gitlab.go
+++ b/gitlab.go
@@ -598,15 +598,7 @@ func (c *Client) NewRequest(method, path string, opt interface{}, options []Requ
 		return nil, err
 	}
 
-	for _, fn := range c.defaultRequestOptions {
-		if fn == nil {
-			continue
-		}
-		if err := fn(req); err != nil {
-			return nil, err
-		}
-	}
-	for _, fn := range options {
+	for _, fn := range append(c.defaultRequestOptions, options...) {
 		if fn == nil {
 			continue
 		}
@@ -682,15 +674,7 @@ func (c *Client) UploadRequest(method, path string, content io.Reader, filename 
 		return nil, err
 	}
 
-	for _, fn := range c.defaultRequestOptions {
-		if fn == nil {
-			continue
-		}
-		if err := fn(req); err != nil {
-			return nil, err
-		}
-	}
-	for _, fn := range options {
+	for _, fn := range append(c.defaultRequestOptions, options...) {
 		if fn == nil {
 			continue
 		}

--- a/gitlab.go
+++ b/gitlab.go
@@ -96,11 +96,11 @@ type Client struct {
 	// Protects the token field from concurrent read/write accesses.
 	tokenLock sync.RWMutex
 
+	// Default request options applied to every request.
+	defaultRequestOptions []RequestOptionFunc
+
 	// User agent used when communicating with the GitLab API.
 	UserAgent string
-
-	// Request options that are applied to every request to the GitLab API.
-	requestOptions []RequestOptionFunc
 
 	// Services used for talking to different parts of the GitLab API.
 	AccessRequests          *AccessRequestsService
@@ -598,7 +598,7 @@ func (c *Client) NewRequest(method, path string, opt interface{}, options []Requ
 		return nil, err
 	}
 
-	for _, fn := range c.requestOptions {
+	for _, fn := range c.defaultRequestOptions {
 		if fn == nil {
 			continue
 		}
@@ -682,7 +682,7 @@ func (c *Client) UploadRequest(method, path string, content io.Reader, filename 
 		return nil, err
 	}
 
-	for _, fn := range c.requestOptions {
+	for _, fn := range c.defaultRequestOptions {
 		if fn == nil {
 			continue
 		}


### PR DESCRIPTION
This pull request adds a `WithRequestOptions` `ClientOptionFunc` that lets you configure the client to apply request options to every request to the GitLab API.

With this client option, I don't have to keep adding the same request options every time I want to make an API call.