### PR TITLE
Add ListOptions to GetProjectApprovalRules

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -1772,11 +1772,16 @@ func (s *ProjectsService) ChangeApprovalConfiguration(pid interface{}, opt *Chan
 	return pa, resp, err
 }
 
-// GetProjectApprovalRules looks up the list of project level approvers.
+// GetProjectApprovalRulesListsOptions represents the available GetProjectApprovalRules() options.
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/merge_request_approvals.html#get-project-level-rules
+type GetProjectApprovalRulesListsOptions ListOptions
+
+// GetProjectApprovalRules looks up the list of project level approver rules.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/merge_request_approvals.html#get-project-level-rules
-func (s *ProjectsService) GetProjectApprovalRules(pid interface{}, options ...RequestOptionFunc) ([]*ProjectApprovalRule, *Response, error) {
+func (s *ProjectsService) GetProjectApprovalRules(pid interface{}, opt *GetProjectApprovalRulesListsOptions, options ...RequestOptionFunc) ([]*ProjectApprovalRule, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err

--- a/projects_test.go
+++ b/projects_test.go
@@ -846,7 +846,7 @@ func TestGetProjectApprovalRules(t *testing.T) {
 		]`)
 	})
 
-	approvals, _, err := client.Projects.GetProjectApprovalRules(1)
+	approvals, _, err := client.Projects.GetProjectApprovalRules(1, nil)
 	if err != nil {
 		t.Errorf("Projects.GetProjectApprovalRules returned error: %v", err)
 	}


### PR DESCRIPTION
This MR adds a `ListOptions` parameter to `GetProjectApprovalRules` to support pagination.

/closes https://github.com/xanzy/go-gitlab/issues/1628