### PR TITLE
fix(stats): fix project issue stats api milestone parameter

### DIFF
--- a/issues_statistics.go
+++ b/issues_statistics.go
@@ -146,7 +146,7 @@ func (s *IssuesStatisticsService) GetGroupIssuesStatistics(gid interface{}, opt 
 type GetProjectIssuesStatisticsOptions struct {
 	IIDs             *[]int     `url:"iids[],omitempty" json:"iids,omitempty"`
 	Labels           *Labels    `url:"labels,omitempty" json:"labels,omitempty"`
-	Milestone        *Milestone `url:"milestone,omitempty" json:"milestone,omitempty"`
+	Milestone        *string    `url:"milestone,omitempty" json:"milestone,omitempty"`
 	Scope            *string    `url:"scope,omitempty" json:"scope,omitempty"`
 	AuthorID         *int       `url:"author_id,omitempty" json:"author_id,omitempty"`
 	AuthorUsername   *string    `url:"author_username,omitempty" json:"author_username,omitempty"`


### PR DESCRIPTION
The project issue statistics api requires milestone string, but it currently is a struct. This patch fixed this parameter to make this api works.