### PR TITLE
Add missing Project lint options

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -85,8 +85,10 @@ func (s *ValidateService) Lint(opts *LintOptions, options ...RequestOptionFunc) 
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/lint.html#validate-a-ci-yaml-configuration-with-a-namespace
 type ProjectNamespaceLintOptions struct {
-	Content *string `url:"content,omitempty" json:"content,omitempty"`
-	DryRun  *bool   `url:"dry_run,omitempty" json:"dry_run,omitempty"`
+	Content     *string `url:"content,omitempty" json:"content,omitempty"`
+	DryRun      *bool   `url:"dry_run,omitempty" json:"dry_run,omitempty"`
+	IncludeJobs *bool   `url:"include_jobs,omitempty" json:"include_jobs,omitempty"`
+	Ref         *string `url:"ref,omitempty" json:"ref,omitempty"`
 }
 
 // ProjectNamespaceLint validates .gitlab-ci.yml content by project.
@@ -119,7 +121,9 @@ func (s *ValidateService) ProjectNamespaceLint(pid interface{}, opt *ProjectName
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/lint.html#validate-a-projects-ci-configuration
 type ProjectLintOptions struct {
-	DryRun *bool `url:"dry_run,omitempty" json:"dry_run,omitempty"`
+	DryRun      *bool   `url:"dry_run,omitempty" json:"dry_run,omitempty"`
+	IncludeJobs *bool   `url:"include_jobs,omitempty" json:"include_jobs,omitempty"`
+	Ref         *string `url:"ref,omitempty" json:"ref,omitempty"`
 }
 
 // ProjectLint validates .gitlab-ci.yml content by project.

--- a/validate_test.go
+++ b/validate_test.go
@@ -163,8 +163,10 @@ func TestValidateProjectNamespace(t *testing.T) {
 		{
 			description: "valid",
 			request: &ProjectNamespaceLintOptions{
-				Content: String("{'build': {'script': 'echo build'}}"),
-				DryRun:  Bool(false),
+				Content:     String("{'build': {'script': 'echo build'}}"),
+				DryRun:      Bool(false),
+				IncludeJobs: Bool(true),
+				Ref:         String("foo"),
 			},
 			response: `{
 				"valid": true,


### PR DESCRIPTION
The two different project lint calls were missing some options from https://docs.gitlab.com/ee/api/lint.html#validate-a-projects-ci-configuration