### PR TITLE
Add method `SnippetContentAtFile` and `Visibility` to Snippet

### DIFF
--- a/snippets.go
+++ b/snippets.go
@@ -182,24 +182,6 @@ func (s *SnippetsService) UpdateSnippet(snippet int, opt *UpdateSnippetOptions, 
 	return ps, resp, err
 }
 
-func (s *SnippetsService) UpdateSnippetAtFile(snippet int, ref, filename string, opt *UpdateSnippetOptions, options ...RequestOptionFunc) (*Snippet, *Response, error) {
-	filepath := url.QueryEscape(filename)
-	u := fmt.Sprintf("snippets/%d/files/%s/%s/raw", snippet, ref, filepath)
-
-	req, err := s.client.NewRequest(http.MethodPut, u, opt, options)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	ps := new(Snippet)
-	resp, err := s.client.Do(req, ps)
-	if err != nil {
-		return nil, resp, err
-	}
-
-	return ps, resp, err
-}
-
 // DeleteSnippet deletes an existing snippet. This is an idempotent
 // function and deleting a non-existent snippet still returns a 200 OK status
 // code.
@@ -208,18 +190,6 @@ func (s *SnippetsService) UpdateSnippetAtFile(snippet int, ref, filename string,
 // https://docs.gitlab.com/ee/api/snippets.html#delete-snippet
 func (s *SnippetsService) DeleteSnippet(snippet int, options ...RequestOptionFunc) (*Response, error) {
 	u := fmt.Sprintf("snippets/%d", snippet)
-
-	req, err := s.client.NewRequest(http.MethodDelete, u, nil, options)
-	if err != nil {
-		return nil, err
-	}
-
-	return s.client.Do(req, nil)
-}
-
-func (s *SnippetsService) DeleteSnippetAtFile(snippet int, ref, filename string, options ...RequestOptionFunc) (*Response, error) {
-	filepath := url.QueryEscape(filename)
-	u := fmt.Sprintf("snippets/%d/files/%s/%s/raw", snippet, ref, filepath)
 
 	req, err := s.client.NewRequest(http.MethodDelete, u, nil, options)
 	if err != nil {

--- a/snippets.go
+++ b/snippets.go
@@ -40,6 +40,7 @@ type Snippet struct {
 	Title       string `json:"title"`
 	FileName    string `json:"file_name"`
 	Description string `json:"description"`
+	Visibility  string `json:"visibility"`
 	Author      struct {
 		ID        int        `json:"id"`
 		Username  string     `json:"username"`

--- a/snippets.go
+++ b/snippets.go
@@ -65,12 +65,14 @@ func (s Snippet) String() string {
 
 // ListSnippetsOptions represents the available ListSnippets() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/snippets.html#list-all-snippets-for-a-user
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/snippets.html#list-all-snippets-for-a-user
 type ListSnippetsOptions ListOptions
 
 // ListSnippets gets a list of snippets.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/snippets.html#list-all-snippets-for-a-user
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/snippets.html#list-all-snippets-for-a-user
 func (s *SnippetsService) ListSnippets(opt *ListSnippetsOptions, options ...RequestOptionFunc) ([]*Snippet, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "snippets", opt, options)
 	if err != nil {
@@ -105,6 +107,49 @@ func (s *SnippetsService) GetSnippet(snippet int, options ...RequestOptionFunc) 
 	}
 
 	return ps, resp, err
+}
+
+// SnippetContent gets a single snippet’s raw contents.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/snippets.html#single-snippet-contents
+func (s *SnippetsService) SnippetContent(snippet int, options ...RequestOptionFunc) ([]byte, *Response, error) {
+	u := fmt.Sprintf("snippets/%d/raw", snippet)
+
+	req, err := s.client.NewRequest(http.MethodGet, u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var b bytes.Buffer
+	resp, err := s.client.Do(req, &b)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return b.Bytes(), resp, err
+}
+
+// SnippetFileContent returns the raw file content as plain text.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/snippets.html#snippet-repository-file-content
+func (s *SnippetsService) SnippetFileContent(snippet int, ref, filename string, options ...RequestOptionFunc) ([]byte, *Response, error) {
+	filepath := url.QueryEscape(filename)
+	u := fmt.Sprintf("snippets/%d/files/%s/%s/raw", snippet, ref, filepath)
+
+	req, err := s.client.NewRequest(http.MethodGet, u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var b bytes.Buffer
+	resp, err := s.client.Do(req, &b)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return b.Bytes(), resp, err
 }
 
 // SnippetFile represents the object that is used to create snippets
@@ -198,49 +243,6 @@ func (s *SnippetsService) DeleteSnippet(snippet int, options ...RequestOptionFun
 	}
 
 	return s.client.Do(req, nil)
-}
-
-// SnippetContent returns the raw snippet as plain text.
-//
-// GitLab API docs:
-// https://docs.gitlab.com/ee/api/snippets.html#single-snippet-contents
-func (s *SnippetsService) SnippetContent(snippet int, options ...RequestOptionFunc) ([]byte, *Response, error) {
-	u := fmt.Sprintf("snippets/%d/raw", snippet)
-
-	req, err := s.client.NewRequest(http.MethodGet, u, nil, options)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	var b bytes.Buffer
-	resp, err := s.client.Do(req, &b)
-	if err != nil {
-		return nil, resp, err
-	}
-
-	return b.Bytes(), resp, err
-}
-
-// SnippetContentAtFile returns the raw snippet at file as plain text.
-//
-// GitLab API docs:
-// https://docs.gitlab.com/ee/api/snippets.html#snippet-repository-file-content
-func (s *SnippetsService) SnippetContentAtFile(snippet int, ref, filename string, options ...RequestOptionFunc) ([]byte, *Response, error) {
-	filepath := url.QueryEscape(filename)
-	u := fmt.Sprintf("snippets/%d/files/%s/%s/raw", snippet, ref, filepath)
-
-	req, err := s.client.NewRequest(http.MethodGet, u, nil, options)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	var b bytes.Buffer
-	resp, err := s.client.Do(req, &b)
-	if err != nil {
-		return nil, resp, err
-	}
-
-	return b.Bytes(), resp, err
 }
 
 // ExploreSnippetsOptions represents the available ExploreSnippets() options.


### PR DESCRIPTION
I made the following changes to the snippet.

- Add method SnippetContentAtFile.
- Add key `Visibility` to Snippet struct. 

### Add method SnippetContentAtFile.

Since Gitlab Premium allows multiple files to be registered in a snippet, we added the method `SnippetContentAtFile`.
This method is used to specify a file in a snippet and retrieve its content.

- https://docs.gitlab.com/ee/user/snippets.html#add-or-remove-multiple-files
- https://docs.gitlab.com/ee/api/snippets.html#snippet-repository-file-content

### Add key `Visibility` to Snippet struct. 

Snippet Visibility Level added to Struct.

- https://docs.gitlab.com/ee/api/snippets.html#snippet-visibility-level