### PR TITLE
Add enterprise attribute to metadata endpoint

### DIFF
--- a/metadata.go
+++ b/metadata.go
@@ -30,9 +30,10 @@ type MetadataService struct {
 //
 // GitLab API docs: https://docs.gitlab.com/ee/api/metadata.html
 type Metadata struct {
-	Version  string `json:"version"`
-	Revision string `json:"revision"`
-	KAS      struct {
+	Version    string `json:"version"`
+	Revision   string `json:"revision"`
+	Enterprise bool   `json:"enterprise"`
+	KAS        struct {
 		Enabled     bool   `json:"enabled"`
 		ExternalURL string `json:"externalUrl"`
 		Version     string `json:"version"`

--- a/metadata_test.go
+++ b/metadata_test.go
@@ -29,7 +29,7 @@ func TestGetMetadata(t *testing.T) {
 	mux.HandleFunc("/api/v4/metadata",
 		func(w http.ResponseWriter, r *http.Request) {
 			testMethod(t, r, http.MethodGet)
-			fmt.Fprint(w, `{"version":"15.6.0-pre","revision":"016e8d8bdc3","kas":{"enabled":true,"externalUrl":"wss://kas.gitlab.com","version":"15.6.0-rc2"}}`)
+			fmt.Fprint(w, `{"version":"15.6.0-pre","revision":"016e8d8bdc3","enterprise":true,"kas":{"enabled":true,"externalUrl":"wss://kas.gitlab.com","version":"15.6.0-rc2"}}`)
 		})
 
 	version, _, err := client.Metadata.GetMetadata()
@@ -37,7 +37,7 @@ func TestGetMetadata(t *testing.T) {
 		t.Errorf("Metadata.GetMetadata returned error: %v", err)
 	}
 
-	want := &Metadata{Version: "15.6.0-pre", Revision: "016e8d8bdc3", KAS: struct {
+	want := &Metadata{Version: "15.6.0-pre", Revision: "016e8d8bdc3", Enterprise: true, KAS: struct {
 		Enabled     bool   `json:"enabled"`
 		ExternalURL string `json:"externalUrl"`
 		Version     string `json:"version"`


### PR DESCRIPTION
The metadata API endpoint supports a `enterprise` response attribute [since 15.6](https://docs.gitlab.com/ee/api/metadata.html). This PR adds this support to the client. 