### PR TITLE
Fix GetProjectApprovalRules pagination

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -1788,7 +1788,7 @@ func (s *ProjectsService) GetProjectApprovalRules(pid interface{}, opt *GetProje
 	}
 	u := fmt.Sprintf("projects/%s/approval_rules", PathEscape(project))
 
-	req, err := s.client.NewRequest(http.MethodGet, u, nil, options)
+	req, err := s.client.NewRequest(http.MethodGet, u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
As pointed out by @bmendric, the new `GetProjectApprovalRulesListsOptions` parameter introduced in #1641 wasn't used in the `GetProjectApprovalRules` function. The parameter is now used in the `NewRequest` function as expected.