### PR TITLE
Add regex option to Branches API

### DIFF
--- a/branches.go
+++ b/branches.go
@@ -56,6 +56,7 @@ func (b Branch) String() string {
 type ListBranchesOptions struct {
 	ListOptions
 	Search *string `url:"search,omitempty" json:"search,omitempty"`
+	Regex  *string `url:"regex,omitempty" json:"regex,omitempty"`
 }
 
 // ListBranches gets a list of repository branches from a project, sorted by


### PR DESCRIPTION
Hello, please add regex option to the branches API as specified in gitlab docs: https://docs.gitlab.com/ee/api/branches.html#list-repository-branches

Thanks!