### PR TITLE
Fix uptade protected branch

### DIFF
--- a/gitlab.go
+++ b/gitlab.go
@@ -568,7 +568,7 @@ func (c *Client) NewRequest(method, path string, opt interface{}, options []Requ
 
 	var body interface{}
 	switch {
-	case method == http.MethodPost || method == http.MethodPut || method == http.MethodPatch:
+	case method == http.MethodPatch || method == http.MethodPost || method == http.MethodPut:
 		reqHeaders.Set("Content-Type", "application/json")
 
 		if opt != nil {

--- a/gitlab.go
+++ b/gitlab.go
@@ -568,7 +568,7 @@ func (c *Client) NewRequest(method, path string, opt interface{}, options []Requ
 
 	var body interface{}
 	switch {
-	case method == http.MethodPost || method == http.MethodPut:
+	case method == http.MethodPost || method == http.MethodPut || method == http.MethodPatch:
 		reqHeaders.Set("Content-Type", "application/json")
 
 		if opt != nil {

--- a/project_managed_licenses_test.go
+++ b/project_managed_licenses_test.go
@@ -124,10 +124,7 @@ func TestEditManagedLicenses(t *testing.T) {
 
 	mux.HandleFunc("/api/v4/projects/1/managed_licenses/3", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPatch)
-		approvalStatus := r.URL.Query().Get("approval_status")
-		if approvalStatus != "blacklisted" {
-			t.Errorf("query param approval_status should be blacklisted but was %s", approvalStatus)
-		}
+		testBody(t, r, `{"approval_status":"blacklisted"}`)
 		mustWriteHTTPResponse(t, w, "testdata/edit_project_managed_license.json")
 	})
 

--- a/protected_branches.go
+++ b/protected_branches.go
@@ -140,10 +140,12 @@ type ProtectRepositoryBranchesOptions struct {
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/protected_branches.html#protect-repository-branches
 type BranchPermissionOptions struct {
+	ID          *int              `url:"id,omitempty" json:"id,omitempty"`
 	UserID      *int              `url:"user_id,omitempty" json:"user_id,omitempty"`
 	GroupID     *int              `url:"group_id,omitempty" json:"group_id,omitempty"`
 	DeployKeyID *int              `url:"deploy_key_id,omitempty" json:"deploy_key_id,omitempty"`
 	AccessLevel *AccessLevelValue `url:"access_level,omitempty" json:"access_level,omitempty"`
+	Destroy     *bool             `url:"_destroy,omitempty" json:"_destroy,omitempty"`
 }
 
 // ProtectRepositoryBranches protects a single repository branch or several

--- a/protected_branches_test.go
+++ b/protected_branches_test.go
@@ -188,10 +188,7 @@ func TestUpdateRepositoryBranches(t *testing.T) {
 
 	mux.HandleFunc("/api/v4/projects/1/protected_branches/master", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPatch)
-		codeApprovalQueryParam := r.URL.Query().Get("code_owner_approval_required")
-		if codeApprovalQueryParam != "true" {
-			t.Errorf("query param code_owner_approval_required should be true but was %s", codeApprovalQueryParam)
-		}
+		testBody(t, r, `{"code_owner_approval_required":true}`)
 		fmt.Fprintf(w, `{
 			"name": "master",
 			"code_owner_approval_required": true


### PR DESCRIPTION
Adds missing elements for the full API functionality of UpdateProtectedBranch() method.

As consequence of this, it's mandatory by API to ship this data via body to the API, therefore I've added the case to the already existing switch-case.

This should have more extensive tests via the testing suit. I've only tested this for my own needs.

This PR fixes #1657 