### PR TITLE
Add snippet repository storage move APIs

### DIFF
--- a/gitlab.go
+++ b/gitlab.go
@@ -206,8 +206,8 @@ type Client struct {
 	Services                     *ServicesService
 	Settings                     *SettingsService
 	Sidekiq                      *SidekiqService
-	Snippets                     *SnippetsService
 	SnippetRepositoryStorageMove *SnippetRepositoryStorageMoveService
+	Snippets                     *SnippetsService
 	SystemHooks                  *SystemHooksService
 	Tags                         *TagsService
 	Todos                        *TodosService

--- a/gitlab.go
+++ b/gitlab.go
@@ -207,6 +207,7 @@ type Client struct {
 	Settings                     *SettingsService
 	Sidekiq                      *SidekiqService
 	Snippets                     *SnippetsService
+	SnippetRepositoryStorageMove *SnippetRepositoryStorageMoveService
 	SystemHooks                  *SystemHooksService
 	Tags                         *TagsService
 	Todos                        *TodosService
@@ -425,6 +426,7 @@ func newClient(options ...ClientOptionFunc) (*Client, error) {
 	c.Settings = &SettingsService{client: c}
 	c.Sidekiq = &SidekiqService{client: c}
 	c.Snippets = &SnippetsService{client: c}
+	c.SnippetRepositoryStorageMove = &SnippetRepositoryStorageMoveService{client: c}
 	c.SystemHooks = &SystemHooksService{client: c}
 	c.Tags = &TagsService{client: c}
 	c.Todos = &TodosService{client: c}

--- a/project_repository_storage_move.go
+++ b/project_repository_storage_move.go
@@ -36,41 +36,44 @@ type ProjectRepositoryStorageMoveService struct {
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/project_repository_storage_moves.html
 type ProjectRepositoryStorageMove struct {
-	ID                     int        `json:"id"`
-	CreatedAt              *time.Time `json:"created_at"`
-	State                  string     `json:"state"`
-	SourceStorageName      string     `json:"source_storage_name"`
-	DestinationStorageName string     `json:"destination_storage_name"`
-	Project                struct {
-		ID                int        `json:"id"`
-		Description       string     `json:"description"`
-		Name              string     `json:"name"`
-		NameWithNamespace string     `json:"name_with_namespace"`
-		Path              string     `json:"path"`
-		PathWithNamespace string     `json:"path_with_namespace"`
-		CreatedAt         *time.Time `json:"created_at"`
-	} `json:"project"`
+	ID                     int                `json:"id"`
+	CreatedAt              *time.Time         `json:"created_at"`
+	State                  string             `json:"state"`
+	SourceStorageName      string             `json:"source_storage_name"`
+	DestinationStorageName string             `json:"destination_storage_name"`
+	Project                *RepositoryProject `json:"project"`
 }
 
-// RetrieveAllStorageMovesOptions represents the available
+type RepositoryProject struct {
+	ID                int        `json:"id"`
+	Description       string     `json:"description"`
+	Name              string     `json:"name"`
+	NameWithNamespace string     `json:"name_with_namespace"`
+	Path              string     `json:"path"`
+	PathWithNamespace string     `json:"path_with_namespace"`
+	CreatedAt         *time.Time `json:"created_at"`
+}
+
+// RetrieveAllProjectStorageMovesOptions represents the available
 // RetrieveAllStorageMoves() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/project_repository_storage_moves.html
-type RetrieveAllStorageMovesOptions ListOptions
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/project_repository_storage_moves.html
+type RetrieveAllProjectStorageMovesOptions ListOptions
 
-// RetrieveAllStorageMoves retrieves all repository storage moves accessible by
-// the authenticated user.
+// RetrieveAllStorageMoves retrieves all project repository storage moves
+// accessible by the authenticated user.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/project_repository_storage_moves.html#retrieve-all-project-repository-storage-moves
-func (s ProjectRepositoryStorageMoveService) RetrieveAllStorageMoves(opts RetrieveAllStorageMovesOptions, options ...RequestOptionFunc) ([]*ProjectRepositoryStorageMove, *Response, error) {
-	req, err := s.client.NewRequest(http.MethodGet, "project_repository_storage_moves", opts, options)
+func (p ProjectRepositoryStorageMoveService) RetrieveAllStorageMoves(opts RetrieveAllProjectStorageMovesOptions, options ...RequestOptionFunc) ([]*ProjectRepositoryStorageMove, *Response, error) {
+	req, err := p.client.NewRequest(http.MethodGet, "project_repository_storage_moves", opts, options)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var psms []*ProjectRepositoryStorageMove
-	resp, err := s.client.Do(req, &psms)
+	resp, err := p.client.Do(req, &psms)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -83,16 +86,16 @@ func (s ProjectRepositoryStorageMoveService) RetrieveAllStorageMoves(opts Retrie
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/project_repository_storage_moves.html#retrieve-all-repository-storage-moves-for-a-project
-func (s ProjectRepositoryStorageMoveService) RetrieveAllStorageMovesForProject(project int, opts RetrieveAllStorageMovesOptions, options ...RequestOptionFunc) ([]*ProjectRepositoryStorageMove, *Response, error) {
+func (p ProjectRepositoryStorageMoveService) RetrieveAllStorageMovesForProject(project int, opts RetrieveAllProjectStorageMovesOptions, options ...RequestOptionFunc) ([]*ProjectRepositoryStorageMove, *Response, error) {
 	u := fmt.Sprintf("projects/%d/repository_storage_moves", project)
 
-	req, err := s.client.NewRequest(http.MethodGet, u, opts, options)
+	req, err := p.client.NewRequest(http.MethodGet, u, opts, options)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var psms []*ProjectRepositoryStorageMove
-	resp, err := s.client.Do(req, &psms)
+	resp, err := p.client.Do(req, &psms)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -100,20 +103,20 @@ func (s ProjectRepositoryStorageMoveService) RetrieveAllStorageMovesForProject(p
 	return psms, resp, err
 }
 
-// GetStorageMove gets a single repository storage move.
+// GetStorageMove gets a single project repository storage move.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/project_repository_storage_moves.html#get-a-single-project-repository-storage-move
-func (s ProjectRepositoryStorageMoveService) GetStorageMove(repositoryStorage int, options ...RequestOptionFunc) (*ProjectRepositoryStorageMove, *Response, error) {
+func (p ProjectRepositoryStorageMoveService) GetStorageMove(repositoryStorage int, options ...RequestOptionFunc) (*ProjectRepositoryStorageMove, *Response, error) {
 	u := fmt.Sprintf("project_repository_storage_moves/%d", repositoryStorage)
 
-	req, err := s.client.NewRequest(http.MethodGet, u, nil, options)
+	req, err := p.client.NewRequest(http.MethodGet, u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	psm := new(ProjectRepositoryStorageMove)
-	resp, err := s.client.Do(req, psm)
+	resp, err := p.client.Do(req, psm)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -125,16 +128,37 @@ func (s ProjectRepositoryStorageMoveService) GetStorageMove(repositoryStorage in
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/project_repository_storage_moves.html#get-a-single-repository-storage-move-for-a-project
-func (s ProjectRepositoryStorageMoveService) GetStorageMoveForProject(project int, repositoryStorage int, options ...RequestOptionFunc) (*ProjectRepositoryStorageMove, *Response, error) {
+func (p ProjectRepositoryStorageMoveService) GetStorageMoveForProject(project int, repositoryStorage int, options ...RequestOptionFunc) (*ProjectRepositoryStorageMove, *Response, error) {
 	u := fmt.Sprintf("projects/%d/repository_storage_moves/%d", project, repositoryStorage)
 
-	req, err := s.client.NewRequest(http.MethodGet, u, nil, options)
+	req, err := p.client.NewRequest(http.MethodGet, u, nil, options)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	psm := new(ProjectRepositoryStorageMove)
-	resp, err := s.client.Do(req, psm)
+	resp, err := p.client.Do(req, psm)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return psm, resp, err
+}
+
+// ScheduleStorageMoveForProject schedule a repository to be moved for a project.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/project_repository_storage_moves.html#schedule-a-repository-storage-move-for-a-project
+func (p ProjectRepositoryStorageMoveService) ScheduleStorageMoveForProject(project int, options ...RequestOptionFunc) (*ProjectRepositoryStorageMove, *Response, error) {
+	u := fmt.Sprintf("projects/%d/repository_storage_moves", project)
+
+	req, err := p.client.NewRequest(http.MethodPost, u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	psm := new(ProjectRepositoryStorageMove)
+	resp, err := p.client.Do(req, psm)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -146,38 +170,11 @@ func (s ProjectRepositoryStorageMoveService) GetStorageMoveForProject(project in
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/project_repository_storage_moves.html#schedule-repository-storage-moves-for-all-projects-on-a-storage-shard
-func (s ProjectRepositoryStorageMoveService) ScheduleAllStorageMoves(options ...RequestOptionFunc) ([]*ProjectRepositoryStorageMove, *Response, error) {
-	req, err := s.client.NewRequest(http.MethodPost, "project_repository_storage_moves", nil, options)
+func (p ProjectRepositoryStorageMoveService) ScheduleAllStorageMoves(options ...RequestOptionFunc) (*Response, error) {
+	req, err := p.client.NewRequest(http.MethodPost, "project_repository_storage_moves", nil, options)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	var psms []*ProjectRepositoryStorageMove
-	resp, err := s.client.Do(req, &psms)
-	if err != nil {
-		return nil, resp, err
-	}
-
-	return psms, resp, err
-}
-
-// ScheduleStorageMoveForProject schedule a repository to be moved for a project.
-//
-// GitLab API docs:
-// https://docs.gitlab.com/ee/api/project_repository_storage_moves.html#schedule-a-repository-storage-move-for-a-project
-func (s ProjectRepositoryStorageMoveService) ScheduleStorageMoveForProject(project int, options ...RequestOptionFunc) (*ProjectRepositoryStorageMove, *Response, error) {
-	u := fmt.Sprintf("projects/%d/repository_storage_moves", project)
-
-	req, err := s.client.NewRequest(http.MethodPost, u, nil, options)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	psm := new(ProjectRepositoryStorageMove)
-	resp, err := s.client.Do(req, psm)
-	if err != nil {
-		return nil, resp, err
-	}
-
-	return psm, resp, err
+	return p.client.Do(req, nil)
 }

--- a/snippet_repository_storage_move.go
+++ b/snippet_repository_storage_move.go
@@ -1,0 +1,203 @@
+//
+// Copyright 2023, Nick Westbury
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package gitlab
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// SnippetRepositoryStorageMoveService handles communication with the
+// snippets related methods of the GitLab API.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/snippet_repository_storage_moves.html
+type SnippetRepositoryStorageMoveService struct {
+	client *Client
+}
+
+// SnippetRepositoryStorageMove represents the status of a repository move.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/snippet_repository_storage_moves.html
+type SnippetRepositoryStorageMove struct {
+	ID                     int          `json:"id"`
+	CreatedAt              *time.Time   `json:"created_at"`
+	State                  string       `json:"state"`
+	SourceStorageName      string       `json:"source_storage_name"`
+	DestinationStorageName string       `json:"destination_storage_name"`
+	Snippet                BasicSnippet `json:"snippet"`
+}
+
+// BasicSnippet represents a snippet as part of a SnippetRepositoryStorageMove.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/snippet_repository_storage_moves.html
+type BasicSnippet struct {
+	ID            int             `json:"id"`
+	Title         string          `json:"title"`
+	Description   string          `json:"description"`
+	Visibility    VisibilityValue `json:"visibility"`
+	UpdatedAt     *time.Time      `json:"updated_at"`
+	CreatedAt     *time.Time      `json:"created_at"`
+	ProjectID     int             `json:"project_id"`
+	WebURL        string          `json:"web_url"`
+	RawURL        string          `json:"raw_url"`
+	SshUrlToRepo  string          `json:"ssh_url_to_repo"`
+	HttpUrlToRepo string          `json:"http_url_to_repo"`
+}
+
+// RetrieveAllSnippetStorageMovesOptions represents the available
+// RetrieveAllStorageMoves() options.
+//
+// https://docs.gitlab.com/ee/api/snippet_repository_storage_moves.html
+type RetrieveAllSnippetStorageMovesOptions ListOptions
+
+// RetrieveAllSnippetStorageMoves retrieves all snippet repository storage moves accessible by
+// the authenticated user.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/snippet_repository_storage_moves.html#retrieve-all-repository-storage-moves-for-a-snippet
+func (s SnippetRepositoryStorageMoveService) RetrieveAllSnippetStorageMoves(opts RetrieveAllSnippetStorageMovesOptions, options ...RequestOptionFunc) ([]*SnippetRepositoryStorageMove, *Response, error) {
+	req, err := s.client.NewRequest(http.MethodGet, "snippet_repository_storage_moves", opts, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var ssms []*SnippetRepositoryStorageMove
+	resp, err := s.client.Do(req, &ssms)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return ssms, resp, err
+}
+
+// RetrieveAllStorageMovesForSnippet retrieves all repository storage moves for
+// a single snippet accessible by the authenticated user.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/snippet_repository_storage_moves.html#retrieve-all-repository-storage-moves-for-a-snippet
+func (s SnippetRepositoryStorageMoveService) RetrieveAllStorageMovesForSnippet(snippet int, opts RetrieveAllSnippetStorageMovesOptions, options ...RequestOptionFunc) ([]*SnippetRepositoryStorageMove, *Response, error) {
+	u := fmt.Sprintf("snippets/%d/repository_storage_moves", snippet)
+
+	req, err := s.client.NewRequest(http.MethodGet, u, opts, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var ssms []*SnippetRepositoryStorageMove
+	resp, err := s.client.Do(req, &ssms)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return ssms, resp, err
+}
+
+// GetSnippetStorageMove gets a single snippet repository storage move.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/snippet_repository_storage_moves.html#get-a-single-snippet-repository-storage-move
+func (s SnippetRepositoryStorageMoveService) GetSnippetStorageMove(repositoryStorage int, options ...RequestOptionFunc) (*SnippetRepositoryStorageMove, *Response, error) {
+	u := fmt.Sprintf("snippet_repository_storage_moves/%d", repositoryStorage)
+
+	req, err := s.client.NewRequest(http.MethodGet, u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ssm := new(SnippetRepositoryStorageMove)
+	resp, err := s.client.Do(req, ssm)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return ssm, resp, err
+}
+
+// GetStorageMoveForSnippet gets a single repository storage move for a snippet.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/snippet_repository_storage_moves.html#get-a-single-repository-storage-move-for-a-snippet
+func (s SnippetRepositoryStorageMoveService) GetStorageMoveForSnippet(snippet int, repositoryStorage int, options ...RequestOptionFunc) (*SnippetRepositoryStorageMove, *Response, error) {
+	u := fmt.Sprintf("snippets/%d/repository_storage_moves/%d", snippet, repositoryStorage)
+
+	req, err := s.client.NewRequest(http.MethodGet, u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ssm := new(SnippetRepositoryStorageMove)
+	resp, err := s.client.Do(req, ssm)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return ssm, resp, err
+}
+
+// ScheduleSnippetStorageMoveOptions represents the available options
+// for ScheduleAllSnippetStorageMoves() and ScheduleStorageMoveForSnippet()
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/snippet_repository_storage_moves.html
+type ScheduleSnippetStorageMoveOptions struct {
+	SourceStorageName      string `json:"source_storage_name,omitempty"`
+	DestinationStorageName string `json:"destination_storage_name,omitempty"`
+}
+
+// ScheduleStorageMoveForSnippet schedule a repository to be moved for a snippet.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/snippet_repository_storage_moves.html#schedule-a-repository-storage-move-for-a-snippet
+func (s SnippetRepositoryStorageMoveService) ScheduleStorageMoveForSnippet(snippet int, opts ScheduleSnippetStorageMoveOptions, options ...RequestOptionFunc) (*SnippetRepositoryStorageMove, *Response, error) {
+	u := fmt.Sprintf("snippets/%d/repository_storage_moves", snippet)
+
+	req, err := s.client.NewRequest(http.MethodPost, u, opts, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ssm := new(SnippetRepositoryStorageMove)
+	resp, err := s.client.Do(req, ssm)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return ssm, resp, err
+}
+
+// ScheduleAllSnippetStorageMoves schedules all snippet repositories to be moved.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/snippet_repository_storage_moves.html#schedule-repository-storage-moves-for-all-snippets-on-a-storage-shard
+func (s SnippetRepositoryStorageMoveService) ScheduleAllSnippetStorageMoves(opts ScheduleSnippetStorageMoveOptions, options ...RequestOptionFunc) (*Response, error) {
+	req, err := s.client.NewRequest(http.MethodPost, "snippet_repository_storage_moves", opts, options)
+	if err != nil {
+		return nil, err
+	}
+
+	var ssm *SnippetRepositoryStorageMove
+	resp, err := s.client.Do(req, &ssm)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, err
+}

--- a/snippet_repository_storage_move.go
+++ b/snippet_repository_storage_move.go
@@ -152,13 +152,12 @@ func (s SnippetRepositoryStorageMoveService) GetStorageMoveForSnippet(snippet in
 	return ssm, resp, err
 }
 
-// ScheduleSnippetStorageMoveOptions represents the available options
-// for ScheduleAllSnippetStorageMoves() and ScheduleStorageMoveForSnippet()
+// ScheduleStorageMoveForSnippetOptions represents the available options
+// for ScheduleStorageMoveForSnippet()
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/snippet_repository_storage_moves.html
-type ScheduleSnippetStorageMoveOptions struct {
-	SourceStorageName      string `json:"source_storage_name,omitempty"`
+type ScheduleStorageMoveForSnippetOptions struct {
 	DestinationStorageName string `json:"destination_storage_name,omitempty"`
 }
 
@@ -166,7 +165,7 @@ type ScheduleSnippetStorageMoveOptions struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/snippet_repository_storage_moves.html#schedule-a-repository-storage-move-for-a-snippet
-func (s SnippetRepositoryStorageMoveService) ScheduleStorageMoveForSnippet(snippet int, opts ScheduleSnippetStorageMoveOptions, options ...RequestOptionFunc) (*SnippetRepositoryStorageMove, *Response, error) {
+func (s SnippetRepositoryStorageMoveService) ScheduleStorageMoveForSnippet(snippet int, opts ScheduleStorageMoveForSnippetOptions, options ...RequestOptionFunc) (*SnippetRepositoryStorageMove, *Response, error) {
 	u := fmt.Sprintf("snippets/%d/repository_storage_moves", snippet)
 
 	req, err := s.client.NewRequest(http.MethodPost, u, opts, options)
@@ -183,11 +182,21 @@ func (s SnippetRepositoryStorageMoveService) ScheduleStorageMoveForSnippet(snipp
 	return ssm, resp, err
 }
 
+// ScheduleAllSnippetStorageMovesOptions represents the available options
+// for ScheduleAllSnippetStorageMoves()
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/snippet_repository_storage_moves.html
+type ScheduleAllSnippetStorageMovesOptions struct {
+	SourceStorageName      string `json:"source_storage_name,omitempty"`
+	DestinationStorageName string `json:"destination_storage_name,omitempty"`
+}
+
 // ScheduleAllSnippetStorageMoves schedules all snippet repositories to be moved.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/snippet_repository_storage_moves.html#schedule-repository-storage-moves-for-all-snippets-on-a-storage-shard
-func (s SnippetRepositoryStorageMoveService) ScheduleAllSnippetStorageMoves(opts ScheduleSnippetStorageMoveOptions, options ...RequestOptionFunc) (*Response, error) {
+func (s SnippetRepositoryStorageMoveService) ScheduleAllSnippetStorageMoves(opts ScheduleAllSnippetStorageMovesOptions, options ...RequestOptionFunc) (*Response, error) {
 	req, err := s.client.NewRequest(http.MethodPost, "snippet_repository_storage_moves", opts, options)
 	if err != nil {
 		return nil, err

--- a/snippet_repository_storage_move.go
+++ b/snippet_repository_storage_move.go
@@ -36,19 +36,15 @@ type SnippetRepositoryStorageMoveService struct {
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/snippet_repository_storage_moves.html
 type SnippetRepositoryStorageMove struct {
-	ID                     int          `json:"id"`
-	CreatedAt              *time.Time   `json:"created_at"`
-	State                  string       `json:"state"`
-	SourceStorageName      string       `json:"source_storage_name"`
-	DestinationStorageName string       `json:"destination_storage_name"`
-	Snippet                BasicSnippet `json:"snippet"`
+	ID                     int                `json:"id"`
+	CreatedAt              *time.Time         `json:"created_at"`
+	State                  string             `json:"state"`
+	SourceStorageName      string             `json:"source_storage_name"`
+	DestinationStorageName string             `json:"destination_storage_name"`
+	Snippet                *RepositorySnippet `json:"snippet"`
 }
 
-// BasicSnippet represents a snippet as part of a SnippetRepositoryStorageMove.
-//
-// GitLab API docs:
-// https://docs.gitlab.com/ee/api/snippet_repository_storage_moves.html
-type BasicSnippet struct {
+type RepositorySnippet struct {
 	ID            int             `json:"id"`
 	Title         string          `json:"title"`
 	Description   string          `json:"description"`
@@ -58,22 +54,23 @@ type BasicSnippet struct {
 	ProjectID     int             `json:"project_id"`
 	WebURL        string          `json:"web_url"`
 	RawURL        string          `json:"raw_url"`
-	SshUrlToRepo  string          `json:"ssh_url_to_repo"`
-	HttpUrlToRepo string          `json:"http_url_to_repo"`
+	SSHURLToRepo  string          `json:"ssh_url_to_repo"`
+	HTTPURLToRepo string          `json:"http_url_to_repo"`
 }
 
 // RetrieveAllSnippetStorageMovesOptions represents the available
 // RetrieveAllStorageMoves() options.
 //
+// GitLab API docs:
 // https://docs.gitlab.com/ee/api/snippet_repository_storage_moves.html
 type RetrieveAllSnippetStorageMovesOptions ListOptions
 
-// RetrieveAllSnippetStorageMoves retrieves all snippet repository storage moves accessible by
-// the authenticated user.
+// RetrieveAllStorageMoves retrieves all snippet repository storage moves
+// accessible by the authenticated user.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/snippet_repository_storage_moves.html#retrieve-all-repository-storage-moves-for-a-snippet
-func (s SnippetRepositoryStorageMoveService) RetrieveAllSnippetStorageMoves(opts RetrieveAllSnippetStorageMovesOptions, options ...RequestOptionFunc) ([]*SnippetRepositoryStorageMove, *Response, error) {
+func (s SnippetRepositoryStorageMoveService) RetrieveAllStorageMoves(opts RetrieveAllSnippetStorageMovesOptions, options ...RequestOptionFunc) ([]*SnippetRepositoryStorageMove, *Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "snippet_repository_storage_moves", opts, options)
 	if err != nil {
 		return nil, nil, err
@@ -110,11 +107,11 @@ func (s SnippetRepositoryStorageMoveService) RetrieveAllStorageMovesForSnippet(s
 	return ssms, resp, err
 }
 
-// GetSnippetStorageMove gets a single snippet repository storage move.
+// GetStorageMove gets a single snippet repository storage move.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/snippet_repository_storage_moves.html#get-a-single-snippet-repository-storage-move
-func (s SnippetRepositoryStorageMoveService) GetSnippetStorageMove(repositoryStorage int, options ...RequestOptionFunc) (*SnippetRepositoryStorageMove, *Response, error) {
+func (s SnippetRepositoryStorageMoveService) GetStorageMove(repositoryStorage int, options ...RequestOptionFunc) (*SnippetRepositoryStorageMove, *Response, error) {
 	u := fmt.Sprintf("snippet_repository_storage_moves/%d", repositoryStorage)
 
 	req, err := s.client.NewRequest(http.MethodGet, u, nil, options)
@@ -152,13 +149,13 @@ func (s SnippetRepositoryStorageMoveService) GetStorageMoveForSnippet(snippet in
 	return ssm, resp, err
 }
 
-// ScheduleStorageMoveForSnippetOptions represents the available options
-// for ScheduleStorageMoveForSnippet()
+// ScheduleStorageMoveForSnippetOptions represents the available
+// ScheduleStorageMoveForSnippet() options.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/snippet_repository_storage_moves.html
 type ScheduleStorageMoveForSnippetOptions struct {
-	DestinationStorageName string `json:"destination_storage_name,omitempty"`
+	DestinationStorageName *string `url:"destination_storage_name,omitempty" json:"destination_storage_name,omitempty"`
 }
 
 // ScheduleStorageMoveForSnippet schedule a repository to be moved for a snippet.
@@ -182,31 +179,25 @@ func (s SnippetRepositoryStorageMoveService) ScheduleStorageMoveForSnippet(snipp
 	return ssm, resp, err
 }
 
-// ScheduleAllSnippetStorageMovesOptions represents the available options
-// for ScheduleAllSnippetStorageMoves()
+// ScheduleAllStorageMovesOptions represents the available
+// ScheduleAllStorageMoves() options.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/snippet_repository_storage_moves.html
-type ScheduleAllSnippetStorageMovesOptions struct {
-	SourceStorageName      string `json:"source_storage_name,omitempty"`
-	DestinationStorageName string `json:"destination_storage_name,omitempty"`
+type ScheduleAllStorageMovesOptions struct {
+	SourceStorageName      *string `url:"source_storage_name,omitempty" json:"source_storage_name,omitempty"`
+	DestinationStorageName *string `url:"destination_storage_name,omitempty" json:"destination_storage_name,omitempty"`
 }
 
-// ScheduleAllSnippetStorageMoves schedules all snippet repositories to be moved.
+// ScheduleAllStorageMoves schedules all snippet repositories to be moved.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/snippet_repository_storage_moves.html#schedule-repository-storage-moves-for-all-snippets-on-a-storage-shard
-func (s SnippetRepositoryStorageMoveService) ScheduleAllSnippetStorageMoves(opts ScheduleAllSnippetStorageMovesOptions, options ...RequestOptionFunc) (*Response, error) {
+func (s SnippetRepositoryStorageMoveService) ScheduleAllStorageMoves(opts ScheduleAllStorageMovesOptions, options ...RequestOptionFunc) (*Response, error) {
 	req, err := s.client.NewRequest(http.MethodPost, "snippet_repository_storage_moves", opts, options)
 	if err != nil {
 		return nil, err
 	}
 
-	var ssm *SnippetRepositoryStorageMove
-	resp, err := s.client.Do(req, &ssm)
-	if err != nil {
-		return resp, err
-	}
-
-	return resp, err
+	return s.client.Do(req, nil)
 }

--- a/snippet_repository_storage_move_test.go
+++ b/snippet_repository_storage_move_test.go
@@ -34,14 +34,14 @@ func TestSnippetRepositoryStorageMove_RetrieveAllSnippetStorageMoves(t *testing.
 
 	opts := RetrieveAllSnippetStorageMovesOptions{Page: 1, PerPage: 2}
 
-	ssms, _, err := client.SnippetRepositoryStorageMove.RetrieveAllSnippetStorageMoves(opts)
+	ssms, _, err := client.SnippetRepositoryStorageMove.RetrieveAllStorageMoves(opts)
 	require.NoError(t, err)
 
 	want := []*SnippetRepositoryStorageMove{
 		{
 			ID:    123,
 			State: "scheduled",
-			Snippet: BasicSnippet{
+			Snippet: &RepositorySnippet{
 				ID:    65,
 				Title: "Test Snippet",
 			},
@@ -49,7 +49,7 @@ func TestSnippetRepositoryStorageMove_RetrieveAllSnippetStorageMoves(t *testing.
 		{
 			ID:    122,
 			State: "finished",
-			Snippet: BasicSnippet{
+			Snippet: &RepositorySnippet{
 				ID:    64,
 				Title: "Test Snippet 2",
 			},
@@ -91,7 +91,7 @@ func TestSnippetRepositoryStorageMove_RetrieveAllStorageMovesForSnippet(t *testi
 		{
 			ID:    123,
 			State: "scheduled",
-			Snippet: BasicSnippet{
+			Snippet: &RepositorySnippet{
 				ID:    65,
 				Title: "Test Snippet",
 			},
@@ -99,7 +99,7 @@ func TestSnippetRepositoryStorageMove_RetrieveAllStorageMovesForSnippet(t *testi
 		{
 			ID:    122,
 			State: "finished",
-			Snippet: BasicSnippet{
+			Snippet: &RepositorySnippet{
 				ID:    65,
 				Title: "Test Snippet",
 			},
@@ -108,7 +108,7 @@ func TestSnippetRepositoryStorageMove_RetrieveAllStorageMovesForSnippet(t *testi
 	require.Equal(t, want, ssms)
 }
 
-func TestSnippetRepositoryStorageMove_GetSnippetStorageMove(t *testing.T) {
+func TestSnippetRepositoryStorageMove_GetStorageMove(t *testing.T) {
 	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/snippet_repository_storage_moves/123", func(w http.ResponseWriter, r *http.Request) {
@@ -124,13 +124,13 @@ func TestSnippetRepositoryStorageMove_GetSnippetStorageMove(t *testing.T) {
 		}`)
 	})
 
-	ssm, _, err := client.SnippetRepositoryStorageMove.GetSnippetStorageMove(123)
+	ssm, _, err := client.SnippetRepositoryStorageMove.GetStorageMove(123)
 	require.NoError(t, err)
 
 	want := &SnippetRepositoryStorageMove{
 		ID:    123,
 		State: "scheduled",
-		Snippet: BasicSnippet{
+		Snippet: &RepositorySnippet{
 			ID:    65,
 			Title: "Test Snippet",
 		},
@@ -160,7 +160,7 @@ func TestSnippetRepositoryStorageMove_GetStorageMoveForSnippet(t *testing.T) {
 	want := &SnippetRepositoryStorageMove{
 		ID:    123,
 		State: "scheduled",
-		Snippet: BasicSnippet{
+		Snippet: &RepositorySnippet{
 			ID:    65,
 			Title: "Test Snippet",
 		},
@@ -190,7 +190,7 @@ func TestSnippetRepositoryStorageMove_ScheduleStorageMoveForSnippet(t *testing.T
 	want := &SnippetRepositoryStorageMove{
 		ID:    124,
 		State: "scheduled",
-		Snippet: BasicSnippet{
+		Snippet: &RepositorySnippet{
 			ID:    65,
 			Title: "Test Snippet",
 		},
@@ -198,7 +198,7 @@ func TestSnippetRepositoryStorageMove_ScheduleStorageMoveForSnippet(t *testing.T
 	require.Equal(t, want, ssm)
 }
 
-func TestSnippetRepositoryStorageMove_ScheduleAllSnippetStorageMoves(t *testing.T) {
+func TestSnippetRepositoryStorageMove_ScheduleAllStorageMoves(t *testing.T) {
 	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/snippet_repository_storage_moves", func(w http.ResponseWriter, r *http.Request) {
@@ -206,6 +206,10 @@ func TestSnippetRepositoryStorageMove_ScheduleAllSnippetStorageMoves(t *testing.
 		fmt.Fprint(w, `{"message": "202 Accepted"}`)
 	})
 
-	_, err := client.SnippetRepositoryStorageMove.ScheduleAllSnippetStorageMoves(ScheduleAllSnippetStorageMovesOptions{SourceStorageName: "default"})
+	_, err := client.SnippetRepositoryStorageMove.ScheduleAllStorageMoves(
+		ScheduleAllStorageMovesOptions{
+			SourceStorageName: String("default"),
+		},
+	)
 	require.NoError(t, err)
 }

--- a/snippet_repository_storage_move_test.go
+++ b/snippet_repository_storage_move_test.go
@@ -184,7 +184,7 @@ func TestSnippetRepositoryStorageMove_ScheduleStorageMoveForSnippet(t *testing.T
 		}`)
 	})
 
-	ssm, _, err := client.SnippetRepositoryStorageMove.ScheduleStorageMoveForSnippet(65, ScheduleSnippetStorageMoveOptions{})
+	ssm, _, err := client.SnippetRepositoryStorageMove.ScheduleStorageMoveForSnippet(65, ScheduleStorageMoveForSnippetOptions{})
 	require.NoError(t, err)
 
 	want := &SnippetRepositoryStorageMove{
@@ -206,6 +206,6 @@ func TestSnippetRepositoryStorageMove_ScheduleAllSnippetStorageMoves(t *testing.
 		fmt.Fprint(w, `{"message": "202 Accepted"}`)
 	})
 
-	_, err := client.SnippetRepositoryStorageMove.ScheduleAllSnippetStorageMoves(ScheduleSnippetStorageMoveOptions{SourceStorageName: "default"})
+	_, err := client.SnippetRepositoryStorageMove.ScheduleAllSnippetStorageMoves(ScheduleAllSnippetStorageMovesOptions{SourceStorageName: "default"})
 	require.NoError(t, err)
 }

--- a/snippet_repository_storage_move_test.go
+++ b/snippet_repository_storage_move_test.go
@@ -1,0 +1,211 @@
+package gitlab
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSnippetRepositoryStorageMove_RetrieveAllSnippetStorageMoves(t *testing.T) {
+	mux, client := setup(t)
+
+	mux.HandleFunc("/api/v4/snippet_repository_storage_moves", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, `[
+		{
+		  "id":123,
+		  "state":"scheduled",
+		  "snippet":{
+			"id":65,
+			"title":"Test Snippet"
+		  }
+		},
+		{
+		  "id":122,
+		  "state":"finished",
+		  "snippet":{
+			"id":64,
+			"title":"Test Snippet 2"
+		  }
+		}]`)
+	})
+
+	opts := RetrieveAllSnippetStorageMovesOptions{Page: 1, PerPage: 2}
+
+	ssms, _, err := client.SnippetRepositoryStorageMove.RetrieveAllSnippetStorageMoves(opts)
+	require.NoError(t, err)
+
+	want := []*SnippetRepositoryStorageMove{
+		{
+			ID:    123,
+			State: "scheduled",
+			Snippet: BasicSnippet{
+				ID:    65,
+				Title: "Test Snippet",
+			},
+		},
+		{
+			ID:    122,
+			State: "finished",
+			Snippet: BasicSnippet{
+				ID:    64,
+				Title: "Test Snippet 2",
+			},
+		},
+	}
+	require.Equal(t, want, ssms)
+}
+
+func TestSnippetRepositoryStorageMove_RetrieveAllStorageMovesForSnippet(t *testing.T) {
+	mux, client := setup(t)
+
+	mux.HandleFunc("/api/v4/snippets/65/repository_storage_moves", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, `[
+		{
+		  "id":123,
+		  "state":"scheduled",
+		  "snippet":{
+			"id":65,
+			"title":"Test Snippet"
+		  }
+		},
+		{
+		  "id":122,
+		  "state":"finished",
+		  "snippet":{
+			"id":65,
+			"title":"Test Snippet"
+		  }
+		}]`)
+	})
+
+	opts := RetrieveAllSnippetStorageMovesOptions{Page: 1, PerPage: 2}
+
+	ssms, _, err := client.SnippetRepositoryStorageMove.RetrieveAllStorageMovesForSnippet(65, opts)
+	require.NoError(t, err)
+
+	want := []*SnippetRepositoryStorageMove{
+		{
+			ID:    123,
+			State: "scheduled",
+			Snippet: BasicSnippet{
+				ID:    65,
+				Title: "Test Snippet",
+			},
+		},
+		{
+			ID:    122,
+			State: "finished",
+			Snippet: BasicSnippet{
+				ID:    65,
+				Title: "Test Snippet",
+			},
+		},
+	}
+	require.Equal(t, want, ssms)
+}
+
+func TestSnippetRepositoryStorageMove_GetSnippetStorageMove(t *testing.T) {
+	mux, client := setup(t)
+
+	mux.HandleFunc("/api/v4/snippet_repository_storage_moves/123", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, `
+		{
+		  "id":123,
+		  "state":"scheduled",
+		  "snippet":{
+			"id":65,
+			"title":"Test Snippet"
+		  }
+		}`)
+	})
+
+	ssm, _, err := client.SnippetRepositoryStorageMove.GetSnippetStorageMove(123)
+	require.NoError(t, err)
+
+	want := &SnippetRepositoryStorageMove{
+		ID:    123,
+		State: "scheduled",
+		Snippet: BasicSnippet{
+			ID:    65,
+			Title: "Test Snippet",
+		},
+	}
+	require.Equal(t, want, ssm)
+}
+
+func TestSnippetRepositoryStorageMove_GetStorageMoveForSnippet(t *testing.T) {
+	mux, client := setup(t)
+
+	mux.HandleFunc("/api/v4/snippets/65/repository_storage_moves/123", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, `
+		{
+		  "id":123,
+		  "state":"scheduled",
+		  "snippet":{
+			"id":65,
+			"title":"Test Snippet"
+		  }
+		}`)
+	})
+
+	ssm, _, err := client.SnippetRepositoryStorageMove.GetStorageMoveForSnippet(65, 123)
+	require.NoError(t, err)
+
+	want := &SnippetRepositoryStorageMove{
+		ID:    123,
+		State: "scheduled",
+		Snippet: BasicSnippet{
+			ID:    65,
+			Title: "Test Snippet",
+		},
+	}
+	require.Equal(t, want, ssm)
+}
+
+func TestSnippetRepositoryStorageMove_ScheduleStorageMoveForSnippet(t *testing.T) {
+	mux, client := setup(t)
+
+	mux.HandleFunc("/api/v4/snippets/65/repository_storage_moves", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		fmt.Fprint(w, `
+		{
+		  "id":124,
+		  "state":"scheduled",
+		  "snippet":{
+			"id":65,
+			"title":"Test Snippet"
+		  }
+		}`)
+	})
+
+	ssm, _, err := client.SnippetRepositoryStorageMove.ScheduleStorageMoveForSnippet(65, ScheduleSnippetStorageMoveOptions{})
+	require.NoError(t, err)
+
+	want := &SnippetRepositoryStorageMove{
+		ID:    124,
+		State: "scheduled",
+		Snippet: BasicSnippet{
+			ID:    65,
+			Title: "Test Snippet",
+		},
+	}
+	require.Equal(t, want, ssm)
+}
+
+func TestSnippetRepositoryStorageMove_ScheduleAllSnippetStorageMoves(t *testing.T) {
+	mux, client := setup(t)
+
+	mux.HandleFunc("/api/v4/snippet_repository_storage_moves", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		fmt.Fprint(w, `{"message": "202 Accepted"}`)
+	})
+
+	_, err := client.SnippetRepositoryStorageMove.ScheduleAllSnippetStorageMoves(ScheduleSnippetStorageMoveOptions{SourceStorageName: "default"})
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Adds api endpoints from https://docs.gitlab.com/ee/api/snippet_repository_storage_moves.html