### PR TITLE
Add ID to TagAccessDescription

### DIFF
--- a/protected_tags.go
+++ b/protected_tags.go
@@ -44,6 +44,7 @@ type ProtectedTag struct {
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/protected_tags.html
 type TagAccessDescription struct {
+	ID                     int              `json:"id"`
 	UserID                 int              `json:"user_id"`
 	GroupID                int              `json:"group_id"`
 	AccessLevel            AccessLevelValue `json:"access_level"`


### PR DESCRIPTION
ID is now available and it is visible in [example responses in documentation](https://docs.gitlab.com/ee/api/protected_tags.html).