### PR TITLE
Add `queued_duration` field to bridge

### DIFF
--- a/jobs.go
+++ b/jobs.go
@@ -94,6 +94,7 @@ type Bridge struct {
 	FinishedAt         *time.Time    `json:"finished_at"`
 	ErasedAt           *time.Time    `json:"erased_at"`
 	Duration           float64       `json:"duration"`
+	QueuedDuration     float64       `json:"queued_duration"`
 	ID                 int           `json:"id"`
 	Name               string        `json:"name"`
 	Pipeline           PipelineInfo  `json:"pipeline"`


### PR DESCRIPTION
Example:
```
"duration": 513.796021,
"queued_duration": 0.410923,
```