### PR TITLE
Add repository storage filter to groups

### DIFF
--- a/groups.go
+++ b/groups.go
@@ -133,13 +133,13 @@ type ListGroupsOptions struct {
 	MinAccessLevel       *AccessLevelValue `url:"min_access_level,omitempty" json:"min_access_level,omitempty"`
 	OrderBy              *string           `url:"order_by,omitempty" json:"order_by,omitempty"`
 	Owned                *bool             `url:"owned,omitempty" json:"owned,omitempty"`
+	RepositoryStorage    *string           `url:"repository_storage,omitempty" json:"repository_storage,omitempty"`
 	Search               *string           `url:"search,omitempty" json:"search,omitempty"`
 	SkipGroups           *[]int            `url:"skip_groups,omitempty" del:"," json:"skip_groups,omitempty"`
 	Sort                 *string           `url:"sort,omitempty" json:"sort,omitempty"`
 	Statistics           *bool             `url:"statistics,omitempty" json:"statistics,omitempty"`
 	TopLevelOnly         *bool             `url:"top_level_only,omitempty" json:"top_level_only,omitempty"`
 	WithCustomAttributes *bool             `url:"with_custom_attributes,omitempty" json:"with_custom_attributes,omitempty"`
-	RepositoryStorage    *string           `url:"repository_storage,omitempty" json:"repository_storage,omitempty"`
 }
 
 // ListGroups gets a list of groups (as user: my groups, as admin: all groups).

--- a/groups.go
+++ b/groups.go
@@ -50,6 +50,7 @@ type Group struct {
 	AvatarURL               string                     `json:"avatar_url"`
 	WebURL                  string                     `json:"web_url"`
 	RequestAccessEnabled    bool                       `json:"request_access_enabled"`
+	RepositoryStorage       string                     `json:"repository_storage"`
 	FullName                string                     `json:"full_name"`
 	FullPath                string                     `json:"full_path"`
 	FileTemplateProjectID   int                        `json:"file_template_project_id"`
@@ -86,7 +87,6 @@ type Group struct {
 	CreatedAt                      *time.Time         `json:"created_at"`
 	IPRestrictionRanges            string             `json:"ip_restriction_ranges"`
 	WikiAccessLevel                AccessControlValue `json:"wiki_access_level"`
-	RepositoryStorage              string             `json:"repository_storage"`
 }
 
 // GroupAvatar represents a GitLab group avatar.
@@ -129,17 +129,17 @@ type SAMLGroupLink struct {
 // GitLab API docs: https://docs.gitlab.com/ee/api/groups.html#list-groups
 type ListGroupsOptions struct {
 	ListOptions
-	AllAvailable         *bool             `url:"all_available,omitempty" json:"all_available,omitempty"`
-	MinAccessLevel       *AccessLevelValue `url:"min_access_level,omitempty" json:"min_access_level,omitempty"`
-	OrderBy              *string           `url:"order_by,omitempty" json:"order_by,omitempty"`
-	Owned                *bool             `url:"owned,omitempty" json:"owned,omitempty"`
-	RepositoryStorage    *string           `url:"repository_storage,omitempty" json:"repository_storage,omitempty"`
-	Search               *string           `url:"search,omitempty" json:"search,omitempty"`
 	SkipGroups           *[]int            `url:"skip_groups,omitempty" del:"," json:"skip_groups,omitempty"`
+	AllAvailable         *bool             `url:"all_available,omitempty" json:"all_available,omitempty"`
+	Search               *string           `url:"search,omitempty" json:"search,omitempty"`
+	OrderBy              *string           `url:"order_by,omitempty" json:"order_by,omitempty"`
 	Sort                 *string           `url:"sort,omitempty" json:"sort,omitempty"`
 	Statistics           *bool             `url:"statistics,omitempty" json:"statistics,omitempty"`
-	TopLevelOnly         *bool             `url:"top_level_only,omitempty" json:"top_level_only,omitempty"`
 	WithCustomAttributes *bool             `url:"with_custom_attributes,omitempty" json:"with_custom_attributes,omitempty"`
+	Owned                *bool             `url:"owned,omitempty" json:"owned,omitempty"`
+	MinAccessLevel       *AccessLevelValue `url:"min_access_level,omitempty" json:"min_access_level,omitempty"`
+	TopLevelOnly         *bool             `url:"top_level_only,omitempty" json:"top_level_only,omitempty"`
+	RepositoryStorage    *string           `url:"repository_storage,omitempty" json:"repository_storage,omitempty"`
 }
 
 // ListGroups gets a list of groups (as user: my groups, as admin: all groups).

--- a/groups.go
+++ b/groups.go
@@ -86,6 +86,7 @@ type Group struct {
 	CreatedAt                      *time.Time         `json:"created_at"`
 	IPRestrictionRanges            string             `json:"ip_restriction_ranges"`
 	WikiAccessLevel                AccessControlValue `json:"wiki_access_level"`
+	RepositoryStorage              string             `json:"repository_storage"`
 }
 
 // GroupAvatar represents a GitLab group avatar.
@@ -138,6 +139,7 @@ type ListGroupsOptions struct {
 	Statistics           *bool             `url:"statistics,omitempty" json:"statistics,omitempty"`
 	TopLevelOnly         *bool             `url:"top_level_only,omitempty" json:"top_level_only,omitempty"`
 	WithCustomAttributes *bool             `url:"with_custom_attributes,omitempty" json:"with_custom_attributes,omitempty"`
+	RepositoryStorage    *string           `url:"repository_storage,omitempty" json:"repository_storage,omitempty"`
 }
 
 // ListGroups gets a list of groups (as user: my groups, as admin: all groups).


### PR DESCRIPTION
Add the option to filter groups by repository storage.

https://gitlab.com/gitlab-org/gitlab/-/merge_requests/127526