### PR TITLE
adapt job event environment

### DIFF
--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -437,7 +437,11 @@ type JobEvent struct {
 		Description string   `json:"description"`
 		Tags        []string `json:"tags"`
 	} `json:"runner"`
-	Environment string `json:"environment"`
+	Environment struct {
+		Name           string `json:"name"`
+		Action         string `json:"action"`
+		DeploymentTier string `json:"deployment_tier"`
+	} `json:"environment"`
 }
 
 // MemberEvent represents a member event.

--- a/event_webhook_types_test.go
+++ b/event_webhook_types_test.go
@@ -183,7 +183,9 @@ func TestJobEventUnmarshal(t *testing.T) {
 	expectedEvent.Runner.IsShared = true
 	expectedEvent.Runner.Tags = []string{"linux", "docker"}
 
-	expectedEvent.Environment = "staging"
+	expectedEvent.Environment.Name = "production"
+	expectedEvent.Environment.Action = "start"
+	expectedEvent.Environment.DeploymentTier = "production"
 
 	assert.Equal(t, expectedEvent, *event, "event should be equal to the expected one")
 }

--- a/testdata/webhooks/job.json
+++ b/testdata/webhooks/job.json
@@ -59,5 +59,9 @@
     "git_ssh_url": "git@gitlab.com:jsmithy2/release-tools-fake.git",
     "visibility_level": 20
   },
-  "environment": "staging"
+  "environment": {
+    "name": "production",
+    "action": "start",
+    "deployment_tier": "production"
+  }
 }


### PR DESCRIPTION
The implementation no longer corresponds to the current payload of the webhook. Unfortunately, I was not able to evaluate how long this has been out of sync, but this pull request restores compatibility with the current Gitlab version.