### PR TITLE
Fix type for SystemOutput

### DIFF
--- a/pipelines.go
+++ b/pipelines.go
@@ -115,16 +115,10 @@ type PipelineTestCases struct {
 	Classname      string          `json:"classname"`
 	File           string          `json:"file"`
 	ExecutionTime  float64         `json:"execution_time"`
-	SystemOutput   *SystemOutput   `json:"system_output"`
+	SystemOutput   string          `json:"system_output"`
 	StackTrace     string          `json:"stack_trace"`
 	AttachmentURL  string          `json:"attachment_url"`
 	RecentFailures *RecentFailures `json:"recent_failures"`
-}
-
-// SystemOutput contains information about test cases when it fails.
-type SystemOutput struct {
-	Type    string `json:"type"`
-	Message string `json:"message"`
 }
 
 // RecentFailures contains failures count for the project's default branch.

--- a/pipelines_test.go
+++ b/pipelines_test.go
@@ -115,10 +115,7 @@ func TestGetPipelineTestReport(t *testing.T) {
 						Classname:     "MyClassOne",
 						File:          "/path/file.ext",
 						ExecutionTime: 19.987,
-						SystemOutput: &SystemOutput{
-							Type:    "failure",
-							Message: "Failed test",
-						},
+						SystemOutput:  "Failed test",
 						StackTrace:    "java.lang.Exception: Stack trace\nat java.base/java.lang.Thread.dumpStack(Thread.java:1383)",
 						AttachmentURL: "http://foo.bar",
 						RecentFailures: &RecentFailures{
@@ -133,13 +130,10 @@ func TestGetPipelineTestReport(t *testing.T) {
 						ExecutionTime: 19.984,
 					},
 					{
-						Status:    "error",
-						Name:      "Error testcase 3",
-						Classname: "MyClass",
-						SystemOutput: &SystemOutput{
-							Type:    "failure",
-							Message: "Failed test",
-						},
+						Status:       "error",
+						Name:         "Error testcase 3",
+						Classname:    "MyClass",
+						SystemOutput: "Failed test",
 					},
 					{
 						Status:        "success",

--- a/testdata/get_pipeline_testreport.json
+++ b/testdata/get_pipeline_testreport.json
@@ -22,10 +22,7 @@
           "classname": "MyClassOne",
           "file": "/path/file.ext",
           "execution_time": 19.987,
-          "system_output": {
-            "type": "failure",
-            "message": "Failed test"
-          },
+          "system_output": "Failed test",
           "stack_trace": "java.lang.Exception: Stack trace\nat java.base/java.lang.Thread.dumpStack(Thread.java:1383)",
           "attachment_url": "http://foo.bar",
           "recent_failures": {
@@ -50,10 +47,7 @@
           "classname": "MyClass",
           "file": null,
           "execution_time": 0.0,
-          "system_output": {
-            "type": "failure",
-            "message": "Failed test"
-          }
+          "system_output": "Failed test"
         },
         {
           "status": "success",


### PR DESCRIPTION
Changes type of SystemOutput from struct back to string.

Closes https://github.com/xanzy/go-gitlab/issues/1733