### PR TITLE
change blob id type to string

### DIFF
--- a/search.go
+++ b/search.go
@@ -248,7 +248,7 @@ type Blob struct {
 	Basename  string `json:"basename"`
 	Data      string `json:"data"`
 	Filename  string `json:"filename"`
-	ID        int    `json:"id"`
+	ID        string `json:"id"`
 	Ref       string `json:"ref"`
 	Startline int    `json:"startline"`
 	ProjectID int    `json:"project_id"`


### PR DESCRIPTION
As stated in #1715 unmarshalling search results is not possible due to the API returning null or strings as blob IDs. This PR changes the data type to string.