### PR TITLE
Add missing system hook event for user_failed_login

### DIFF
--- a/event_parsing.go
+++ b/event_parsing.go
@@ -155,7 +155,8 @@ func ParseSystemhook(payload []byte) (event interface{}, err error) {
 	case
 		"user_create",
 		"user_destroy",
-		"user_rename":
+		"user_rename",
+		"user_failed_login":
 		event = &UserSystemEvent{}
 	case
 		"user_add_to_group",

--- a/event_parsing_systemhook_test.go
+++ b/event_parsing_systemhook_test.go
@@ -140,6 +140,7 @@ func TestParseSystemhookUser(t *testing.T) {
 		{"user_create", loadFixture("testdata/systemhooks/user_create.json")},
 		{"user_destroy", loadFixture("testdata/systemhooks/user_destroy.json")},
 		{"user_rename", loadFixture("testdata/systemhooks/user_rename.json")},
+		{"user_failed_login", loadFixture("testdata/systemhooks/user_failed_login.json")},
 	}
 	for _, tc := range tests {
 		t.Run(tc.event, func(t *testing.T) {

--- a/event_systemhook_types.go
+++ b/event_systemhook_types.go
@@ -90,6 +90,7 @@ type UserSystemEvent struct {
 	Username    string `json:"username"`
 	OldUsername string `json:"old_username,omitempty"`
 	Email       string `json:"email"`
+	State       string `json:"state,omitempty"`
 }
 
 // UserGroupSystemEvent represents a user group system event.


### PR DESCRIPTION
This PR adds the missing system hook event for `user_failed_login` as documented in the [GitLab Docs](https://docs.gitlab.com/ee/administration/system_hooks.html).

Interestingly enough the test data for the event was already there.