### PR TITLE
Add Support for Job Token Scope APIs

### DIFF
--- a/gitlab.go
+++ b/gitlab.go
@@ -153,6 +153,7 @@ type Client struct {
 	Issues                       *IssuesService
 	IssuesStatistics             *IssuesStatisticsService
 	Jobs                         *JobsService
+	JobTokenScope                *JobTokenScopeService
 	Keys                         *KeysService
 	Labels                       *LabelsService
 	License                      *LicenseService
@@ -370,6 +371,7 @@ func newClient(options ...ClientOptionFunc) (*Client, error) {
 	c.Issues = &IssuesService{client: c, timeStats: timeStats}
 	c.IssuesStatistics = &IssuesStatisticsService{client: c}
 	c.Jobs = &JobsService{client: c}
+	c.JobTokenScope = &JobTokenScopeService{client: c}
 	c.Keys = &KeysService{client: c}
 	c.Labels = &LabelsService{client: c}
 	c.License = &LicenseService{client: c}

--- a/job_token_scope.go
+++ b/job_token_scope.go
@@ -44,7 +44,7 @@ func (j *JobTokenScopeService) GetProjectJobTokenInboundAllowlist(pid interface{
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf(`/projects/%s/job_token_scope/allowlist`, PathEscape(project))
+	u := fmt.Sprintf(`projects/%s/job_token_scope/allowlist`, PathEscape(project))
 
 	req, err := j.client.NewRequest(http.MethodGet, u, opt, options)
 	if err != nil {
@@ -68,11 +68,11 @@ type JobTokenInboundAllowOptions struct {
 	TargetProjectID int `json:"target_project_id"`
 }
 
-// CreateJobTokenInboundAllowResponse represents the response from the
+// AddJobTokenInboundAllowResponse represents the response from the
 // Create a new project to a project’s CI/CD job token inbound allowlist API request
 //
 // GitLab API docs: https://docs.gitlab.com/ee/api/project_job_token_scopes.html#create-a-new-project-to-a-projects-cicd-job-token-inbound-allowlist
-type CreateJobTokenInboundAllowResponse struct {
+type AddJobTokenInboundAllowResponse struct {
 	SourceProjectID int `json:"source_project_id"`
 	TargetProjectID int `json:"target_project_id"`
 }
@@ -80,19 +80,19 @@ type CreateJobTokenInboundAllowResponse struct {
 // Adds a new Project to a Project's Job Token Inbound Allow list
 //
 // GitLab API docs: https://docs.gitlab.com/ee/api/project_job_token_scopes.html#create-a-new-project-to-a-projects-cicd-job-token-inbound-allowlist
-func (j *JobTokenScopeService) AddProjectToJobScopeAllowList(pid interface{}, opt *JobTokenInboundAllowOptions, options ...RequestOptionFunc) (*CreateJobTokenInboundAllowResponse, *Response, error) {
+func (j *JobTokenScopeService) AddProjectToJobScopeAllowList(pid interface{}, opt *JobTokenInboundAllowOptions, options ...RequestOptionFunc) (*AddJobTokenInboundAllowResponse, *Response, error) {
 	// Parse the project Id or namespace and create the URL
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf(`/projects/%s/job_token_scope/allowlist`, PathEscape(project))
+	u := fmt.Sprintf(`projects/%s/job_token_scope/allowlist`, PathEscape(project))
 	req, err := j.client.NewRequest(http.MethodPost, u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	a := new(CreateJobTokenInboundAllowResponse)
+	a := new(AddJobTokenInboundAllowResponse)
 	resp, err := j.client.Do(req, a)
 	if err != nil {
 		return nil, resp, err
@@ -110,15 +110,14 @@ func (j *JobTokenScopeService) RemoveProjectFromJobScopeAllowList(pid interface{
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf(`/projects/%s/job_token_scope/allowlist/%d`, PathEscape(project), opt.TargetProjectID)
+	u := fmt.Sprintf(`projects/%s/job_token_scope/allowlist/%d`, PathEscape(project), opt.TargetProjectID)
 	req, err := j.client.NewRequest(http.MethodDelete, u, nil, options)
 	if err != nil {
 		return nil, err
 	}
 
-	// This API returns an empty body on a successful request.
-	a := new(interface{})
-	resp, err := j.client.Do(req, a)
+	// This API has no body in the request or response
+	resp, err := j.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}

--- a/job_token_scope.go
+++ b/job_token_scope.go
@@ -26,19 +26,29 @@ type JobTokenScopeService struct {
 	client *Client
 }
 
-// GetJobTokenInboundAllowOptions represents the available options
-// when querying the inbound CI allow-list for projects
+// JobTokenInboundAllowItem represents a single job token inbound allowlist item.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/project_job_token_scopes.html#get-a-projects-cicd-job-token-inbound-allowlist
-type GetJobTokenInboundAllowOptions struct {
+// GitLab API docs: https://docs.gitlab.com/ee/api/project_job_token_scopes.html
+type JobTokenInboundAllowItem struct {
+	SourceProjectID int `json:"source_project_id"`
+	TargetProjectID int `json:"target_project_id"`
+}
+
+// GetJobTokenInboundAllowListOptions represents the available
+// GetJobTokenInboundAllowList() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/project_job_token_scopes.html#get-a-projects-cicd-job-token-inbound-allowlist
+type GetJobTokenInboundAllowListOptions struct {
 	ListOptions
 }
 
-// Fetch the CI/CD job token inbound allowlist (job token scope) of a project.
+// GetProjectJobTokenInboundAllowList fetches the CI/CD job token inbound
+// allowlist (job token scope) of a project.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/project_job_token_scopes.html#get-a-projects-cicd-job-token-inbound-allowlist
-func (j *JobTokenScopeService) GetProjectJobTokenInboundAllowlist(pid interface{}, opt *GetJobTokenInboundAllowOptions, options ...RequestOptionFunc) ([]*Project, *Response, error) {
-	// Parse the project Id or namespace and create the URL
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/project_job_token_scopes.html#get-a-projects-cicd-job-token-inbound-allowlist
+func (j *JobTokenScopeService) GetProjectJobTokenInboundAllowList(pid interface{}, opt *GetJobTokenInboundAllowListOptions, options ...RequestOptionFunc) ([]*Project, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
@@ -50,76 +60,66 @@ func (j *JobTokenScopeService) GetProjectJobTokenInboundAllowlist(pid interface{
 		return nil, nil, err
 	}
 
-	var p []*Project
-	resp, err := j.client.Do(req, &p)
+	var ps []*Project
+	resp, err := j.client.Do(req, &ps)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return p, resp, nil
+	return ps, resp, nil
 }
 
-// JobTokenInboundAllowOptions represents the available options
-// when adding or removing a project to the CI/CD job token inbound allowlist of a project.
+// AddProjectToJobScopeAllowListOptions represents the available
+// AddProjectToJobScopeAllowList() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/project_job_token_scopes.html#create-a-new-project-to-a-projects-cicd-job-token-inbound-allowlist
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/project_job_token_scopes.html#create-a-new-project-to-a-projects-cicd-job-token-inbound-allowlist
 type JobTokenInboundAllowOptions struct {
-	TargetProjectID int `json:"target_project_id"`
+	TargetProjectID *int `url:"target_project_id,omitempty" json:"target_project_id,omitempty"`
 }
 
-// AddJobTokenInboundAllowResponse represents the response from the
-// Create a new project to a project’s CI/CD job token inbound allowlist API request
+// AddProjectToJobScopeAllowList adds a new project to a project's job token
+// inbound allow list.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/project_job_token_scopes.html#create-a-new-project-to-a-projects-cicd-job-token-inbound-allowlist
-type AddJobTokenInboundAllowResponse struct {
-	SourceProjectID int `json:"source_project_id"`
-	TargetProjectID int `json:"target_project_id"`
-}
-
-// Adds a new Project to a Project's Job Token Inbound Allow list
-//
-// GitLab API docs: https://docs.gitlab.com/ee/api/project_job_token_scopes.html#create-a-new-project-to-a-projects-cicd-job-token-inbound-allowlist
-func (j *JobTokenScopeService) AddProjectToJobScopeAllowList(pid interface{}, opt *JobTokenInboundAllowOptions, options ...RequestOptionFunc) (*AddJobTokenInboundAllowResponse, *Response, error) {
-	// Parse the project Id or namespace and create the URL
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/project_job_token_scopes.html#create-a-new-project-to-a-projects-cicd-job-token-inbound-allowlist
+func (j *JobTokenScopeService) AddProjectToJobScopeAllowList(pid interface{}, opt *JobTokenInboundAllowOptions, options ...RequestOptionFunc) (*JobTokenInboundAllowItem, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf(`projects/%s/job_token_scope/allowlist`, PathEscape(project))
+
 	req, err := j.client.NewRequest(http.MethodPost, u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	a := new(AddJobTokenInboundAllowResponse)
-	resp, err := j.client.Do(req, a)
+	ai := new(JobTokenInboundAllowItem)
+	resp, err := j.client.Do(req, ai)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return a, resp, nil
+	return ai, resp, nil
 }
 
-// Removes a Project from a Project's Job Token Inbound Allow list
+// RemoveProjectFromJobScopeAllowList removes a project from a project's job
+// token inbound allow list.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/project_job_token_scopes.html#remove-a-project-from-a-projects-cicd-job-token-inbound-allowlist
-func (j *JobTokenScopeService) RemoveProjectFromJobScopeAllowList(pid interface{}, opt *JobTokenInboundAllowOptions, options ...RequestOptionFunc) (*Response, error) {
-	// Parse the project Id or namespace and create the URL
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/project_job_token_scopes.html#remove-a-project-from-a-projects-cicd-job-token-inbound-allowlist
+func (j *JobTokenScopeService) RemoveProjectFromJobScopeAllowList(pid interface{}, targetProject int, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf(`projects/%s/job_token_scope/allowlist/%d`, PathEscape(project), opt.TargetProjectID)
+	u := fmt.Sprintf(`projects/%s/job_token_scope/allowlist/%d`, PathEscape(project), targetProject)
+
 	req, err := j.client.NewRequest(http.MethodDelete, u, nil, options)
 	if err != nil {
 		return nil, err
 	}
 
-	// This API has no body in the request or response
-	resp, err := j.client.Do(req, nil)
-	if err != nil {
-		return resp, err
-	}
-
-	return resp, nil
+	return j.client.Do(req, nil)
 }

--- a/job_token_scope.go
+++ b/job_token_scope.go
@@ -1,0 +1,64 @@
+//
+// Copyright 2021, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package gitlab
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// JobTokenScopeService handles communication with project CI settings
+// such as token permissions.
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/project_job_token_scopes.html
+type JobTokenScopeService struct {
+	client *Client
+}
+
+// GetJobTokenInboundAllowOptions represents the available options
+// when querying the inbound CI allow-list for projects
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/project_job_token_scopes.html#get-a-projects-cicd-job-token-inbound-allowlist
+type GetJobTokenInboundAllowOptions struct {
+	ListOptions
+}
+
+// Fetch the CI/CD job token inbound allowlist (job token scope) of a project.
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/project_job_token_scopes.html#get-a-projects-cicd-job-token-inbound-allowlist
+func (j *JobTokenScopeService) GetProjectJobTokenInboundAllowlist(pid interface{}, opt *GetJobTokenInboundAllowOptions, options ...RequestOptionFunc) ([]*Project, *Response, error) {
+
+	// Parse the project Id or namespace and create the URL
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf(`/projects/%s/job_token_scope/allowlist`, PathEscape(project))
+
+	req, err := j.client.NewRequest(http.MethodGet, u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var p []*Project
+	resp, err := j.client.Do(req, &p)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return p, resp, nil
+}

--- a/job_token_scope.go
+++ b/job_token_scope.go
@@ -38,7 +38,6 @@ type GetJobTokenInboundAllowOptions struct {
 //
 // GitLab API docs: https://docs.gitlab.com/ee/api/project_job_token_scopes.html#get-a-projects-cicd-job-token-inbound-allowlist
 func (j *JobTokenScopeService) GetProjectJobTokenInboundAllowlist(pid interface{}, opt *GetJobTokenInboundAllowOptions, options ...RequestOptionFunc) ([]*Project, *Response, error) {
-
 	// Parse the project Id or namespace and create the URL
 	project, err := parseID(pid)
 	if err != nil {

--- a/job_token_scope.go
+++ b/job_token_scope.go
@@ -1,19 +1,16 @@
-//
 // Copyright 2021, Sander van Harmelen
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-
 package gitlab
 
 import (
@@ -61,4 +58,70 @@ func (j *JobTokenScopeService) GetProjectJobTokenInboundAllowlist(pid interface{
 	}
 
 	return p, resp, nil
+}
+
+// JobTokenInboundAllowOptions represents the available options
+// when adding or removing a project to the CI/CD job token inbound allowlist of a project.
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/project_job_token_scopes.html#create-a-new-project-to-a-projects-cicd-job-token-inbound-allowlist
+type JobTokenInboundAllowOptions struct {
+	TargetProjectID int `json:"target_project_id"`
+}
+
+// CreateJobTokenInboundAllowResponse represents the response from the
+// Create a new project to a project’s CI/CD job token inbound allowlist API request
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/project_job_token_scopes.html#create-a-new-project-to-a-projects-cicd-job-token-inbound-allowlist
+type CreateJobTokenInboundAllowResponse struct {
+	SourceProjectID int `json:"source_project_id"`
+	TargetProjectID int `json:"target_project_id"`
+}
+
+// Adds a new Project to a Project's Job Token Inbound Allow list
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/project_job_token_scopes.html#create-a-new-project-to-a-projects-cicd-job-token-inbound-allowlist
+func (j *JobTokenScopeService) AddProjectToJobScopeAllowList(pid interface{}, opt *JobTokenInboundAllowOptions, options ...RequestOptionFunc) (*CreateJobTokenInboundAllowResponse, *Response, error) {
+	// Parse the project Id or namespace and create the URL
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf(`/projects/%s/job_token_scope/allowlist`, PathEscape(project))
+	req, err := j.client.NewRequest(http.MethodPost, u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	a := new(CreateJobTokenInboundAllowResponse)
+	resp, err := j.client.Do(req, a)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return a, resp, nil
+}
+
+// Removes a Project from a Project's Job Token Inbound Allow list
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/project_job_token_scopes.html#remove-a-project-from-a-projects-cicd-job-token-inbound-allowlist
+func (j *JobTokenScopeService) RemoveProjectFromJobScopeAllowList(pid interface{}, opt *JobTokenInboundAllowOptions, options ...RequestOptionFunc) (*Response, error) {
+	// Parse the project Id or namespace and create the URL
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf(`/projects/%s/job_token_scope/allowlist/%d`, PathEscape(project), opt.TargetProjectID)
+	req, err := j.client.NewRequest(http.MethodDelete, u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	// This API returns an empty body on a successful request.
+	a := new(interface{})
+	resp, err := j.client.Do(req, a)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, nil
 }

--- a/job_token_scope_test.go
+++ b/job_token_scope_test.go
@@ -23,10 +23,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// This tests that when calling the GetProjectJobTokenInboundAllowlist, we get a list of projects
-// back properly. There isn't a "deep" test with every attribute specifieid, because the object
-// returned is a *Project object, which is already tested in project.go.
-func TestGetProjectJobTokenInboundAllowlist(t *testing.T) {
+// This tests that when calling the GetProjectJobTokenInboundAllowList, we get a
+// list of projects back properly. There isn't a "deep" test with every attribute
+// specifieid, because the object returned is a *Project object, which is already
+// tested in project.go.
+func TestGetProjectJobTokenInboundAllowList(t *testing.T) {
 	mux, client := setup(t)
 
 	// Handle project ID 1, and print a result of two projects
@@ -38,7 +39,10 @@ func TestGetProjectJobTokenInboundAllowlist(t *testing.T) {
 	})
 
 	want := []*Project{{ID: 1}, {ID: 2}}
-	projects, _, err := client.JobTokenScope.GetProjectJobTokenInboundAllowlist(1, &GetJobTokenInboundAllowOptions{})
+	projects, _, err := client.JobTokenScope.GetProjectJobTokenInboundAllowList(
+		1,
+		&GetJobTokenInboundAllowListOptions{},
+	)
 
 	assert.NoError(t, err)
 	assert.Equal(t, want, projects)
@@ -53,14 +57,14 @@ func TestAddProjectToJobScopeAllowList(t *testing.T) {
 		// Read the request to determine which target project is passed in
 		body, err := ioutil.ReadAll(r.Body)
 		if err != nil {
-			t.Fatalf("Failed to read body during TestAddProjectToJobScopeAllowList")
+			t.Fatalf("JobTokenScope.AddProjectToJobScopeAllowList failed to read body")
 		}
 
 		// Parse to object to ensure it's sent on the request appropriately.
 		var createTokenRequest JobTokenInboundAllowOptions
 		err = json.Unmarshal(body, &createTokenRequest)
 		if err != nil {
-			t.Fatalf("Failed to unmarshal body into the proper request type during TestAddProjectToJobScopeAllowList: %v", err)
+			t.Fatalf("JobTokenScope.AddProjectToJobScopeAllowList failed to unmarshal body: %v", err)
 		}
 
 		// Ensure we provide the proper response
@@ -70,15 +74,18 @@ func TestAddProjectToJobScopeAllowList(t *testing.T) {
 		fmt.Fprintf(w, `{
 			"source_project_id": 1,
 			"target_project_id": %d
-		}`, createTokenRequest.TargetProjectID)
+		}`, *createTokenRequest.TargetProjectID)
 	})
 
-	want := &AddJobTokenInboundAllowResponse{
+	want := &JobTokenInboundAllowItem{
 		SourceProjectID: 1,
 		TargetProjectID: 2,
 	}
 
-	addTokenResponse, resp, err := client.JobTokenScope.AddProjectToJobScopeAllowList(1, &JobTokenInboundAllowOptions{TargetProjectID: 2})
+	addTokenResponse, resp, err := client.JobTokenScope.AddProjectToJobScopeAllowList(
+		1,
+		&JobTokenInboundAllowOptions{TargetProjectID: Int(2)},
+	)
 	assert.NoError(t, err)
 	assert.Equal(t, want, addTokenResponse)
 	assert.Equal(t, 201, resp.StatusCode)
@@ -93,12 +100,12 @@ func TestRemoveProjectFromJobScopeAllowList(t *testing.T) {
 		// Read the request to determine which target project is passed in
 		body, err := ioutil.ReadAll(r.Body)
 		if err != nil {
-			t.Fatalf("Failed to read body during TestRemoveProjectFromJobScopeAllowList")
+			t.Fatalf("JobTokenScope.RemoveProjectFromJobScopeAllowList failed to read body")
 		}
 
 		// The body should be empty since all attributes are passed in the path
 		if body != nil && string(body) != "" {
-			t.Fatalf("Body included a value during TestRemoveProjectFromJobScopeAllowList, and it should be blank. Body: %s", body)
+			t.Fatalf("JobTokenScope.RemoveProjectFromJobScopeAllowList failed to unmarshal body: %v", err)
 		}
 
 		// Ensure we provide the proper response
@@ -108,7 +115,7 @@ func TestRemoveProjectFromJobScopeAllowList(t *testing.T) {
 		fmt.Fprint(w, "")
 	})
 
-	resp, err := client.JobTokenScope.RemoveProjectFromJobScopeAllowList(1, &JobTokenInboundAllowOptions{TargetProjectID: 2})
+	resp, err := client.JobTokenScope.RemoveProjectFromJobScopeAllowList(1, 2)
 	assert.NoError(t, err)
 	assert.Equal(t, 204, resp.StatusCode)
 }

--- a/job_token_scope_test.go
+++ b/job_token_scope_test.go
@@ -67,10 +67,10 @@ func TestAddProjectToJobScopeAllowList(t *testing.T) {
 		w.WriteHeader(http.StatusCreated)
 
 		// Print on the response with the proper target project
-		fmt.Fprint(w, fmt.Sprintf(`{
+		fmt.Fprintf(w, `{
 			"source_project_id": 1,
 			"target_project_id": %d
-		}`, createTokenRequest.TargetProjectID))
+		}`, createTokenRequest.TargetProjectID)
 	})
 
 	want := &AddJobTokenInboundAllowResponse{

--- a/job_token_scope_test.go
+++ b/job_token_scope_test.go
@@ -1,0 +1,114 @@
+// Copyright 2021, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package gitlab
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// This tests that when calling the GetProjectJobTokenInboundAllowlist, we get a list of projects
+// back properly. There isn't a "deep" test with every attribute specifieid, because the object
+// returned is a *Project object, which is already tested in project.go.
+func TestGetProjectJobTokenInboundAllowlist(t *testing.T) {
+	mux, client := setup(t)
+
+	// Handle project ID 1, and print a result of two projects
+	mux.HandleFunc("/api/v4/projects/1/job_token_scope/allowlist", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+
+		// Print on the response
+		fmt.Fprint(w, `[{"id":1},{"id":2}]`)
+	})
+
+	want := []*Project{{ID: 1}, {ID: 2}}
+	projects, _, err := client.JobTokenScope.GetProjectJobTokenInboundAllowlist(1, &GetJobTokenInboundAllowOptions{})
+
+	assert.NoError(t, err)
+	assert.Equal(t, want, projects)
+}
+
+func TestAddProjectToJobScopeAllowList(t *testing.T) {
+	mux, client := setup(t)
+
+	mux.HandleFunc("/api/v4/projects/1/job_token_scope/allowlist", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+
+		// Read the request to determine which target project is passed in
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("Failed to read body during TestAddProjectToJobScopeAllowList")
+		}
+
+		// Parse to object to ensure it's sent on the request appropriately.
+		var createTokenRequest JobTokenInboundAllowOptions
+		err = json.Unmarshal(body, &createTokenRequest)
+		if err != nil {
+			t.Fatalf("Failed to unmarshal body into the proper request type during TestAddProjectToJobScopeAllowList: %v", err)
+		}
+
+		// Ensure we provide the proper response
+		w.WriteHeader(http.StatusCreated)
+
+		// Print on the response with the proper target project
+		fmt.Fprint(w, fmt.Sprintf(`{
+			"source_project_id": 1,
+			"target_project_id": %d
+		}`, createTokenRequest.TargetProjectID))
+	})
+
+	want := &AddJobTokenInboundAllowResponse{
+		SourceProjectID: 1,
+		TargetProjectID: 2,
+	}
+
+	addTokenResponse, resp, err := client.JobTokenScope.AddProjectToJobScopeAllowList(1, &JobTokenInboundAllowOptions{TargetProjectID: 2})
+	assert.NoError(t, err)
+	assert.Equal(t, want, addTokenResponse)
+	assert.Equal(t, 201, resp.StatusCode)
+}
+
+func TestRemoveProjectFromJobScopeAllowList(t *testing.T) {
+	mux, client := setup(t)
+
+	mux.HandleFunc("/api/v4/projects/1/job_token_scope/allowlist/2", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodDelete)
+
+		// Read the request to determine which target project is passed in
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("Failed to read body during TestRemoveProjectFromJobScopeAllowList")
+		}
+
+		// The body should be empty since all attributes are passed in the path
+		if body != nil && string(body) != "" {
+			t.Fatalf("Body included a value during TestRemoveProjectFromJobScopeAllowList, and it should be blank. Body: %s", body)
+		}
+
+		// Ensure we provide the proper response
+		w.WriteHeader(http.StatusNoContent)
+
+		// Print an empty body, since that's what the API provides.
+		fmt.Fprint(w, "")
+	})
+
+	resp, err := client.JobTokenScope.RemoveProjectFromJobScopeAllowList(1, &JobTokenInboundAllowOptions{TargetProjectID: 2})
+	assert.NoError(t, err)
+	assert.Equal(t, 204, resp.StatusCode)
+}


### PR DESCRIPTION
With GitLab 16.0, CI_JOB_TOKEN now enforces the use of the project allow list. In order to add support for that to the terraform provider, we need to add the APIs to `go-gitlab`.

This PR will add support for those APIs, documented here: https://docs.gitlab.com/ee/api/project_job_token_scopes.html