### PR TITLE
Add field import_url to Project

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -99,6 +99,7 @@ type Project struct {
 	MirrorTriggerBuilds                       bool                       `json:"mirror_trigger_builds"`
 	OnlyMirrorProtectedBranches               bool                       `json:"only_mirror_protected_branches"`
 	MirrorOverwritesDivergedBranches          bool                       `json:"mirror_overwrites_diverged_branches"`
+	ImportURL                                 string                     `json:"import_url"`
 	PackagesEnabled                           bool                       `json:"packages_enabled"`
 	ServiceDeskEnabled                        bool                       `json:"service_desk_enabled"`
 	ServiceDeskAddress                        string                     `json:"service_desk_address"`


### PR DESCRIPTION
Field is available in the API, but missing from the api docs.

https://gitlab.com/gitlab-org/gitlab/-/blob/b93c0cf331413309e44695dac7a3bc63f5bf1b5d/lib/api/entities/project.rb#L98-100