### PR TITLE
Add `erased_at` field to jobs and bridges api

### DIFF
--- a/jobs.go
+++ b/jobs.go
@@ -41,6 +41,7 @@ type Job struct {
 	CreatedAt         *time.Time `json:"created_at"`
 	StartedAt         *time.Time `json:"started_at"`
 	FinishedAt        *time.Time `json:"finished_at"`
+	ErasedAt          *time.Time `json:"erased_at"`
 	Duration          float64    `json:"duration"`
 	QueuedDuration    float64    `json:"queued_duration"`
 	ArtifactsExpireAt *time.Time `json:"artifacts_expire_at"`
@@ -91,6 +92,7 @@ type Bridge struct {
 	CreatedAt          *time.Time    `json:"created_at"`
 	StartedAt          *time.Time    `json:"started_at"`
 	FinishedAt         *time.Time    `json:"finished_at"`
+	ErasedAt           *time.Time    `json:"erased_at"`
 	Duration           float64       `json:"duration"`
 	ID                 int           `json:"id"`
 	Name               string        `json:"name"`


### PR DESCRIPTION
To distinguish jobs that doesn't have trace (log) due to it's been erased, I've added `erased_at` field. Example:
```
"created_at": "2023-05-22T14:33:08.957Z",
"started_at": "2023-05-22T14:33:26.596Z",
"finished_at": "2023-05-22T14:46:20.896Z",
"erased_at": "2023-05-22T14:47:59.634Z",
```