### PR TITLE
Bugfix: add name parameter to group badges

### DIFF
--- a/group_badges.go
+++ b/group_badges.go
@@ -44,6 +44,7 @@ const (
 // https://docs.gitlab.com/ee/api/group_badges.html
 type GroupBadge struct {
 	ID               int       `json:"id"`
+	Name             string    `json:"name"`
 	LinkURL          string    `json:"link_url"`
 	ImageURL         string    `json:"image_url"`
 	RenderedLinkURL  string    `json:"rendered_link_url"`
@@ -55,7 +56,10 @@ type GroupBadge struct {
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/group_badges.html#list-all-badges-of-a-group
-type ListGroupBadgesOptions ListOptions
+type ListGroupBadgesOptions struct {
+	ListOptions
+	Name *string `url:"name,omitempty" json:"name,omitempty"`
+}
 
 // ListGroupBadges gets a list of a group badges.
 //
@@ -114,6 +118,7 @@ func (s *GroupBadgesService) GetGroupBadge(gid interface{}, badge int, options .
 type AddGroupBadgeOptions struct {
 	LinkURL  *string `url:"link_url,omitempty" json:"link_url,omitempty"`
 	ImageURL *string `url:"image_url,omitempty" json:"image_url,omitempty"`
+	Name     *string `url:"name,omitempty" json:"name,omitempty"`
 }
 
 // AddGroupBadge adds a badge to a group.
@@ -148,6 +153,7 @@ func (s *GroupBadgesService) AddGroupBadge(gid interface{}, opt *AddGroupBadgeOp
 type EditGroupBadgeOptions struct {
 	LinkURL  *string `url:"link_url,omitempty" json:"link_url,omitempty"`
 	ImageURL *string `url:"image_url,omitempty" json:"image_url,omitempty"`
+	Name     *string `url:"name,omitempty" json:"name,omitempty"`
 }
 
 // EditGroupBadge updates a badge of a group.
@@ -201,6 +207,7 @@ func (s *GroupBadgesService) DeleteGroupBadge(gid interface{}, badge int, option
 type GroupBadgePreviewOptions struct {
 	LinkURL  *string `url:"link_url,omitempty" json:"link_url,omitempty"`
 	ImageURL *string `url:"image_url,omitempty" json:"image_url,omitempty"`
+	Name     *string `url:"name,omitempty" json:"name,omitempty"`
 }
 
 // PreviewGroupBadge returns how the link_url and image_url final URLs would be after

--- a/group_badges_test.go
+++ b/group_badges_test.go
@@ -29,7 +29,7 @@ func TestListGroupBadges(t *testing.T) {
 	mux.HandleFunc("/api/v4/groups/1/badges",
 		func(w http.ResponseWriter, r *http.Request) {
 			testMethod(t, r, http.MethodGet)
-			fmt.Fprint(w, `[{"id":1, "kind":"group"},{"id":2, "kind":"group"}]`)
+			fmt.Fprint(w, `[{"id":1, "name":"one", "kind":"group"},{"id":2, "name":"two", "kind":"group"}]`)
 		})
 
 	badges, _, err := client.GroupBadges.ListGroupBadges(1, &ListGroupBadgesOptions{})
@@ -37,7 +37,7 @@ func TestListGroupBadges(t *testing.T) {
 		t.Errorf("GroupBadges.ListGroupBadges returned error: %v", err)
 	}
 
-	want := []*GroupBadge{{ID: 1, Kind: GroupBadgeKind}, {ID: 2, Kind: GroupBadgeKind}}
+	want := []*GroupBadge{{ID: 1, Name: "one", Kind: GroupBadgeKind}, {ID: 2, Name: "two", Kind: GroupBadgeKind}}
 	if !reflect.DeepEqual(want, badges) {
 		t.Errorf("GroupBadges.ListGroupBadges returned %+v, want %+v", badges, want)
 	}
@@ -49,7 +49,7 @@ func TestGetGroupBadge(t *testing.T) {
 	mux.HandleFunc("/api/v4/groups/1/badges/2",
 		func(w http.ResponseWriter, r *http.Request) {
 			testMethod(t, r, http.MethodGet)
-			fmt.Fprint(w, `{"id":2, "kind":"group"}`)
+			fmt.Fprint(w, `{"id":2, "name":"two", "kind":"group"}`)
 		})
 
 	badge, _, err := client.GroupBadges.GetGroupBadge(1, 2)
@@ -57,7 +57,7 @@ func TestGetGroupBadge(t *testing.T) {
 		t.Errorf("GroupBadges.GetGroupBadge returned error: %v", err)
 	}
 
-	want := &GroupBadge{ID: 2, Kind: GroupBadgeKind}
+	want := &GroupBadge{ID: 2, Name: "two", Kind: GroupBadgeKind}
 	if !reflect.DeepEqual(want, badge) {
 		t.Errorf("GroupBadges.GetGroupBadge returned %+v, want %+v", badge, want)
 	}
@@ -69,7 +69,7 @@ func TestAddGroupBadge(t *testing.T) {
 	mux.HandleFunc("/api/v4/groups/1/badges",
 		func(w http.ResponseWriter, r *http.Request) {
 			testMethod(t, r, http.MethodPost)
-			fmt.Fprint(w, `{"id":3, "link_url":"LINK", "image_url":"IMAGE", "kind":"group"}`)
+			fmt.Fprint(w, `{"id":3, "name":"three", "link_url":"LINK", "image_url":"IMAGE", "kind":"group"}`)
 		})
 
 	opt := &AddGroupBadgeOptions{ImageURL: String("IMAGE"), LinkURL: String("LINK")}
@@ -78,7 +78,7 @@ func TestAddGroupBadge(t *testing.T) {
 		t.Errorf("GroupBadges.AddGroupBadge returned error: %v", err)
 	}
 
-	want := &GroupBadge{ID: 3, ImageURL: "IMAGE", LinkURL: "LINK", Kind: GroupBadgeKind}
+	want := &GroupBadge{ID: 3, Name: "three", ImageURL: "IMAGE", LinkURL: "LINK", Kind: GroupBadgeKind}
 	if !reflect.DeepEqual(want, badge) {
 		t.Errorf("GroupBadges.AddGroupBadge returned %+v, want %+v", badge, want)
 	}
@@ -90,7 +90,7 @@ func TestEditGroupBadge(t *testing.T) {
 	mux.HandleFunc("/api/v4/groups/1/badges/2",
 		func(w http.ResponseWriter, r *http.Request) {
 			testMethod(t, r, http.MethodPut)
-			fmt.Fprint(w, `{"id":2, "link_url":"NEW_LINK", "image_url":"NEW_IMAGE", "kind":"group"}`)
+			fmt.Fprint(w, `{"id":2, "name":"two", "link_url":"NEW_LINK", "image_url":"NEW_IMAGE", "kind":"group"}`)
 		})
 
 	opt := &EditGroupBadgeOptions{ImageURL: String("NEW_IMAGE"), LinkURL: String("NEW_LINK")}
@@ -99,7 +99,7 @@ func TestEditGroupBadge(t *testing.T) {
 		t.Errorf("GroupBadges.EditGroupBadge returned error: %v", err)
 	}
 
-	want := &GroupBadge{ID: 2, ImageURL: "NEW_IMAGE", LinkURL: "NEW_LINK", Kind: GroupBadgeKind}
+	want := &GroupBadge{ID: 2, Name: "two", ImageURL: "NEW_IMAGE", LinkURL: "NEW_LINK", Kind: GroupBadgeKind}
 	if !reflect.DeepEqual(want, badge) {
 		t.Errorf("GroupBadges.EditGroupBadge returned %+v, want %+v", badge, want)
 	}


### PR DESCRIPTION
I noticed that the `name` parameter was missing for the group badges API. This was implemented for project badges, but strangely not for group badges yet.

https://docs.gitlab.com/ee/api/group_badges.html