### PR TITLE
Draft: Updated Webhook types 

### DIFF
--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -197,6 +197,23 @@ type DeploymentEvent struct {
 	CommitTitle string     `json:"commit_title"`
 }
 
+// FeatureFlagEvent represents a feature flag event
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#feature-flag-events
+type FeatureFlagEvent struct {
+	ObjectKind       string     `json:"object_kind"`
+	Project          *Project   `json:"project"` // TODO check which Project struct to use Project or ProjectEvent
+	User             *EventUser `json:"user"`
+	UserURL          string     `json:"user_url"`
+	ObjectAttributes struct {
+		ID          int    `json:"id"`
+		Name        string `json:"name"`
+		Description string `json:"description"`
+		Active      bool   `json:"active"`
+	} `json:"object_attributes"`
+}
+
 // IssueCommentEvent represents a comment on an issue event.
 //
 // GitLab API docs:

--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -671,10 +671,22 @@ type MergeEvent struct {
 	Repository *Repository   `json:"repository"`
 	Labels     []*EventLabel `json:"labels"`
 	Changes    struct {
+		Assignees struct {
+			Previous []*EventUser `json:"previous"`
+			Current  []*EventUser `json:"current"`
+		} `json:"assignees"`
+		Reviewers struct {
+			Previous []*EventUser `json:"previous"`
+			Current  []*EventUser `json:"current"`
+		} `json:"reviewers"`
 		Description struct {
 			Previous string `json:"previous"`
 			Current  string `json:"current"`
 		} `json:"description"`
+		Labels struct {
+			Previous []*EventLabel `json:"previous"`
+			Current  []*EventLabel `json:"current"`
+		} `json:"labels"`
 		LastEditedAt struct {
 			Previous string `json:"previous"`
 			Current  string `json:"current"`
@@ -683,6 +695,34 @@ type MergeEvent struct {
 			Previous int `json:"previous"`
 			Current  int `json:"current"`
 		} `json:"last_edited_by_id"`
+		MilestoneID struct {
+			Previous int `json:"previous"`
+			Current  int `json:"current"`
+		} `json:"milestone_id"`
+		SourceBranch struct {
+			Previous string `json:"previous"`
+			Current  string `json:"current"`
+		} `json:"source_branch"`
+		SourceProjectID struct {
+			Previous int `json:"previous"`
+			Current  int `json:"current"`
+		} `json:"source_project_id"`
+		StateID struct {
+			Previous StateID `json:"previous"`
+			Current  StateID `json:"current"`
+		} `json:"state_id"`
+		TargetBranch struct {
+			Previous string `json:"previous"`
+			Current  string `json:"current"`
+		} `json:"target_branch"`
+		TargetProjectID struct {
+			Previous int `json:"previous"`
+			Current  int `json:"current"`
+		} `json:"target_project_id"`
+		Title struct {
+			Previous string `json:"previous"`
+			Current  string `json:"current"`
+		} `json:"title"`
 		UpdatedAt struct {
 			Previous string `json:"previous"`
 			Current  string `json:"current"`
@@ -691,10 +731,6 @@ type MergeEvent struct {
 			Previous int `json:"previous"`
 			Current  int `json:"current"`
 		} `json:"updated_by_id"`
-		Labels struct {
-			Previous *EventLabel `json:"previous"`
-			Current  EventLabel  `json:"current"`
-		} `json:"labels"`
 	} `json:"changes"`
 	Assignees []*EventUser `json:"assignees"`
 	Reviewers []*EventUser `json:"reviewers"`

--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -140,18 +140,9 @@ type CommitCommentEvent struct {
 		CommitID     string `json:"commit_id"`
 		NoteableID   int    `json:"noteable_id"`
 		System       bool   `json:"system"`
-		StDiff       struct {
-			Diff        string `json:"diff"`
-			NewPath     string `json:"new_path"`
-			OldPath     string `json:"old_path"`
-			AMode       string `json:"a_mode"`
-			BMode       string `json:"b_mode"`
-			NewFile     bool   `json:"new_file"`
-			RenamedFile bool   `json:"renamed_file"`
-			DeletedFile bool   `json:"deleted_file"`
-		} `json:"st_diff"`
-		Description string `json:"description"`
-		URL         string `json:"url"`
+		StDiff       *Diff  `json:"st_diff"`
+		Description  string `json:"description"`
+		URL          string `json:"url"`
 	} `json:"object_attributes"`
 	Commit *struct { // TODO create Commit struct
 		ID        string     `json:"id"`
@@ -439,9 +430,11 @@ type MemberEvent struct {
 // https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#comment-on-a-merge-request
 type MergeCommentEvent struct {
 	ObjectKind string     `json:"object_kind"`
+	EventType  string     `json:"event_type"`
 	User       *EventUser `json:"user"`
 	ProjectID  int        `json:"project_id"`
-	Project    struct {
+	Project    struct {   // TODO use Project struct
+		ID                int             `json:"id"`
 		Name              string          `json:"name"`
 		Description       string          `json:"description"`
 		AvatarURL         string          `json:"avatar_url"`
@@ -462,7 +455,7 @@ type MergeCommentEvent struct {
 		AuthorID         int           `json:"author_id"`
 		ChangePosition   *NotePosition `json:"change_position"`
 		CommitID         string        `json:"commit_id"`
-		CreatedAt        string        `json:"created_at"`
+		CreatedAt        string        `json:"created_at"` // TODO Should be *time.Time
 		DiscussionID     string        `json:"discussion_id"`
 		ID               int           `json:"id"`
 		LineCode         string        `json:"line_code"`
@@ -484,42 +477,43 @@ type MergeCommentEvent struct {
 		URL              string        `json:"url"`
 	} `json:"object_attributes"`
 	Repository   *Repository `json:"repository"`
-	MergeRequest struct {
-		ID                        int          `json:"id"`
-		TargetBranch              string       `json:"target_branch"`
-		SourceBranch              string       `json:"source_branch"`
-		SourceProjectID           int          `json:"source_project_id"`
-		AuthorID                  int          `json:"author_id"`
-		AssigneeID                int          `json:"assignee_id"`
-		AssigneeIDs               []int        `json:"assignee_ids"`
-		Title                     string       `json:"title"`
-		CreatedAt                 string       `json:"created_at"`
-		UpdatedAt                 string       `json:"updated_at"`
-		MilestoneID               int          `json:"milestone_id"`
-		State                     string       `json:"state"`
-		MergeStatus               string       `json:"merge_status"`
-		TargetProjectID           int          `json:"target_project_id"`
-		IID                       int          `json:"iid"`
-		Description               string       `json:"description"`
-		Position                  int          `json:"position"`
-		LockedAt                  string       `json:"locked_at"`
-		UpdatedByID               int          `json:"updated_by_id"`
-		MergeError                string       `json:"merge_error"`
-		MergeParams               *MergeParams `json:"merge_params"`
-		MergeWhenPipelineSucceeds bool         `json:"merge_when_pipeline_succeeds"`
-		MergeUserID               int          `json:"merge_user_id"`
-		MergeCommitSHA            string       `json:"merge_commit_sha"`
-		DeletedAt                 string       `json:"deleted_at"`
-		InProgressMergeCommitSHA  string       `json:"in_progress_merge_commit_sha"`
-		LockVersion               int          `json:"lock_version"`
-		ApprovalsBeforeMerge      string       `json:"approvals_before_merge"`
-		RebaseCommitSHA           string       `json:"rebase_commit_sha"`
-		TimeEstimate              int          `json:"time_estimate"`
-		Squash                    bool         `json:"squash"`
-		LastEditedAt              string       `json:"last_edited_at"`
-		LastEditedByID            int          `json:"last_edited_by_id"`
-		Source                    *Repository  `json:"source"`
-		Target                    *Repository  `json:"target"`
+	MergeRequest struct {    // TODO Check if MergeEvent struct can be used
+		ID                        int           `json:"id"`
+		TargetBranch              string        `json:"target_branch"`
+		SourceBranch              string        `json:"source_branch"`
+		SourceProjectID           int           `json:"source_project_id"`
+		AuthorID                  int           `json:"author_id"`
+		AssigneeID                int           `json:"assignee_id"`
+		AssigneeIDs               []int         `json:"assignee_ids"`
+		Title                     string        `json:"title"`
+		CreatedAt                 string        `json:"created_at"` // TODO Should be *time.Time
+		UpdatedAt                 string        `json:"updated_at"` // TODO Should be *time.Time
+		MilestoneID               int           `json:"milestone_id"`
+		State                     string        `json:"state"`
+		MergeStatus               string        `json:"merge_status"`
+		TargetProjectID           int           `json:"target_project_id"`
+		IID                       int           `json:"iid"`
+		Description               string        `json:"description"`
+		Position                  int           `json:"position"`
+		Labels                    []*EventLabel `json:"labels"`
+		LockedAt                  string        `json:"locked_at"`
+		UpdatedByID               int           `json:"updated_by_id"`
+		MergeError                string        `json:"merge_error"`
+		MergeParams               *MergeParams  `json:"merge_params"`
+		MergeWhenPipelineSucceeds bool          `json:"merge_when_pipeline_succeeds"`
+		MergeUserID               int           `json:"merge_user_id"`
+		MergeCommitSHA            string        `json:"merge_commit_sha"`
+		DeletedAt                 string        `json:"deleted_at"`
+		InProgressMergeCommitSHA  string        `json:"in_progress_merge_commit_sha"`
+		LockVersion               int           `json:"lock_version"`
+		ApprovalsBeforeMerge      string        `json:"approvals_before_merge"`
+		RebaseCommitSHA           string        `json:"rebase_commit_sha"`
+		TimeEstimate              int           `json:"time_estimate"`
+		Squash                    bool          `json:"squash"`
+		LastEditedAt              string        `json:"last_edited_at"`
+		LastEditedByID            int           `json:"last_edited_by_id"`
+		Source                    *Repository   `json:"source"`
+		Target                    *Repository   `json:"target"`
 		LastCommit                struct {
 			ID        string     `json:"id"`
 			Title     string     `json:"title"`
@@ -531,9 +525,11 @@ type MergeCommentEvent struct {
 				Email string `json:"email"`
 			} `json:"author"`
 		} `json:"last_commit"`
-		WorkInProgress bool `json:"work_in_progress"`
-		TotalTimeSpent int  `json:"total_time_spent"`
-		HeadPipelineID int  `json:"head_pipeline_id"`
+		WorkInProgress      bool       `json:"work_in_progress"`
+		TotalTimeSpent      int        `json:"total_time_spent"`
+		HeadPipelineID      int        `json:"head_pipeline_id"`
+		Assignee            *EventUser `json:"assignee"`
+		DetailedMergeStatus string     `json:"detailed_merge_status"`
 	} `json:"merge_request"`
 }
 

--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -87,15 +87,15 @@ type BuildEvent struct {
 	ProjectName       string     `json:"project_name"`
 	User              *EventUser `json:"user"`
 	Commit            struct {
-		ID          int    `json:"id"`
-		SHA         string `json:"sha"`
-		Message     string `json:"message"`
-		AuthorName  string `json:"author_name"`
-		AuthorEmail string `json:"author_email"`
-		Status      string `json:"status"`
-		Duration    int    `json:"duration"`
-		StartedAt   string `json:"started_at"`
-		FinishedAt  string `json:"finished_at"`
+		ID          int     `json:"id"`
+		SHA         string  `json:"sha"`
+		Message     string  `json:"message"`
+		AuthorName  string  `json:"author_name"`
+		AuthorEmail string  `json:"author_email"`
+		Status      string  `json:"status"`
+		Duration    float64 `json:"duration"`
+		StartedAt   string  `json:"started_at"`
+		FinishedAt  string  `json:"finished_at"`
 	} `json:"commit"`
 	Repository *Repository `json:"repository"`
 }
@@ -327,7 +327,6 @@ type IssueEvent struct {
 		LastEditedAt        string   `json:"last_edited_at"` // Should be *time.Time
 		LastEditedByID      int      `json:"last_edited_by_id"`
 		RelativePosition    int      `json:"relative_position"`
-		Position            int      `json:"position"` // TODO GitLab doc doesn't mention this field
 		BranchName          string   `json:"branch_name"`
 		Description         string   `json:"description"`
 		MilestoneID         int      `json:"milestone_id"`
@@ -340,10 +339,10 @@ type IssueEvent struct {
 		TimeEstimate        int      `json:"time_estimate"`
 		TotalTimeSpent      int      `json:"total_time_spent"`
 		TimeChange          int      `json:"time_change"`
-		HumanTotalTimeSpent string   `json:"human_total_time_spent"` // TODO Check type
-		HumanTimeEstimate   string   `json:"human_time_estimate"`    // TODO Check type
-		HumanTimeChange     string   `json:"human_time_change"`      // TODO Check type
-		Weight              string   `json:"weight"`                 // TODO Check type
+		HumanTotalTimeSpent string   `json:"human_total_time_spent"`
+		HumanTimeEstimate   string   `json:"human_time_estimate"`
+		HumanTimeChange     string   `json:"human_time_change"`
+		Weight              string   `json:"weight"`
 		IID                 int      `json:"iid"`
 		URL                 string   `json:"url"`
 		State               string   `json:"state"`
@@ -426,28 +425,28 @@ type JobEvent struct {
 	ProjectName         string     `json:"project_name"`
 	User                *EventUser `json:"user"`
 	Commit              struct {
-		ID          int    `json:"id"`
-		Name        string `json:"name"`
-		SHA         string `json:"sha"`
-		Message     string `json:"message"`
-		AuthorName  string `json:"author_name"`
-		AuthorEmail string `json:"author_email"`
-		AuthorURL   string `json:"author_url"`
-		Status      string `json:"status"`
-		Duration    int    `json:"duration"`
-		StartedAt   string `json:"started_at"`
-		FinishedAt  string `json:"finished_at"`
+		ID          int     `json:"id"`
+		Name        string  `json:"name"`
+		SHA         string  `json:"sha"`
+		Message     string  `json:"message"`
+		AuthorName  string  `json:"author_name"`
+		AuthorEmail string  `json:"author_email"`
+		AuthorURL   string  `json:"author_url"`
+		Status      string  `json:"status"`
+		Duration    float64 `json:"duration"`
+		StartedAt   string  `json:"started_at"`
+		FinishedAt  string  `json:"finished_at"`
 	} `json:"commit"`
 	Repository *Repository `json:"repository"`
 	Runner     struct {
 		ID          int      `json:"id"`
 		Active      bool     `json:"active"`
 		RunnerType  string   `json:"runner_type"`
-		Shared      bool     `json:"is_shared"` // TODO variable name should be IsShared
+		IsShared    bool     `json:"is_shared"`
 		Description string   `json:"description"`
 		Tags        []string `json:"tags"`
 	} `json:"runner"`
-	Environment string `json:"environment"` // TODO: Verify type
+	Environment string `json:"environment"`
 }
 
 // MemberEvent represents a member event.
@@ -672,15 +671,15 @@ type MergeEvent struct {
 	Repository *Repository   `json:"repository"`
 	Labels     []*EventLabel `json:"labels"`
 	Changes    struct {
-		Description struct { // TODO GitLab doc doesn't mention this field
+		Description struct {
 			Previous string `json:"previous"`
 			Current  string `json:"current"`
 		} `json:"description"`
-		LastEditedAt struct { // TODO GitLab doc doesn't mention this field
+		LastEditedAt struct {
 			Previous string `json:"previous"`
 			Current  string `json:"current"`
 		} `json:"last_edited_at"`
-		LastEditedByID struct { // TODO GitLab doc doesn't mention this field
+		LastEditedByID struct {
 			Previous int `json:"previous"`
 			Current  int `json:"current"`
 		} `json:"last_edited_by_id"`
@@ -764,12 +763,12 @@ type PipelineEvent struct {
 		BeforeSHA      string   `json:"before_sha"`
 		Source         string   `json:"source"`
 		Status         string   `json:"status"`
-		DetailedStatus string   `json:"detailed_status"` // TODO GitLab doc doesn't mention this field
+		DetailedStatus string   `json:"detailed_status"`
 		Stages         []string `json:"stages"`
-		CreatedAt      string   `json:"created_at"`      // TODO should be *time.Time
-		FinishedAt     string   `json:"finished_at"`     // TODO should be *time.Time
-		Duration       int      `json:"duration"`        // TODO verify type
-		QueuedDuration int      `json:"queued_duration"` // TODO verify type
+		CreatedAt      string   `json:"created_at"`  // TODO should be *time.Time
+		FinishedAt     string   `json:"finished_at"` // TODO should be *time.Time
+		Duration       float64  `json:"duration"`
+		QueuedDuration float64  `json:"queued_duration"`
 		Variables      []struct {
 			Key   string `json:"key"`
 			Value string `json:"value"`
@@ -959,7 +958,7 @@ type ReleaseEvent struct {
 			URL    string `json:"url"`
 		} `json:"sources"`
 	} `json:"assets"`
-	Commit struct {
+	Commit struct { // TODO replace with Commit struct
 		ID        string `json:"id"`
 		Message   string `json:"message"`
 		Title     string `json:"title"`

--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -1039,19 +1039,21 @@ type SubGroupEvent struct {
 // GitLab API docs:
 // https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#tag-events
 type TagEvent struct {
-	ObjectKind   string `json:"object_kind"`
-	Before       string `json:"before"`
-	After        string `json:"after"`
-	Ref          string `json:"ref"`
-	CheckoutSHA  string `json:"checkout_sha"`
-	UserID       int    `json:"user_id"`
-	UserName     string `json:"user_name"`
-	UserUsername string `json:"user_username"`
-	UserAvatar   string `json:"user_avatar"`
-	UserEmail    string `json:"user_email"`
-	ProjectID    int    `json:"project_id"`
-	Message      string `json:"message"`
-	Project      struct {
+	ObjectKind   string   `json:"object_kind"`
+	EventName    string   `json:"event_name"`
+	Before       string   `json:"before"`
+	After        string   `json:"after"`
+	Ref          string   `json:"ref"`
+	CheckoutSHA  string   `json:"checkout_sha"`
+	UserID       int      `json:"user_id"`
+	UserName     string   `json:"user_name"`
+	UserUsername string   `json:"user_username"`
+	UserAvatar   string   `json:"user_avatar"`
+	UserEmail    string   `json:"user_email"`
+	ProjectID    int      `json:"project_id"`
+	Message      string   `json:"message"`
+	Project      struct { // TODO replace with Project struct
+		ID                int             `json:"id"`
 		Name              string          `json:"name"`
 		Description       string          `json:"description"`
 		AvatarURL         string          `json:"avatar_url"`
@@ -1068,7 +1070,7 @@ type TagEvent struct {
 		Visibility        VisibilityValue `json:"visibility"`
 	} `json:"project"`
 	Repository *Repository `json:"repository"`
-	Commits    []*struct {
+	Commits    []*struct { // TODO Check if can be replaced with Commit struct
 		ID        string     `json:"id"`
 		Message   string     `json:"message"`
 		Title     string     `json:"title"`

--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -537,6 +537,7 @@ type MergeCommentEvent struct {
 // https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#merge-request-events
 type MergeEvent struct {
 	ObjectKind string     `json:"object_kind"`
+	EventType  string     `json:"event_type"`
 	User       *EventUser `json:"user"`
 	Project    struct {
 		ID                int             `json:"id"`
@@ -548,12 +549,13 @@ type MergeEvent struct {
 		Namespace         string          `json:"namespace"`
 		PathWithNamespace string          `json:"path_with_namespace"`
 		DefaultBranch     string          `json:"default_branch"`
+		CIConfigPath      string          `json:"ci_config_path"`
 		Homepage          string          `json:"homepage"`
 		URL               string          `json:"url"`
 		SSHURL            string          `json:"ssh_url"`
 		HTTPURL           string          `json:"http_url"`
 		WebURL            string          `json:"web_url"`
-		Visibility        VisibilityValue `json:"visibility"`
+		Visibility        VisibilityValue `json:"visibility"` // TODO GitLab now returns visibility_level of int type
 	} `json:"project"`
 	ObjectAttributes struct {
 		ID                       int          `json:"id"`
@@ -592,9 +594,13 @@ type MergeEvent struct {
 		Source                   *Repository  `json:"source"`
 		Target                   *Repository  `json:"target"`
 		HeadPipelineID           *int         `json:"head_pipeline_id"`
+		LastEditedAt             customTime   `json:"last_edited_at"`
+		LastEditedByID           int          `json:"last_edited_by_id"`
+		StateID                  int          `json:"state_id"` // TODO Create GitLab state id type
 		LastCommit               struct {
 			ID        string     `json:"id"`
 			Message   string     `json:"message"`
+			Title     string     `json:"title"`
 			Timestamp *time.Time `json:"timestamp"`
 			URL       string     `json:"url"`
 			Author    struct {
@@ -602,59 +608,34 @@ type MergeEvent struct {
 				Email string `json:"email"`
 			} `json:"author"`
 		} `json:"last_commit"`
-		BlockingDiscussionsResolved bool       `json:"blocking_discussions_resolved"`
-		WorkInProgress              bool       `json:"work_in_progress"`
-		URL                         string     `json:"url"`
-		Action                      string     `json:"action"`
-		OldRev                      string     `json:"oldrev"`
-		Assignee                    *EventUser `json:"assignee"`
+		BlockingDiscussionsResolved bool          `json:"blocking_discussions_resolved"`
+		WorkInProgress              bool          `json:"work_in_progress"`
+		TotalTimeSpent              int           `json:"total_time_spent"`
+		TimeChange                  int           `json:"time_change"`
+		HumanTotalTimeSpent         int           `json:"human_total_time_spent"`
+		HumanTimeChange             int           `json:"human_time_change"`
+		HumanTimeEstimate           int           `json:"human_time_estimate"`
+		Labels                      []*EventLabel `json:"labels"`
+		FirstContribution           bool          `json:"first_contribution"`
+		DetailedMergeStatus         string        `json:"detailed_merge_status"`
+		URL                         string        `json:"url"`
+		Action                      string        `json:"action"`
 	} `json:"object_attributes"`
 	Repository *Repository   `json:"repository"`
-	Assignee   *EventUser    `json:"assignee"`
-	Assignees  []*EventUser  `json:"assignees"`
-	Reviewers  []*EventUser  `json:"reviewers"`
 	Labels     []*EventLabel `json:"labels"`
 	Changes    struct {
-		Assignees struct {
-			Previous []*EventUser `json:"previous"`
-			Current  []*EventUser `json:"current"`
-		} `json:"assignees"`
-		Reviewers struct {
-			Previous []*EventUser `json:"previous"`
-			Current  []*EventUser `json:"current"`
-		} `json:"reviewers"`
 		Description struct {
 			Previous string `json:"previous"`
 			Current  string `json:"current"`
 		} `json:"description"`
-		Labels struct {
-			Previous []*EventLabel `json:"previous"`
-			Current  []*EventLabel `json:"current"`
-		} `json:"labels"`
-		SourceBranch struct {
+		LastEditedAt struct {
 			Previous string `json:"previous"`
 			Current  string `json:"current"`
-		} `json:"source_branch"`
-		SourceProjectID struct {
+		} `json:"last_edited_at"`
+		LastEditedByID struct {
 			Previous int `json:"previous"`
 			Current  int `json:"current"`
-		} `json:"source_project_id"`
-		StateID struct {
-			Previous StateID `json:"previous"`
-			Current  StateID `json:"current"`
-		} `json:"state_id"`
-		TargetBranch struct {
-			Previous string `json:"previous"`
-			Current  string `json:"current"`
-		} `json:"target_branch"`
-		TargetProjectID struct {
-			Previous int `json:"previous"`
-			Current  int `json:"current"`
-		} `json:"target_project_id"`
-		Title struct {
-			Previous string `json:"previous"`
-			Current  string `json:"current"`
-		} `json:"title"`
+		} `json:"last_edited_by_id"`
 		UpdatedAt struct {
 			Previous string `json:"previous"`
 			Current  string `json:"current"`
@@ -663,10 +644,6 @@ type MergeEvent struct {
 			Previous int `json:"previous"`
 			Current  int `json:"current"`
 		} `json:"updated_by_id"`
-		MilestoneID struct {
-			Previous int `json:"previous"`
-			Current  int `json:"current"`
-		} `json:"milestone_id"`
 	} `json:"changes"`
 }
 

--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -202,10 +202,11 @@ type DeploymentEvent struct {
 // GitLab API docs:
 // https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#comment-on-an-issue
 type IssueCommentEvent struct {
-	ObjectKind string `json:"object_kind"`
-	User       *User  `json:"user"`
-	ProjectID  int    `json:"project_id"`
-	Project    struct {
+	ObjectKind string   `json:"object_kind"`
+	EventType  string   `json:"event_type"`
+	User       *User    `json:"user"`
+	ProjectID  int      `json:"project_id"`
+	Project    struct { // TODO: create EventProject struct
 		Name              string          `json:"name"`
 		Description       string          `json:"description"`
 		AvatarURL         string          `json:"avatar_url"`
@@ -240,7 +241,7 @@ type IssueCommentEvent struct {
 		Description  string  `json:"description"`
 		URL          string  `json:"url"`
 	} `json:"object_attributes"`
-	Issue struct {
+	Issue struct { // TODO Check if this can be replaced by IssueEvent struct
 		ID                  int           `json:"id"`
 		IID                 int           `json:"iid"`
 		ProjectID           int           `json:"project_id"`
@@ -250,12 +251,12 @@ type IssueCommentEvent struct {
 		State               string        `json:"state"`
 		Title               string        `json:"title"`
 		Labels              []*EventLabel `json:"labels"`
-		LastEditedAt        string        `json:"last_edit_at"`
+		LastEditedAt        string        `json:"last_edit_at"` // TODO should be *time.Time
 		LastEditedByID      int           `json:"last_edited_by_id"`
-		UpdatedAt           string        `json:"updated_at"`
+		UpdatedAt           string        `json:"updated_at"` // TODO should be *time.Time
 		UpdatedByID         int           `json:"updated_by_id"`
-		CreatedAt           string        `json:"created_at"`
-		ClosedAt            string        `json:"closed_at"`
+		CreatedAt           string        `json:"created_at"` // TODO should be *time.Time
+		ClosedAt            string        `json:"closed_at"`  // TODO should be *time.Time
 		DueDate             *ISOTime      `json:"due_date"`
 		URL                 string        `json:"url"`
 		TimeEstimate        int           `json:"time_estimate"`
@@ -265,6 +266,8 @@ type IssueCommentEvent struct {
 		HumanTimeEstimate   string        `json:"human_time_estimate"`
 		AssigneeIDs         []int         `json:"assignee_ids"`
 		AssigneeID          int           `json:"assignee_id"`
+		Position            int           `json:"position"`
+		BranchName          string        `json:"branch_name"`
 	} `json:"issue"`
 }
 

--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -935,9 +935,10 @@ type ReleaseEvent struct {
 // https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#comment-on-a-code-snippet
 type SnippetCommentEvent struct {
 	ObjectKind string     `json:"object_kind"`
+	EventType  string     `json:"event_type"`
 	User       *EventUser `json:"user"`
 	ProjectID  int        `json:"project_id"`
-	Project    struct {
+	Project    struct {   // TODO replace with Project struct
 		Name              string          `json:"name"`
 		Description       string          `json:"description"`
 		AvatarURL         string          `json:"avatar_url"`
@@ -959,8 +960,8 @@ type SnippetCommentEvent struct {
 		Note         string `json:"note"`
 		NoteableType string `json:"noteable_type"`
 		AuthorID     int    `json:"author_id"`
-		CreatedAt    string `json:"created_at"`
-		UpdatedAt    string `json:"updated_at"`
+		CreatedAt    string `json:"created_at"` // TODO should be *time.Time
+		UpdatedAt    string `json:"updated_at"` // TODO should be *time.Time
 		ProjectID    int    `json:"project_id"`
 		Attachment   string `json:"attachment"`
 		LineCode     string `json:"line_code"`
@@ -977,10 +978,10 @@ type SnippetCommentEvent struct {
 		Content            string `json:"content"`
 		AuthorID           int    `json:"author_id"`
 		ProjectID          int    `json:"project_id"`
-		CreatedAt          string `json:"created_at"`
-		UpdatedAt          string `json:"updated_at"`
+		CreatedAt          string `json:"created_at"` // TODO should be *time.Time
+		UpdatedAt          string `json:"updated_at"` // TODO should be *time.Time
 		Filename           string `json:"file_name"`
-		ExpiresAt          string `json:"expires_at"`
+		ExpiresAt          string `json:"expires_at"` // TODO should be *time.Time
 		Type               string `json:"type"`
 		VisibilityLevel    int    `json:"visibility_level"`
 		Description        string `json:"description"`

--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -277,8 +277,9 @@ type IssueCommentEvent struct {
 // https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#issue-events
 type IssueEvent struct {
 	ObjectKind string     `json:"object_kind"`
+	EventType  string     `json:"event_type"`
 	User       *EventUser `json:"user"`
-	Project    struct {
+	Project    struct {   // TODO replace with EventProject struct
 		ID                int             `json:"id"`
 		Name              string          `json:"name"`
 		Description       string          `json:"description"`
@@ -297,21 +298,46 @@ type IssueEvent struct {
 	} `json:"project"`
 	Repository       *Repository `json:"repository"`
 	ObjectAttributes struct {
-		ID          int    `json:"id"`
-		Title       string `json:"title"`
-		AssigneeID  int    `json:"assignee_id"`
-		AuthorID    int    `json:"author_id"`
-		ProjectID   int    `json:"project_id"`
-		CreatedAt   string `json:"created_at"` // Should be *time.Time (see Gitlab issue #21468)
-		UpdatedAt   string `json:"updated_at"` // Should be *time.Time (see Gitlab issue #21468)
-		Position    int    `json:"position"`
-		BranchName  string `json:"branch_name"`
-		Description string `json:"description"`
-		MilestoneID int    `json:"milestone_id"`
-		State       string `json:"state"`
-		IID         int    `json:"iid"`
-		URL         string `json:"url"`
-		Action      string `json:"action"`
+		ID                  int      `json:"id"`
+		Title               string   `json:"title"`
+		AssigneeIDs         []int    `json:"assignee_ids"`
+		AssigneeID          int      `json:"assignee_id"`
+		AuthorID            int      `json:"author_id"`
+		ProjectID           int      `json:"project_id"`
+		CreatedAt           string   `json:"created_at"` // Should be *time.Time (see Gitlab issue #21468)
+		UpdatedAt           string   `json:"updated_at"` // Should be *time.Time (see Gitlab issue #21468)
+		UpdatedByID         int      `json:"updated_by_id"`
+		LastEditedAt        string   `json:"last_edited_at"` // Should be *time.Time
+		LastEditedByID      int      `json:"last_edited_by_id"`
+		RelativePosition    int      `json:"relative_position"`
+		Position            int      `json:"position"` // TODO GitLab doc doesn't mention this field
+		BranchName          string   `json:"branch_name"`
+		Description         string   `json:"description"`
+		MilestoneID         int      `json:"milestone_id"`
+		StateID             int      `json:"state_id"`
+		Confidential        bool     `json:"confidential"`
+		DiscussionLocked    bool     `json:"discussion_locked"`
+		DueDate             *ISOTime `json:"due_date"`
+		MovedToID           int      `json:"moved_to_id"`
+		DuplicatedToID      int      `json:"duplicated_to_id"`
+		TimeEstimate        int      `json:"time_estimate"`
+		TotalTimeSpent      int      `json:"total_time_spent"`
+		TimeChange          int      `json:"time_change"`
+		HumanTotalTimeSpent string   `json:"human_total_time_spent"` // TODO Check type
+		HumanTimeEstimate   string   `json:"human_time_estimate"`    // TODO Check type
+		HumanTimeChange     string   `json:"human_time_change"`      // TODO Check type
+		Weight              string   `json:"weight"`                 // TODO Check type
+		IID                 int      `json:"iid"`
+		URL                 string   `json:"url"`
+		State               string   `json:"state"`
+		Action              string   `json:"action"`
+		Severity            string   `json:"severity"`
+		EscalationStatus    string   `json:"escalation_status"`
+		EscalationPolicy    struct {
+			ID   int    `json:"id"`
+			Name string `json:"name"`
+		} `json:"escalation_policy"`
+		Labels []*EventLabel `json:"labels"`
 	} `json:"object_attributes"`
 	Assignee  *EventUser    `json:"assignee"`
 	Assignees *[]EventUser  `json:"assignees"`

--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -577,8 +577,8 @@ type MergeEvent struct {
 		TargetProjectID          int          `json:"target_project_id"`
 		IID                      int          `json:"iid"`
 		Description              string       `json:"description"`
-		Position                 int          `json:"position"`
-		LockedAt                 string       `json:"locked_at"`
+		Position                 int          `json:"position"`  // TODO this is not returned by GitLab
+		LockedAt                 string       `json:"locked_at"` // TODO this is not returned by GitLab
 		UpdatedByID              int          `json:"updated_by_id"`
 		MergeError               string       `json:"merge_error"`
 		MergeParams              *MergeParams `json:"merge_params"`
@@ -624,15 +624,15 @@ type MergeEvent struct {
 	Repository *Repository   `json:"repository"`
 	Labels     []*EventLabel `json:"labels"`
 	Changes    struct {
-		Description struct {
+		Description struct { // TODO GitLab doc doesn't mention this field
 			Previous string `json:"previous"`
 			Current  string `json:"current"`
 		} `json:"description"`
-		LastEditedAt struct {
+		LastEditedAt struct { // TODO GitLab doc doesn't mention this field
 			Previous string `json:"previous"`
 			Current  string `json:"current"`
 		} `json:"last_edited_at"`
-		LastEditedByID struct {
+		LastEditedByID struct { // TODO GitLab doc doesn't mention this field
 			Previous int `json:"previous"`
 			Current  int `json:"current"`
 		} `json:"last_edited_by_id"`
@@ -644,7 +644,13 @@ type MergeEvent struct {
 			Previous int `json:"previous"`
 			Current  int `json:"current"`
 		} `json:"updated_by_id"`
+		Labels struct {
+			Previous *EventLabel `json:"previous"`
+			Current  EventLabel  `json:"current"`
+		} `json:"labels"`
 	} `json:"changes"`
+	Assignees []*EventUser `json:"assignees"`
+	Reviewers []*EventUser `json:"reviewers"`
 }
 
 // EventUser represents a user record in an event and is used as an even initiator or a merge assignee.

--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -404,7 +404,7 @@ type JobEvent struct {
 		ID          int      `json:"id"`
 		Active      bool     `json:"active"`
 		RunnerType  string   `json:"runner_type"`
-		Shared      bool     `json:"is_shared"`
+		Shared      bool     `json:"is_shared"` // TODO variable name should be IsShared
 		Description string   `json:"description"`
 		Tags        []string `json:"tags"`
 	} `json:"runner"`
@@ -713,37 +713,39 @@ type PipelineEvent struct {
 	ObjectKind       string `json:"object_kind"`
 	ObjectAttributes struct {
 		ID             int      `json:"id"`
+		IID            int      `json:"iid"`
 		Ref            string   `json:"ref"`
 		Tag            bool     `json:"tag"`
 		SHA            string   `json:"sha"`
 		BeforeSHA      string   `json:"before_sha"`
 		Source         string   `json:"source"`
 		Status         string   `json:"status"`
-		DetailedStatus string   `json:"detailed_status"`
+		DetailedStatus string   `json:"detailed_status"` // TODO GitLab doc doesn't mention this field
 		Stages         []string `json:"stages"`
-		CreatedAt      string   `json:"created_at"`
-		FinishedAt     string   `json:"finished_at"`
-		Duration       int      `json:"duration"`
-		QueuedDuration int      `json:"queued_duration"`
+		CreatedAt      string   `json:"created_at"`      // TODO should be *time.Time
+		FinishedAt     string   `json:"finished_at"`     // TODO should be *time.Time
+		Duration       int      `json:"duration"`        // TODO verify type
+		QueuedDuration int      `json:"queued_duration"` // TODO verify type
 		Variables      []struct {
 			Key   string `json:"key"`
 			Value string `json:"value"`
 		} `json:"variables"`
 	} `json:"object_attributes"`
 	MergeRequest struct {
-		ID                 int    `json:"id"`
-		IID                int    `json:"iid"`
-		Title              string `json:"title"`
-		SourceBranch       string `json:"source_branch"`
-		SourceProjectID    int    `json:"source_project_id"`
-		TargetBranch       string `json:"target_branch"`
-		TargetProjectID    int    `json:"target_project_id"`
-		State              string `json:"state"`
-		MergeRequestStatus string `json:"merge_status"`
-		URL                string `json:"url"`
+		ID                  int    `json:"id"`
+		IID                 int    `json:"iid"`
+		Title               string `json:"title"`
+		SourceBranch        string `json:"source_branch"`
+		SourceProjectID     int    `json:"source_project_id"`
+		TargetBranch        string `json:"target_branch"`
+		TargetProjectID     int    `json:"target_project_id"`
+		State               string `json:"state"`
+		MergeRequestStatus  string `json:"merge_status"`
+		DetailedMergeStatus string `json:"detailed_merge_status"`
+		URL                 string `json:"url"`
 	} `json:"merge_request"`
 	User    *EventUser `json:"user"`
-	Project struct {
+	Project struct {   // TODO create EventProject struct
 		ID                int             `json:"id"`
 		Name              string          `json:"name"`
 		Description       string          `json:"description"`
@@ -758,7 +760,7 @@ type PipelineEvent struct {
 		SSHURL            string          `json:"ssh_url"`
 		HTTPURL           string          `json:"http_url"`
 		WebURL            string          `json:"web_url"`
-		Visibility        VisibilityValue `json:"visibility"`
+		Visibility        VisibilityValue `json:"visibility"` // TODO GitLab now returns visibility_level of int type
 	} `json:"project"`
 	Commit struct {
 		ID        string     `json:"id"`
@@ -771,14 +773,23 @@ type PipelineEvent struct {
 			Email string `json:"email"`
 		} `json:"author"`
 	} `json:"commit"`
+	SourcePipeline struct {
+		Project struct {
+			ID                int    `json:"id"`
+			WebURL            string `json:"web_url"`
+			PathWithNamespace string `json:"path_with_namespace"`
+		} `json:"project"`
+		PipelineID int `json:"pipeline_id"`
+		JobID      int `json:"job_id"`
+	} `json:"source_pipeline"`
 	Builds []struct {
 		ID             int        `json:"id"`
 		Stage          string     `json:"stage"`
 		Name           string     `json:"name"`
 		Status         string     `json:"status"`
-		CreatedAt      string     `json:"created_at"`
-		StartedAt      string     `json:"started_at"`
-		FinishedAt     string     `json:"finished_at"`
+		CreatedAt      string     `json:"created_at"`  // TODO should be *time.Time
+		StartedAt      string     `json:"started_at"`  // TODO should be *time.Time
+		FinishedAt     string     `json:"finished_at"` // TODO should be *time.Time
 		Duration       float64    `json:"duration"`
 		QueuedDuration float64    `json:"queued_duration"`
 		FailureReason  string     `json:"failure_reason"`
@@ -786,7 +797,7 @@ type PipelineEvent struct {
 		Manual         bool       `json:"manual"`
 		AllowFailure   bool       `json:"allow_failure"`
 		User           *EventUser `json:"user"`
-		Runner         struct {
+		Runner         struct {   // TODO Create EventRunner struct
 			ID          int      `json:"id"`
 			Description string   `json:"description"`
 			Active      bool     `json:"active"`
@@ -811,18 +822,20 @@ type PipelineEvent struct {
 // GitLab API docs:
 // https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#push-events
 type PushEvent struct {
-	ObjectKind   string `json:"object_kind"`
-	Before       string `json:"before"`
-	After        string `json:"after"`
-	Ref          string `json:"ref"`
-	CheckoutSHA  string `json:"checkout_sha"`
-	UserID       int    `json:"user_id"`
-	UserName     string `json:"user_name"`
-	UserUsername string `json:"user_username"`
-	UserEmail    string `json:"user_email"`
-	UserAvatar   string `json:"user_avatar"`
-	ProjectID    int    `json:"project_id"`
-	Project      struct {
+	ObjectKind   string   `json:"object_kind"`
+	EventName    string   `json:"event_name"`
+	Before       string   `json:"before"`
+	After        string   `json:"after"`
+	Ref          string   `json:"ref"`
+	CheckoutSHA  string   `json:"checkout_sha"`
+	UserID       int      `json:"user_id"`
+	UserName     string   `json:"user_name"`
+	UserUsername string   `json:"user_username"`
+	UserEmail    string   `json:"user_email"`
+	UserAvatar   string   `json:"user_avatar"`
+	ProjectID    int      `json:"project_id"`
+	Project      struct { // TODO create EventProject struct
+		ID                int             `json:"id"`
 		Name              string          `json:"name"`
 		Description       string          `json:"description"`
 		AvatarURL         string          `json:"avatar_url"`
@@ -836,7 +849,7 @@ type PushEvent struct {
 		SSHURL            string          `json:"ssh_url"`
 		HTTPURL           string          `json:"http_url"`
 		WebURL            string          `json:"web_url"`
-		Visibility        VisibilityValue `json:"visibility"`
+		Visibility        VisibilityValue `json:"visibility"` // GitLab now returns visibility_level of int type
 	} `json:"project"`
 	Repository *Repository `json:"repository"`
 	Commits    []*struct {

--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -365,27 +365,28 @@ type IssueEvent struct {
 // GitLab API docs:
 // https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#job-events
 type JobEvent struct {
-	ObjectKind         string     `json:"object_kind"`
-	Ref                string     `json:"ref"`
-	Tag                bool       `json:"tag"`
-	BeforeSHA          string     `json:"before_sha"`
-	SHA                string     `json:"sha"`
-	BuildID            int        `json:"build_id"`
-	BuildName          string     `json:"build_name"`
-	BuildStage         string     `json:"build_stage"`
-	BuildStatus        string     `json:"build_status"`
-	BuildCreatedAt     string     `json:"build_created_at"`
-	BuildStartedAt     string     `json:"build_started_at"`
-	BuildFinishedAt    string     `json:"build_finished_at"`
-	BuildDuration      float64    `json:"build_duration"`
-	BuildAllowFailure  bool       `json:"build_allow_failure"`
-	BuildFailureReason string     `json:"build_failure_reason"`
-	RetriesCount       int        `json:"retries_count"`
-	PipelineID         int        `json:"pipeline_id"`
-	ProjectID          int        `json:"project_id"`
-	ProjectName        string     `json:"project_name"`
-	User               *EventUser `json:"user"`
-	Commit             struct {
+	ObjectKind          string     `json:"object_kind"`
+	Ref                 string     `json:"ref"`
+	Tag                 bool       `json:"tag"`
+	BeforeSHA           string     `json:"before_sha"`
+	SHA                 string     `json:"sha"`
+	BuildID             int        `json:"build_id"`
+	BuildName           string     `json:"build_name"`
+	BuildStage          string     `json:"build_stage"`
+	BuildStatus         string     `json:"build_status"`
+	BuildCreatedAt      string     `json:"build_created_at"`
+	BuildStartedAt      string     `json:"build_started_at"`  // TODO Should be *time.Time
+	BuildFinishedAt     string     `json:"build_finished_at"` // TODO Should be *time.Time
+	BuildDuration       float64    `json:"build_duration"`
+	BuildQueuedDuration float64    `json:"build_queued_duration"`
+	BuildAllowFailure   bool       `json:"build_allow_failure"`
+	BuildFailureReason  string     `json:"build_failure_reason"`
+	RetriesCount        int        `json:"retries_count"`
+	PipelineID          int        `json:"pipeline_id"`
+	ProjectID           int        `json:"project_id"`
+	ProjectName         string     `json:"project_name"`
+	User                *EventUser `json:"user"`
+	Commit              struct {
 		ID          int    `json:"id"`
 		Name        string `json:"name"`
 		SHA         string `json:"sha"`
@@ -400,11 +401,14 @@ type JobEvent struct {
 	} `json:"commit"`
 	Repository *Repository `json:"repository"`
 	Runner     struct {
-		ID          int    `json:"id"`
-		Active      bool   `json:"active"`
-		Shared      bool   `json:"is_shared"`
-		Description string `json:"description"`
+		ID          int      `json:"id"`
+		Active      bool     `json:"active"`
+		RunnerType  string   `json:"runner_type"`
+		Shared      bool     `json:"is_shared"`
+		Description string   `json:"description"`
+		Tags        []string `json:"tags"`
 	} `json:"runner"`
+	Environment string `json:"environment"` // TODO: Verify type
 }
 
 // MemberEvent represents a member event.

--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -105,10 +105,12 @@ type BuildEvent struct {
 // GitLab API docs:
 // https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#comment-on-a-commit
 type CommitCommentEvent struct {
-	ObjectKind string `json:"object_kind"`
-	User       *User  `json:"user"`
-	ProjectID  int    `json:"project_id"`
-	Project    struct {
+	ObjectKind string   `json:"object_kind"`
+	EventType  string   `json:"event_type"`
+	User       *User    `json:"user"`
+	ProjectID  int      `json:"project_id"`
+	Project    struct { // TODO: create EventProject struct
+		ID                int             `json:"id"`
 		Name              string          `json:"name"`
 		Description       string          `json:"description"`
 		AvatarURL         string          `json:"avatar_url"`
@@ -122,7 +124,7 @@ type CommitCommentEvent struct {
 		SSHURL            string          `json:"ssh_url"`
 		HTTPURL           string          `json:"http_url"`
 		WebURL            string          `json:"web_url"`
-		Visibility        VisibilityValue `json:"visibility"`
+		Visibility        VisibilityValue `json:"visibility"` // TODO GitLab now returns visibility_level of int type
 	} `json:"project"`
 	Repository       *Repository `json:"repository"`
 	ObjectAttributes struct {
@@ -130,8 +132,8 @@ type CommitCommentEvent struct {
 		Note         string `json:"note"`
 		NoteableType string `json:"noteable_type"`
 		AuthorID     int    `json:"author_id"`
-		CreatedAt    string `json:"created_at"`
-		UpdatedAt    string `json:"updated_at"`
+		CreatedAt    string `json:"created_at"` // TODO: should be *time.Time
+		UpdatedAt    string `json:"updated_at"` // TODO: should be *time.Time
 		ProjectID    int    `json:"project_id"`
 		Attachment   string `json:"attachment"`
 		LineCode     string `json:"line_code"`
@@ -151,7 +153,7 @@ type CommitCommentEvent struct {
 		Description string `json:"description"`
 		URL         string `json:"url"`
 	} `json:"object_attributes"`
-	Commit *struct {
+	Commit *struct { // TODO create Commit struct
 		ID        string     `json:"id"`
 		Title     string     `json:"title"`
 		Message   string     `json:"message"`

--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -1094,7 +1094,8 @@ type TagEvent struct {
 type WikiPageEvent struct {
 	ObjectKind string     `json:"object_kind"`
 	User       *EventUser `json:"user"`
-	Project    struct {
+	Project    struct {   // TODO replace with Project struct
+		ID                int             `json:"id"`
 		Name              string          `json:"name"`
 		Description       string          `json:"description"`
 		AvatarURL         string          `json:"avatar_url"`
@@ -1125,6 +1126,7 @@ type WikiPageEvent struct {
 		Slug    string `json:"slug"`
 		URL     string `json:"url"`
 		Action  string `json:"action"`
+		DiffURL string `json:"diff_url"`
 	} `json:"object_attributes"`
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/xanzy/go-gitlab
+module github.com/smit-modi/go-gitlab
 
 go 1.18
 
@@ -7,6 +7,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-retryablehttp v0.7.2
 	github.com/stretchr/testify v1.8.1
+	github.com/xanzy/go-gitlab v0.81.0
 	golang.org/x/oauth2 v0.6.0
 	golang.org/x/time v0.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/xanzy/go-gitlab v0.81.0 h1:ofbhZ5ZY9AjHATWQie4qd2JfncdUmvcSA/zfQB767Dk=
+github.com/xanzy/go-gitlab v0.81.0/go.mod h1:VMbY3JIWdZ/ckvHbQqkyd3iYk2aViKrNIQ23IbFMQDo=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.8.0 h1:Zrh2ngAOFYneWTAIAPethzeaQLuHwhuBkuV6ZiRnUaQ=

--- a/projects.go
+++ b/projects.go
@@ -266,7 +266,7 @@ type Repository struct {
 	GitSSHURL         string          `json:"git_ssh_url"`
 	GitHTTPURL        string          `json:"git_http_url"`
 	Namespace         string          `json:"namespace"`
-	Visibility        VisibilityValue `json:"visibility"` // GitLab now returns visibility_level of int type
+	Visibility        VisibilityValue `json:"visibility"` // TODO GitLab now returns visibility_level of int type
 	PathWithNamespace string          `json:"path_with_namespace"`
 	DefaultBranch     string          `json:"default_branch"`
 	Homepage          string          `json:"homepage"`

--- a/projects.go
+++ b/projects.go
@@ -258,6 +258,7 @@ type ProjectNamespace struct {
 
 // Repository represents a repository.
 type Repository struct {
+	ID                int             `json:"id"`
 	Name              string          `json:"name"`
 	Description       string          `json:"description"`
 	WebURL            string          `json:"web_url"`
@@ -265,7 +266,7 @@ type Repository struct {
 	GitSSHURL         string          `json:"git_ssh_url"`
 	GitHTTPURL        string          `json:"git_http_url"`
 	Namespace         string          `json:"namespace"`
-	Visibility        VisibilityValue `json:"visibility"`
+	Visibility        VisibilityValue `json:"visibility"` // GitLab now returns visibility_level of int type
 	PathWithNamespace string          `json:"path_with_namespace"`
 	DefaultBranch     string          `json:"default_branch"`
 	Homepage          string          `json:"homepage"`

--- a/testdata/webhooks/deployment.json
+++ b/testdata/webhooks/deployment.json
@@ -1,9 +1,13 @@
 {
   "object_kind": "deployment",
   "status": "success",
+  "status_changed_at": "2023-03-15 00:00:17 +0000",
+  "deployment_id": 123,
   "deployable_id": 796,
   "deployable_url": "http://10.126.0.2:3000/root/test-deployment-webhooks/-/jobs/796",
   "environment": "staging",
+  "environment_slug": "staging",
+  "environment_external_url": null,
   "project": {
     "id": 30,
     "name": "test-deployment-webhooks",


### PR DESCRIPTION
Added missing fields in DeploymentEvent.

Since GitLab doesn't send time data in RFC3339 format, currently, it is being unmarshalled as a string, I have added `customTime` as https://github.com/go-playground/webhooks/blob/master/gitlab/payload.go#L12 is doing.

For now only updated DeploymentEvent, planning to update other events as well soon.