### PR TITLE
fix: Merge `ProjectMember`, `GroupMember` & `BillableGroupMember` into a single `Member` struct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ _testmain.go
 *.iml
 *.swp
 *.swo
+
+# vendor
+vendor

--- a/group_members.go
+++ b/group_members.go
@@ -19,7 +19,6 @@ package gitlab
 import (
 	"fmt"
 	"net/http"
-	"time"
 )
 
 // GroupMembersService handles communication with the group members
@@ -44,18 +43,7 @@ type GroupMemberSAMLIdentity struct {
 // GroupMember represents a GitLab group member.
 //
 // GitLab API docs: https://docs.gitlab.com/ee/api/members.html
-type GroupMember struct {
-	ID                int                      `json:"id"`
-	Username          string                   `json:"username"`
-	Name              string                   `json:"name"`
-	State             string                   `json:"state"`
-	AvatarURL         string                   `json:"avatar_url"`
-	WebURL            string                   `json:"web_url"`
-	CreatedAt         *time.Time               `json:"created_at"`
-	ExpiresAt         *ISOTime                 `json:"expires_at"`
-	AccessLevel       AccessLevelValue         `json:"access_level"`
-	GroupSAMLIdentity *GroupMemberSAMLIdentity `json:"group_saml_identity"`
-}
+type GroupMember = Member
 
 // ListGroupMembersOptions represents the available ListGroupMembers() and
 // ListAllGroupMembers() options.
@@ -158,21 +146,7 @@ func (s *GroupMembersService) GetGroupMember(gid interface{}, user int, options 
 // BillableGroupMember represents a GitLab billable group member.
 //
 // GitLab API docs: https://docs.gitlab.com/ee/api/members.html#list-all-billable-members-of-a-group
-type BillableGroupMember struct {
-	ID             int        `json:"id"`
-	Username       string     `json:"username"`
-	Name           string     `json:"name"`
-	State          string     `json:"state"`
-	AvatarURL      string     `json:"avatar_url"`
-	WebURL         string     `json:"web_url"`
-	Email          string     `json:"email"`
-	LastActivityOn *ISOTime   `json:"last_activity_on"`
-	MembershipType string     `json:"membership_type"`
-	Removeable     bool       `json:"removeable"`
-	CreatedAt      *time.Time `json:"created_at"`
-	IsLastOwner    bool       `json:"is_last_owner"`
-	LastLoginAt    *time.Time `json:"last_login_at"`
-}
+type BillableGroupMember = Member
 
 // ListBillableGroupMembersOptions represents the available ListBillableGroupMembers() options.
 //

--- a/group_members_test.go
+++ b/group_members_test.go
@@ -43,7 +43,7 @@ func TestListBillableGroupMembers(t *testing.T) {
 						"web_url":"http://192.168.1.8:3000/root",
 						"last_activity_on":"2021-01-27",
 						"membership_type": "group_member",
-						"removeable": true,
+						"removable": true,
 						"created_at": "2017-10-23T11:41:28.793Z",
 						"is_last_owner": false,
 						"last_login_at": "2022-12-12T09:22:51.581Z"
@@ -71,7 +71,7 @@ func TestListBillableGroupMembers(t *testing.T) {
 			WebURL:         "http://192.168.1.8:3000/root",
 			LastActivityOn: &lastActivityOnISOTime,
 			MembershipType: "group_member",
-			Removeable:     true,
+			Removable:      true,
 			CreatedAt:      &createdAt,
 			IsLastOwner:    false,
 			LastLoginAt:    &lastLoginAt,

--- a/group_members_test.go
+++ b/group_members_test.go
@@ -80,6 +80,106 @@ func TestListBillableGroupMembers(t *testing.T) {
 	assert.Equal(t, want, billableMembers, "Expected returned Groups.ListBillableGroupMembers to equal")
 }
 
+func TestListGroupMembersWithoutEmail(t *testing.T) {
+	mux, client := setup(t)
+
+	mux.HandleFunc("/api/v4/groups/1/members",
+		func(w http.ResponseWriter, r *http.Request) {
+			testMethod(t, r, http.MethodGet)
+			fmt.Fprint(w,
+				`[
+					{
+						"id": 1,
+						"username": "raymond_smith",
+						"name": "Raymond Smith",
+						"state": "active",
+						"avatar_url": "https://www.gravatar.com/avatar/c2525a7f58ae3776070e44c106c48e15?s=80&d=identicon",
+						"web_url": "http://192.168.1.8:3000/root",
+						"created_at": "2012-10-21T14:13:35Z",
+						"expires_at": "2012-10-22",
+						"access_level": 30,
+						"group_saml_identity": null
+					}
+				]`)
+		})
+
+	members, _, err := client.Groups.ListGroupMembers(1, &ListGroupMembersOptions{})
+	if err != nil {
+		t.Errorf("Groups.ListGroupMembers returned error: %v", err)
+	}
+
+	createdAt, _ := time.Parse(time.RFC3339, "2012-10-21T14:13:35Z")
+	expiresAt, _ := time.Parse(time.RFC3339, "2012-10-22T00:00:00Z")
+	expiresAtISOTime := ISOTime(expiresAt)
+	want := []*GroupMember{
+		{
+			ID:          1,
+			Username:    "raymond_smith",
+			Name:        "Raymond Smith",
+			State:       "active",
+			AvatarURL:   "https://www.gravatar.com/avatar/c2525a7f58ae3776070e44c106c48e15?s=80&d=identicon",
+			WebURL:      "http://192.168.1.8:3000/root",
+			CreatedAt:   &createdAt,
+			ExpiresAt:   &expiresAtISOTime,
+			AccessLevel: 30,
+		},
+	}
+	if !reflect.DeepEqual(want, members) {
+		t.Errorf("Groups.ListBillableGroupMembers returned %+v, want %+v", members[0], want[0])
+	}
+}
+
+func TestListGroupMembersWithEmail(t *testing.T) {
+	mux, client := setup(t)
+
+	mux.HandleFunc("/api/v4/groups/1/members",
+		func(w http.ResponseWriter, r *http.Request) {
+			testMethod(t, r, http.MethodGet)
+			fmt.Fprint(w,
+				`[
+					{
+						"id": 1,
+						"username": "raymond_smith",
+						"name": "Raymond Smith",
+						"state": "active",
+						"avatar_url": "https://www.gravatar.com/avatar/c2525a7f58ae3776070e44c106c48e15?s=80&d=identicon",
+						"web_url": "http://192.168.1.8:3000/root",
+						"created_at": "2012-10-21T14:13:35Z",
+						"expires_at": "2012-10-22",
+						"access_level": 30,
+						"email": "john@example.com",
+						"group_saml_identity": null
+					}
+				]`)
+		})
+
+	members, _, err := client.Groups.ListGroupMembers(1, &ListGroupMembersOptions{})
+	if err != nil {
+		t.Errorf("Groups.ListGroupMembers returned error: %v", err)
+	}
+
+	createdAt, _ := time.Parse(time.RFC3339, "2012-10-21T14:13:35Z")
+	expiresAt, _ := time.Parse(time.RFC3339, "2012-10-22T00:00:00Z")
+	expiresAtISOTime := ISOTime(expiresAt)
+	want := []*GroupMember{
+		{
+			ID:          1,
+			Username:    "raymond_smith",
+			Name:        "Raymond Smith",
+			State:       "active",
+			AvatarURL:   "https://www.gravatar.com/avatar/c2525a7f58ae3776070e44c106c48e15?s=80&d=identicon",
+			WebURL:      "http://192.168.1.8:3000/root",
+			CreatedAt:   &createdAt,
+			ExpiresAt:   &expiresAtISOTime,
+			AccessLevel: 30,
+			Email:       "john@example.com",
+		},
+	}
+	if !reflect.DeepEqual(want, members) {
+		t.Errorf("Groups.ListBillableGroupMembers returned %+v, want %+v", members[0], want[0])
+	}
+}
+
 func TestListGroupMembersWithoutSAML(t *testing.T) {
 	mux, client := setup(t)
 

--- a/member.go
+++ b/member.go
@@ -1,0 +1,36 @@
+package gitlab
+
+import (
+	"time"
+)
+
+// Member represents any of the following:
+// - project member
+// - group member
+// - billable group member
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/members.html
+
+type Member struct {
+	ID             int    `json:"id"`
+	Username       string `json:"username"`
+	Email          string `json:"email"`
+	Name           string `json:"name"`
+	State          string `json:"state"`
+	MembershipType string `json:"membership_type"`
+
+	AvatarURL string `json:"avatar_url"`
+	WebURL    string `json:"web_url"`
+
+	CreatedAt      *time.Time `json:"created_at"`
+	ExpiresAt      *ISOTime   `json:"expires_at"`
+	LastLoginAt    *time.Time `json:"last_login_at"`
+	LastActivityOn *ISOTime   `json:"last_activity_on"`
+
+	AccessLevel       AccessLevelValue         `json:"access_level"`
+	GroupSAMLIdentity *GroupMemberSAMLIdentity `json:"group_saml_identity"`
+
+	Removable   bool `json:"removable"`
+	IsLastOwner bool `json:"is_last_owner"`
+}

--- a/projects.go
+++ b/projects.go
@@ -1139,18 +1139,7 @@ func (s *ProjectsService) DeleteSharedProjectFromGroup(pid interface{}, groupID 
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/members.html#list-all-members-of-a-group-or-project
-type ProjectMember struct {
-	ID          int              `json:"id"`
-	Username    string           `json:"username"`
-	Email       string           `json:"email"`
-	Name        string           `json:"name"`
-	State       string           `json:"state"`
-	CreatedAt   *time.Time       `json:"created_at"`
-	ExpiresAt   *ISOTime         `json:"expires_at"`
-	AccessLevel AccessLevelValue `json:"access_level"`
-	WebURL      string           `json:"web_url"`
-	AvatarURL   string           `json:"avatar_url"`
-}
+type ProjectMember = Member
 
 // ProjectHook represents a project hook.
 //


### PR DESCRIPTION
This is a more correct alternative to #1702 and it does the following:
1. Merges the structs described in the same API doc into a single implementation (fields are just a union of the `BillableGroupMember`, `GroupMember` & `ProjectMember`)
2. Fixes the typo in `removable` field (see the [docs](https://docs.gitlab.com/ee/api/members.html) to see that it is really a typo in the codebase ATM).