### PR TITLE
feat: Add LastDownloadedAt for Package

### DIFF
--- a/packages.go
+++ b/packages.go
@@ -74,11 +74,11 @@ func (s PackageLinks) String() string {
 
 // PackageTag holds label information about the package
 type PackageTag struct {
-	ID        int       `json:"id"`
-	PackageID int       `json:"package_id"`
-	Name      string    `json:"name"`
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
+	ID        int        `json:"id"`
+	PackageID int        `json:"package_id"`
+	Name      string     `json:"name"`
+	CreatedAt *time.Time `json:"created_at"`
+	UpdatedAt *time.Time `json:"updated_at"`
 }
 
 func (s PackageTag) String() string {

--- a/packages.go
+++ b/packages.go
@@ -34,14 +34,15 @@ type PackagesService struct {
 //
 // GitLab API docs: https://docs.gitlab.com/ee/api/packages.html
 type Package struct {
-	ID          int           `json:"id"`
-	Name        string        `json:"name"`
-	Version     string        `json:"version"`
-	PackageType string        `json:"package_type"`
-	Status      string        `json:"status"`
-	Links       *PackageLinks `json:"_links"`
-	CreatedAt   *time.Time    `json:"created_at"`
-	Tags        []PackageTag  `json:"tags"`
+	ID               int           `json:"id"`
+	Name             string        `json:"name"`
+	Version          string        `json:"version"`
+	PackageType      string        `json:"package_type"`
+	Status           string        `json:"status"`
+	Links            *PackageLinks `json:"_links"`
+	CreatedAt        *time.Time    `json:"created_at"`
+	LastDownloadedAt *time.Time    `json:"last_downloaded_at"`
+	Tags             []PackageTag  `json:"tags"`
 }
 
 func (s Package) String() string {

--- a/packages_test.go
+++ b/packages_test.go
@@ -22,6 +22,7 @@ func TestPackagesService_ListProjectPackages(t *testing.T) {
 				"conan_package_name": "Hello",
 				"version": "0.1",
 				"package_type": "conan",
+				"last_downloaded_at": "2023-01-04T20:00:00.000Z"
 				"_links": {
 				  "web_path": "/foo/bar/-/packages/3",
 				  "delete_api_path": "https://gitlab.example.com/api/v4/projects/1/packages/3"
@@ -42,10 +43,11 @@ func TestPackagesService_ListProjectPackages(t *testing.T) {
 
 	timestamp := time.Date(2023, 1, 4, 20, 0, 0, 0, time.UTC)
 	want := []*Package{{
-		ID:          3,
-		Name:        "Hello/0.1@mycompany/stable",
-		Version:     "0.1",
-		PackageType: "conan",
+		ID:               3,
+		Name:             "Hello/0.1@mycompany/stable",
+		Version:          "0.1",
+		PackageType:      "conan",
+		LastDownloadedAt: &timestamp,
 		Links: &PackageLinks{
 			WebPath:       "/foo/bar/-/packages/3",
 			DeleteAPIPath: "https://gitlab.example.com/api/v4/projects/1/packages/3",

--- a/packages_test.go
+++ b/packages_test.go
@@ -22,7 +22,7 @@ func TestPackagesService_ListProjectPackages(t *testing.T) {
 				"conan_package_name": "Hello",
 				"version": "0.1",
 				"package_type": "conan",
-				"last_downloaded_at": "2023-01-04T20:00:00.000Z"
+				"last_downloaded_at": "2023-01-04T20:00:00.000Z",
 				"_links": {
 				  "web_path": "/foo/bar/-/packages/3",
 				  "delete_api_path": "https://gitlab.example.com/api/v4/projects/1/packages/3"
@@ -57,8 +57,8 @@ func TestPackagesService_ListProjectPackages(t *testing.T) {
 				ID:        1,
 				PackageID: 37,
 				Name:      "Some Label",
-				CreatedAt: timestamp,
-				UpdatedAt: timestamp,
+				CreatedAt: &timestamp,
+				UpdatedAt: &timestamp,
 			}},
 	}}
 


### PR DESCRIPTION
The API for retrieving packages from a group or repository offers also a `last_downloaded_at` field:
```json
[
    {
        "id": 36,
        "name": "My.Fancy.Package",
        "version": "2.2.0",
        "package_type": "nuget",
        "status": "default",
        "_links": {
            "web_path": "/myrepo/dotnet-nuget/-/packages/36",
            "delete_api_path": "https://gitlab.myprivateinstance.io/api/v4/projects/44/packages/36"
        },
        "created_at": "2023-01-04T15:20:44.174Z",
        "last_downloaded_at": null,
        "tags": []
    }
]
```