### PR TITLE
Return Environment on stop.

### DIFF
--- a/environments.go
+++ b/environments.go
@@ -84,7 +84,7 @@ func (s *EnvironmentsService) ListEnvironments(pid interface{}, opts *ListEnviro
 		return nil, resp, err
 	}
 
-	return envs, resp, err
+	return envs, resp, nil
 }
 
 // GetEnvironment gets a specific environment from a project.
@@ -109,7 +109,7 @@ func (s *EnvironmentsService) GetEnvironment(pid interface{}, environment int, o
 		return nil, resp, err
 	}
 
-	return env, resp, err
+	return env, resp, nil
 }
 
 // CreateEnvironmentOptions represents the available CreateEnvironment() options.
@@ -147,7 +147,7 @@ func (s *EnvironmentsService) CreateEnvironment(pid interface{}, opt *CreateEnvi
 		return nil, resp, err
 	}
 
-	return env, resp, err
+	return env, resp, nil
 }
 
 // EditEnvironmentOptions represents the available EditEnvironment() options.
@@ -182,7 +182,7 @@ func (s *EnvironmentsService) EditEnvironment(pid interface{}, environment int, 
 		return nil, resp, err
 	}
 
-	return env, resp, err
+	return env, resp, nil
 }
 
 // DeleteEnvironment removes an environment from a project team.
@@ -225,6 +225,6 @@ func (s *EnvironmentsService) StopEnvironment(pid interface{}, environmentID int
 	if err != nil {
 		return nil, resp, err
 	}
-	
+
 	return env, resp, nil
 }

--- a/environments.go
+++ b/environments.go
@@ -208,17 +208,19 @@ func (s *EnvironmentsService) DeleteEnvironment(pid interface{}, environment int
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/environments.html#stop-an-environment
-func (s *EnvironmentsService) StopEnvironment(pid interface{}, environmentID int, options ...RequestOptionFunc) (*Response, error) {
+func (s *EnvironmentsService) StopEnvironment(pid interface{}, environmentID int, options ...RequestOptionFunc) (*Environment, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/environments/%d/stop", PathEscape(project), environmentID)
 
 	req, err := s.client.NewRequest(http.MethodPost, u, nil, options)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return s.client.Do(req, nil)
+	env := new(Environment)
+	resp, err := s.client.Do(req, env)
+	return env, resp, err
 }

--- a/environments.go
+++ b/environments.go
@@ -222,5 +222,9 @@ func (s *EnvironmentsService) StopEnvironment(pid interface{}, environmentID int
 
 	env := new(Environment)
 	resp, err := s.client.Do(req, env)
-	return env, resp, err
+	if err != nil {
+		return nil, resp, err
+	}
+	
+	return env, resp, nil
 }

--- a/environments_test.go
+++ b/environments_test.go
@@ -165,7 +165,7 @@ func TestStopEnvironment(t *testing.T) {
 		testMethod(t, r, http.MethodPost)
 		testURL(t, r, "/api/v4/projects/1/environments/1/stop")
 	})
-	_, err := client.Environments.StopEnvironment(1, 1)
+	_, _, err := client.Environments.StopEnvironment(1, 1)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/environments_test.go
+++ b/environments_test.go
@@ -164,6 +164,7 @@ func TestStopEnvironment(t *testing.T) {
 	mux.HandleFunc("/api/v4/projects/1/environments/1/stop", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
 		testURL(t, r, "/api/v4/projects/1/environments/1/stop")
+		fmt.Fprint(w, `{"id": 1,"name": "staging", "state": "stopping", "slug": "staging", "external_url": "https://staging.example.gitlab.com", "tier": "staging"}`)
 	})
 	_, _, err := client.Environments.StopEnvironment(1, 1)
 	if err != nil {


### PR DESCRIPTION
This removes manual parsing of the response json in clients, when they want to know the state, for example.