### PR TITLE
Add failure_reason field to bridge

### DIFF
--- a/jobs.go
+++ b/jobs.go
@@ -100,6 +100,7 @@ type Bridge struct {
 	Ref                string        `json:"ref"`
 	Stage              string        `json:"stage"`
 	Status             string        `json:"status"`
+	FailureReason      string        `json:"failure_reason"`
 	Tag                bool          `json:"tag"`
 	WebURL             string        `json:"web_url"`
 	User               *User         `json:"user"`


### PR DESCRIPTION
API response example:
```
"id": 312,
"status": "failed",
"stage": "tests",
"failure_reason": "downstream_pipeline_creation_failed",
```