### PR TITLE
Add additional attributes to JobEvent

### DIFF
--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -356,6 +356,7 @@ type JobEvent struct {
 	User               *EventUser `json:"user"`
 	Commit             struct {
 		ID          int    `json:"id"`
+		Name        string `json:"name"`
 		SHA         string `json:"sha"`
 		Message     string `json:"message"`
 		AuthorName  string `json:"author_name"`

--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -349,6 +349,7 @@ type JobEvent struct {
 	BuildDuration      float64    `json:"build_duration"`
 	BuildAllowFailure  bool       `json:"build_allow_failure"`
 	BuildFailureReason string     `json:"build_failure_reason"`
+	RetriesCount       int        `json:"retries_count"`
 	PipelineID         int        `json:"pipeline_id"`
 	ProjectID          int        `json:"project_id"`
 	ProjectName        string     `json:"project_name"`

--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -344,6 +344,7 @@ type JobEvent struct {
 	BuildName          string     `json:"build_name"`
 	BuildStage         string     `json:"build_stage"`
 	BuildStatus        string     `json:"build_status"`
+	BuildCreatedAt     string     `json:"build_created_at"`
 	BuildStartedAt     string     `json:"build_started_at"`
 	BuildFinishedAt    string     `json:"build_finished_at"`
 	BuildDuration      float64    `json:"build_duration"`

--- a/event_webhook_types_test.go
+++ b/event_webhook_types_test.go
@@ -60,8 +60,85 @@ func TestBuildEventUnmarshal(t *testing.T) {
 	}
 
 	if event.BuildCreatedAt != "2021-02-23T02:41:37.886Z" {
-		t.Errorf("BuildCreatedAt is %s, want %s", event.User.Name, expectedName)
+		t.Errorf("BuildCreatedAt is %s, want 2021-02-23T02:41:37.886Z", event.BuildCreatedAt)
 	}
+}
+
+func TestJobEventUnmarshal(t *testing.T) {
+	jsonObject := loadFixture("testdata/webhooks/job.json")
+
+	var event *JobEvent
+	err := json.Unmarshal(jsonObject, &event)
+	if err != nil {
+		t.Errorf("Job Event can not unmarshaled: %v\n ", err.Error())
+	}
+
+	if event == nil {
+		t.Errorf("Job Event is null")
+	}
+
+	expectedEvent := JobEvent{
+		ObjectKind:         "build",
+		Ref:                "main",
+		Tag:                false,
+		BeforeSHA:          "0000000000000000000000000000000000000000",
+		SHA:                "95d49d1efbd941908580e79d65e4b5ecaf4a8305",
+		BuildID:            3580121225,
+		BuildName:          "auto_deploy:start",
+		BuildStage:         "coordinated:tag",
+		BuildStatus:        "success",
+		BuildCreatedAt:     "2023-01-10 13:50:02 UTC",
+		BuildStartedAt:     "2023-01-10 13:50:05 UTC",
+		BuildFinishedAt:    "2023-01-10 13:50:54 UTC",
+		BuildDuration:      49.503592,
+		BuildAllowFailure:  false,
+		BuildFailureReason: "unknown_failure",
+		RetriesCount:       1,
+		PipelineID:         743121198,
+		ProjectID:          31537070,
+		ProjectName:        "John Smith / release-tools-fake",
+		User: &EventUser{
+			ID:        2967854,
+			Name:      "John Smith",
+			Username:  "jsmithy2",
+			AvatarURL: "https://gitlab.com/uploads/-/system/user/avatar/2967852/avatar.png",
+			Email:     "john@smith.com",
+		},
+		Repository: &Repository{
+			Name:              "release-tools-fake",
+			Description:       "",
+			WebURL:            "",
+			AvatarURL:         "",
+			GitSSHURL:         "git@gitlab.com:jsmithy2/release-tools-fake.git",
+			GitHTTPURL:        "https://gitlab.com/jsmithy2/release-tools-fake.git",
+			Namespace:         "",
+			Visibility:        "",
+			PathWithNamespace: "",
+			DefaultBranch:     "",
+			Homepage:          "https://gitlab.com/jsmithy2/release-tools-fake",
+			URL:               "git@gitlab.com:jsmithy2/release-tools-fake.git",
+			SSHURL:            "",
+			HTTPURL:           "",
+		},
+	}
+	expectedEvent.Commit.ID = 743121198
+	expectedEvent.Commit.Name = "Build pipeline"
+	expectedEvent.Commit.SHA = "95d49d1efbd941908580e79d65e4b5ecaf4a8305"
+	expectedEvent.Commit.Message = "Remove test jobs and add back other jobs"
+	expectedEvent.Commit.AuthorName = "John Smith"
+	expectedEvent.Commit.AuthorEmail = "john@smith.com"
+	expectedEvent.Commit.AuthorURL = "https://gitlab.com/jsmithy2"
+	expectedEvent.Commit.Status = "running"
+	expectedEvent.Commit.Duration = 128
+	expectedEvent.Commit.StartedAt = "2023-01-10 13:50:05 UTC"
+	expectedEvent.Commit.FinishedAt = "2022-10-12 08:09:29 UTC"
+
+	expectedEvent.Runner.ID = 12270837
+	expectedEvent.Runner.Active = true
+	expectedEvent.Runner.Shared = true
+	expectedEvent.Runner.Description = "4-blue.shared.runners-manager.gitlab.com/default"
+
+	assert.Equal(t, expectedEvent, *event, "event should be equal to the expected one")
 }
 
 func TestDeploymentEventUnmarshal(t *testing.T) {

--- a/testdata/webhooks/job.json
+++ b/testdata/webhooks/job.json
@@ -1,0 +1,72 @@
+{
+  "object_kind": "build",
+  "ref": "main",
+  "tag": false,
+  "before_sha": "0000000000000000000000000000000000000000",
+  "sha": "95d49d1efbd941908580e79d65e4b5ecaf4a8305",
+  "build_id": 3580121225,
+  "build_name": "auto_deploy:start",
+  "build_stage": "coordinated:tag",
+  "build_status": "success",
+  "build_created_at": "2023-01-10 13:50:02 UTC",
+  "build_started_at": "2023-01-10 13:50:05 UTC",
+  "build_finished_at": "2023-01-10 13:50:54 UTC",
+  "build_duration": 49.503592,
+  "build_queued_duration": 0.193009,
+  "build_allow_failure": false,
+  "build_failure_reason": "unknown_failure",
+  "retries_count": 1,
+  "pipeline_id": 743121198,
+  "project_id": 31537070,
+  "project_name": "John Smith / release-tools-fake",
+  "runner": {
+    "id": 12270837,
+    "description": "4-blue.shared.runners-manager.gitlab.com/default",
+    "runner_type": "instance_type",
+    "active": true,
+    "is_shared": true,
+    "tags": [
+      "gce",
+      "east-c",
+      "linux",
+      "ruby",
+      "mysql",
+      "postgres",
+      "mongo",
+      "git-annex",
+      "shared",
+      "docker",
+      "saas-linux-small-amd64"
+    ]
+  },
+  "user": {
+    "id": 2967854,
+    "name": "John Smith",
+    "username": "jsmithy2",
+    "avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/2967852/avatar.png",
+    "email": "john@smith.com"
+  },
+  "commit": {
+    "id": 743121198,
+    "name": "Build pipeline",
+    "sha": "95d49d1efbd941908580e79d65e4b5ecaf4a8305",
+    "message": "Remove test jobs and add back other jobs",
+    "author_name": "John Smith",
+    "author_email": "john@smith.com",
+    "author_url": "https://gitlab.com/jsmithy2",
+    "status": "running",
+    "duration": 128,
+    "started_at": "2023-01-10 13:50:05 UTC",
+    "finished_at": "2022-10-12 08:09:29 UTC"
+  },
+  "repository": {
+    "name": "release-tools-fake",
+    "url": "git@gitlab.com:jsmithy2/release-tools-fake.git",
+    "description": "",
+    "homepage": "https://gitlab.com/jsmithy2/release-tools-fake",
+    "git_http_url": "https://gitlab.com/jsmithy2/release-tools-fake.git",
+    "git_ssh_url": "git@gitlab.com:jsmithy2/release-tools-fake.git",
+    "visibility_level": 20
+  },
+  "environment": null
+}


### PR DESCRIPTION
Add `retries_count`, `commit.name` and `build_created_at` to the JobEvent struct.

`retries_count` and `commit.name` are new attributes that have been recently added to the job webhook event payload:
- https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#number-of-retries
- https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#pipeline-name

`retries_count` is an integer that indicates if the job is a retry. 0 means that the job has not been retried. 1 means that it’s the first retry.

`commit.name` is the custom pipeline name, if the pipeline has a name.

`build_created_at` is the timestamp when the job was created.

Curiously, the `BuildEvent` and the `JobEvent` types appear to both be for Job events (https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#job-events).