### PR TITLE
refactor: add pipeline `iid` in the webhook event

### DIFF
--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -784,6 +784,7 @@ type PipelineEvent struct {
 	ObjectKind       string `json:"object_kind"`
 	ObjectAttributes struct {
 		ID             int      `json:"id"`
+		IID            int      `json:"iid"`
 		Ref            string   `json:"ref"`
 		Tag            bool     `json:"tag"`
 		SHA            string   `json:"sha"`

--- a/event_webhook_types_test.go
+++ b/event_webhook_types_test.go
@@ -932,7 +932,11 @@ func TestPipelineEventUnmarshal(t *testing.T) {
 	}
 
 	if event.ObjectAttributes.ID != 31 {
-		t.Errorf("ObjectAttributes.ID is %v, want %v", event.ObjectAttributes.ID, 1977)
+		t.Errorf("ObjectAttributes.ID is %v, want %v", event.ObjectAttributes.ID, 31)
+	}
+
+	if event.ObjectAttributes.IID != 123 {
+		t.Errorf("ObjectAttributes.IID is %v, want %v", event.ObjectAttributes.ID, 123)
 	}
 
 	if event.ObjectAttributes.DetailedStatus != "passed" {

--- a/testdata/webhooks/pipeline.json
+++ b/testdata/webhooks/pipeline.json
@@ -2,6 +2,7 @@
   "object_kind": "pipeline",
   "object_attributes": {
     "id": 31,
+    "iid": 123,
     "ref": "master",
     "tag": false,
     "sha": "bcbb5ec396a2c0f828686f14fac9b80b780504f2",


### PR DESCRIPTION
Added another missing attribute in webhook events. 