### PR TITLE
Add pipeline IID to the PipelineInfo struct

### DIFF
--- a/pipelines.go
+++ b/pipelines.go
@@ -135,6 +135,7 @@ func (p PipelineTestReport) String() string {
 // on other assets, like Commit.
 type PipelineInfo struct {
 	ID        int        `json:"id"`
+	IID       int        `json:"iid"`
 	ProjectID int        `json:"project_id"`
 	Status    string     `json:"status"`
 	Source    string     `json:"source"`


### PR DESCRIPTION
Adds the pipeline IID to the `PipelineInfo` struct so it can be displayed in the `glab ci list` output.