### PR TITLE
Add omitempty and test

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -633,7 +633,7 @@ func (s *ProjectsService) GetProjectEvents(pid interface{}, opt *GetProjectEvent
 // GitLab API docs: https://docs.gitlab.com/ee/api/projects.html#create-project
 type CreateProjectOptions struct {
 	AllowMergeOnSkippedPipeline               *bool                                `url:"allow_merge_on_skipped_pipeline,omitempty" json:"allow_merge_on_skipped_pipeline,omitempty"`
-	OnlyAllowMergeIfAllStatusChecksPassed     *bool                                `url:"only_allow_merge_if_all_status_checks_passed" json:"only_allow_merge_if_all_status_checks_passed"`
+	OnlyAllowMergeIfAllStatusChecksPassed     *bool                                `url:"only_allow_merge_if_all_status_checks_passed,omitempty" json:"only_allow_merge_if_all_status_checks_passed,omitempty"`
 	AnalyticsAccessLevel                      *AccessControlValue                  `url:"analytics_access_level,omitempty" json:"analytics_access_level,omitempty"`
 	ApprovalsBeforeMerge                      *int                                 `url:"approvals_before_merge,omitempty" json:"approvals_before_merge,omitempty"`
 	AutoCancelPendingPipelines                *string                              `url:"auto_cancel_pending_pipelines,omitempty" json:"auto_cancel_pending_pipelines,omitempty"`
@@ -853,7 +853,7 @@ func (s *ProjectsService) CreateProjectForUser(user int, opt *CreateProjectForUs
 // GitLab API docs: https://docs.gitlab.com/ee/api/projects.html#edit-project
 type EditProjectOptions struct {
 	AllowMergeOnSkippedPipeline               *bool                                `url:"allow_merge_on_skipped_pipeline,omitempty" json:"allow_merge_on_skipped_pipeline,omitempty"`
-	OnlyAllowMergeIfAllStatusChecksPassed     *bool                                `url:"only_allow_merge_if_all_status_checks_passed" json:"only_allow_merge_if_all_status_checks_passed"`
+	OnlyAllowMergeIfAllStatusChecksPassed     *bool                                `url:"only_allow_merge_if_all_status_checks_passed,omitempty" json:"only_allow_merge_if_all_status_checks_passed,omitempty"`
 	AnalyticsAccessLevel                      *AccessControlValue                  `url:"analytics_access_level,omitempty" json:"analytics_access_level,omitempty"`
 	ApprovalsBeforeMerge                      *int                                 `url:"approvals_before_merge,omitempty" json:"approvals_before_merge,omitempty"`
 	AutoCancelPendingPipelines                *string                              `url:"auto_cancel_pending_pipelines,omitempty" json:"auto_cancel_pending_pipelines,omitempty"`

--- a/projects_test.go
+++ b/projects_test.go
@@ -1366,7 +1366,6 @@ func TestCreateProjectApprovalRuleEligibleApprovers(t *testing.T) {
 }
 
 func TestProjectModelsOptionalMergeAttribute(t *testing.T) {
-
 	// Create a `CreateProjectOptions` struct, ensure that merge attribute doesn't serialize
 	jsonString, err := json.Marshal(&CreateProjectOptions{
 		Name: String("testProject"),
@@ -1384,5 +1383,4 @@ func TestProjectModelsOptionalMergeAttribute(t *testing.T) {
 		t.Fatal("Failed to marshal object", err)
 	}
 	assert.False(t, strings.Contains(string(jsonString), "only_allow_merge_if_all_status_checks_passed"))
-
 }

--- a/projects_test.go
+++ b/projects_test.go
@@ -18,6 +18,7 @@ package gitlab
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
@@ -25,6 +26,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestListProjects(t *testing.T) {
@@ -1360,4 +1363,26 @@ func TestCreateProjectApprovalRuleEligibleApprovers(t *testing.T) {
 	if !reflect.DeepEqual(want, rule) {
 		t.Errorf("Projects.CreateProjectApprovalRule returned %+v, want %+v", rule, want)
 	}
+}
+
+func TestProjectModelsOptionalMergeAttribute(t *testing.T) {
+
+	// Create a `CreateProjectOptions` struct, ensure that merge attribute doesn't serialize
+	jsonString, err := json.Marshal(&CreateProjectOptions{
+		Name: String("testProject"),
+	})
+	if err != nil {
+		t.Fatal("Failed to marshal object", err)
+	}
+	assert.False(t, strings.Contains(string(jsonString), "only_allow_merge_if_all_status_checks_passed"))
+
+	// Test the same thing but for `EditProjectOptions` struct
+	jsonString, err = json.Marshal(&EditProjectOptions{
+		Name: String("testProject"),
+	})
+	if err != nil {
+		t.Fatal("Failed to marshal object", err)
+	}
+	assert.False(t, strings.Contains(string(jsonString), "only_allow_merge_if_all_status_checks_passed"))
+
 }


### PR DESCRIPTION
Closes #1664 

This updates one optional project attribute to use `omitempty`, and creates one test to ensure that marshalling the object with that attribute not set doesn't include that tag anymore :)