### PR TITLE
Add URL to PipelineEvent > ObjectAttributes

### DIFF
--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -801,6 +801,7 @@ type PipelineEvent struct {
 		FinishedAt     string   `json:"finished_at"`
 		Duration       int      `json:"duration"`
 		QueuedDuration int      `json:"queued_duration"`
+		URL            string   `json:"url"`
 		Variables      []struct {
 			Key   string `json:"key"`
 			Value string `json:"value"`


### PR DESCRIPTION
Fix missed url field in PipelineEvent > ObjectAttributes


github.com/xanzy/go-gitlab@v0.86.0/event_webhook_types.go L807

go struct:
```go
ObjectAttributes struct {
		ID             int      `json:"id"`
		IID            int      `json:"iid"`
		Ref            string   `json:"ref"`
		Tag            bool     `json:"tag"`
		SHA            string   `json:"sha"`
		BeforeSHA      string   `json:"before_sha"`
		Source         string   `json:"source"`
		Status         string   `json:"status"`
		DetailedStatus string   `json:"detailed_status"`
		Stages         []string `json:"stages"`
		CreatedAt      string   `json:"created_at"`
		FinishedAt     string   `json:"finished_at"`
		Duration       int      `json:"duration"`
		QueuedDuration int      `json:"queued_duration"`
		Variables      []struct {
			Key   string `json:"key"`
			Value string `json:"value"`
		} `json:"variables"`
	} `json:"object_attributes"`
```

https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#pipeline-events
reference json:
```
"object_attributes":{
      "id": 31,
      "iid": 3,
      "name": "Pipeline for branch: master",
      "ref": "master",
      "tag": false,
      "sha": "bcbb5ec396a2c0f828686f14fac9b80b780504f2",
      "before_sha": "bcbb5ec396a2c0f828686f14fac9b80b780504f2",
      "source": "merge_request_event",
      "status": "success",
      "stages":[
         "build",
         "test",
         "deploy"
      ],
      "created_at": "2016-08-12 15:23:28 UTC",
      "finished_at": "2016-08-12 15:26:29 UTC",
      "duration": 63,
      "variables": [
        {
          "key": "NESTOR_PROD_ENVIRONMENT",
          "value": "us-west-1"
        }
      ],
      "url": "http://example.com/gitlab-org/gitlab-test/-/pipelines/31"
   },
```
