### PR TITLE
update ListProjectVisibleEventsOptions according to the latest doc

### DIFF
--- a/events.go
+++ b/events.go
@@ -196,7 +196,13 @@ func (s ProjectEvent) String() string {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/events.html#list-a-projects-visible-events
-type ListProjectVisibleEventsOptions ListOptions
+type ListProjectVisibleEventsOptions struct {
+	Action     *EventTypeValue       `url:"action,omitempty" json:"action,omitempty"`
+	TargetType *EventTargetTypeValue `url:"target_type,omitempty" json:"target_type,omitempty"`
+	Before     *ISOTime              `url:"before,omitempty" json:"before,omitempty"`
+	After      *ISOTime              `url:"after,omitempty" json:"after,omitempty"`
+	Sort       *string               `url:"sort,omitempty" json:"sort,omitempty"`
+}
 
 // ListProjectVisibleEvents gets the events for the specified project.
 //

--- a/events.go
+++ b/events.go
@@ -197,6 +197,7 @@ func (s ProjectEvent) String() string {
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/events.html#list-a-projects-visible-events
 type ListProjectVisibleEventsOptions struct {
+	ListOptions
 	Action     *EventTypeValue       `url:"action,omitempty" json:"action,omitempty"`
 	TargetType *EventTargetTypeValue `url:"target_type,omitempty" json:"target_type,omitempty"`
 	Before     *ISOTime              `url:"before,omitempty" json:"before,omitempty"`


### PR DESCRIPTION
According to the latest doc https://docs.gitlab.com/ee/api/events.html#list-a-projects-visible-events, 
ListProjectVisibleEventsOptions should contain action, targetType ... etc.

<img width="1062" alt="image" src="https://user-images.githubusercontent.com/18712242/237027475-1b389255-b7ae-497b-9366-22fc9763becd.png">
