### PR TITLE
Add admin permission const

### DIFF
--- a/types.go
+++ b/types.go
@@ -66,6 +66,7 @@ const (
 	DeveloperPermissions     AccessLevelValue = 30
 	MaintainerPermissions    AccessLevelValue = 40
 	OwnerPermissions         AccessLevelValue = 50
+	AdminPermissions         AccessLevelValue = 60
 
 	// Deprecated: Renamed to MaintainerPermissions in GitLab 11.0.
 	MasterPermissions AccessLevelValue = 40


### PR DESCRIPTION
Closes #1739

This PR simply adds a single const value to the permission const values so that the list is comprehensive for use in downstream APIs. 