### PR TITLE
Add new runner api support

### DIFF
--- a/users.go
+++ b/users.go
@@ -1415,16 +1415,17 @@ func (s *UsersService) DisableTwoFactor(user int, options ...RequestOptionFunc) 
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/users.html#create-a-runner
 type CreateUserRunnerOptions struct {
-	RunnerType     string   `json:"runner_type"`
-	GroupID        int      `json:"group_id"`
-	ProjectID      int      `json:"project_id"`
-	Description    string   `json:"description"`
-	Paused         bool     `json:"paused"`
-	Locked         bool     `json:"locked"`
-	RunUntagged    bool     `json:"run_untagged"`
-	TagList        []string `json:"tag_list"`
-	AccessLevel    string   `json:"access_level"`
-	MaximumTimeout int      `json:"maximum_timeout"`
+	RunnerType      string   `json:"runner_type"`
+	GroupID         int      `json:"group_id"`
+	ProjectID       int      `json:"project_id"`
+	Description     string   `json:"description"`
+	Paused          bool     `json:"paused"`
+	Locked          bool     `json:"locked"`
+	RunUntagged     bool     `json:"run_untagged"`
+	TagList         []string `json:"tag_list"`
+	AccessLevel     string   `json:"access_level"`
+	MaximumTimeout  int      `json:"maximum_timeout"`
+	MaintenanceNote string   `json:"maintenance_note"`
 }
 
 // UserRunner represents the a GitLab runner instance created using the user-based flow
@@ -1432,19 +1433,9 @@ type CreateUserRunnerOptions struct {
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/users.html#create-a-runner
 type UserRunner struct {
-	ID             int      `json:"id"`
-	Token          string   `json:"token"`
-	TokenExpiresAt string   `json:"token_expires_at"`
-	RunnerType     string   `json:"runner_type"`
-	GroupID        int      `json:"group_id"`
-	ProjectID      int      `json:"project_id"`
-	Description    string   `json:"description"`
-	Paused         bool     `json:"paused"`
-	Locked         bool     `json:"locked"`
-	RunUntagged    bool     `json:"run_untagged"`
-	TagList        []string `json:"tag_list"`
-	AccessLevel    string   `json:"access_level"`
-	MaximumTimeout int      `json:"maximum_timeout"`
+	ID             int    `json:"id"`
+	Token          string `json:"token"`
+	TokenExpiresAt string `json:"token_expires_at"`
 }
 
 // CreateUserRunner creates a new runner using the user-based flow and returns the authentication

--- a/users.go
+++ b/users.go
@@ -1409,51 +1409,46 @@ func (s *UsersService) DisableTwoFactor(user int, options ...RequestOptionFunc) 
 	}
 }
 
-// CreateUserRunnerOptions represents the options available when creating a GitLab Runner
-// using the new user-based flow.
-//
-// GitLab API docs:
-// https://docs.gitlab.com/ee/api/users.html#create-a-runner
-type CreateUserRunnerOptions struct {
-	RunnerType      string   `json:"runner_type"`
-	GroupID         int      `json:"group_id"`
-	ProjectID       int      `json:"project_id"`
-	Description     string   `json:"description"`
-	Paused          bool     `json:"paused"`
-	Locked          bool     `json:"locked"`
-	RunUntagged     bool     `json:"run_untagged"`
-	TagList         []string `json:"tag_list"`
-	AccessLevel     string   `json:"access_level"`
-	MaximumTimeout  int      `json:"maximum_timeout"`
-	MaintenanceNote string   `json:"maintenance_note"`
-}
-
-// UserRunner represents the a GitLab runner instance created using the user-based flow
+// UserRunner represents a GitLab runner linked to the current user.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/users.html#create-a-runner
 type UserRunner struct {
-	ID             int    `json:"id"`
-	Token          string `json:"token"`
-	TokenExpiresAt string `json:"token_expires_at"`
+	ID             int        `json:"id"`
+	Token          string     `json:"token"`
+	TokenExpiresAt *time.Time `json:"token_expires_at"`
 }
 
-// CreateUserRunner creates a new runner using the user-based flow and returns the authentication
-// token.
+// CreateUserRunnerOptions represents the available CreateUserRunner() options.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/users.html#create-a-runner
-func (s *UsersService) CreateUserRunner(runnerOpts *CreateUserRunnerOptions, options ...RequestOptionFunc) (*UserRunner, *Response, error) {
-	// The user who owns the runner comes from the access token used to authorize the request.
-	u := "user/runners"
+type CreateUserRunnerOptions struct {
+	RunnerType      *string   `url:"runner_type,omitempty" json:"runner_type,omitempty"`
+	GroupID         *int      `url:"group_id,omitempty" json:"group_id,omitempty"`
+	ProjectID       *int      `url:"project_id,omitempty" json:"project_id,omitempty"`
+	Description     *string   `url:"description,omitempty" json:"description,omitempty"`
+	Paused          *bool     `url:"paused,omitempty" json:"paused,omitempty"`
+	Locked          *bool     `url:"locked,omitempty" json:"locked,omitempty"`
+	RunUntagged     *bool     `url:"run_untagged,omitempty" json:"run_untagged,omitempty"`
+	TagList         *[]string `url:"tag_list,omitempty" json:"tag_list,omitempty"`
+	AccessLevel     *string   `url:"access_level,omitempty" json:"access_level,omitempty"`
+	MaximumTimeout  *int      `url:"maximum_timeout,omitempty" json:"maximum_timeout,omitempty"`
+	MaintenanceNote *string   `url:"maintenance_note,omitempty" json:"maintenance_note,omitempty"`
+}
 
-	req, err := s.client.NewRequest(http.MethodPost, u, runnerOpts, options)
+// CreateUserRunner creates a runner linked to the current user.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/users.html#create-a-runner
+func (s *UsersService) CreateUserRunner(opts *CreateUserRunnerOptions, options ...RequestOptionFunc) (*UserRunner, *Response, error) {
+	req, err := s.client.NewRequest(http.MethodPost, "user/runners", opts, options)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	var r *UserRunner
-	resp, err := s.client.Do(req, &r)
+	r := new(UserRunner)
+	resp, err := s.client.Do(req, r)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/users.go
+++ b/users.go
@@ -1447,10 +1447,11 @@ type UserRunner struct {
 	MaximumTimeout int      `json:"maximum_timeout"`
 }
 
-// GetUserMemberships retrieves a list of the user's memberships.
+// CreateUserRunner creates a new runner using the user-based flow and returns the authentication
+// token.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/users.html#user-memberships
+// https://docs.gitlab.com/ee/api/users.html#create-a-runner
 func (s *UsersService) CreateUserRunner(runnerOpts *CreateUserRunnerOptions, options ...RequestOptionFunc) (*UserRunner, *Response, error) {
 	// The user who owns the runner comes from the access token used to authorize the request.
 	u := "user/runners"

--- a/users.go
+++ b/users.go
@@ -1408,3 +1408,63 @@ func (s *UsersService) DisableTwoFactor(user int, options ...RequestOptionFunc) 
 		return fmt.Errorf("Received unexpected result code: %d", resp.StatusCode)
 	}
 }
+
+// CreateUserRunnerOptions represents the options available when creating a GitLab Runner
+// using the new user-based flow.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/users.html#create-a-runner
+type CreateUserRunnerOptions struct {
+	RunnerType     string   `json:"runner_type"`
+	GroupID        int      `json:"group_id"`
+	ProjectID      int      `json:"project_id"`
+	Description    string   `json:"description"`
+	Paused         bool     `json:"paused"`
+	Locked         bool     `json:"locked"`
+	RunUntagged    bool     `json:"run_untagged"`
+	TagList        []string `json:"tag_list"`
+	AccessLevel    string   `json:"access_level"`
+	MaximumTimeout int      `json:"maximum_timeout"`
+}
+
+// UserRunner represents the a GitLab runner instance created using the user-based flow
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/users.html#create-a-runner
+type UserRunner struct {
+	ID             int      `json:"id"`
+	Token          string   `json:"token"`
+	TokenExpiresAt string   `json:"token_expires_at"`
+	RunnerType     string   `json:"runner_type"`
+	GroupID        int      `json:"group_id"`
+	ProjectID      int      `json:"project_id"`
+	Description    string   `json:"description"`
+	Paused         bool     `json:"paused"`
+	Locked         bool     `json:"locked"`
+	RunUntagged    bool     `json:"run_untagged"`
+	TagList        []string `json:"tag_list"`
+	AccessLevel    string   `json:"access_level"`
+	MaximumTimeout int      `json:"maximum_timeout"`
+}
+
+// GetUserMemberships retrieves a list of the user's memberships.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/users.html#user-memberships
+func (s *UsersService) CreateUserRunner(runnerOpts *CreateUserRunnerOptions, options ...RequestOptionFunc) (*UserRunner, *Response, error) {
+	// The user who owns the runner comes from the access token used to authorize the request.
+	u := "user/runners"
+
+	req, err := s.client.NewRequest(http.MethodPost, u, runnerOpts, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var r *UserRunner
+	resp, err := s.client.Do(req, &r)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return r, resp, nil
+}

--- a/users_test.go
+++ b/users_test.go
@@ -653,3 +653,26 @@ func TestDisableUser2FA(t *testing.T) {
 		t.Errorf("Users.DisableTwoFactor returned error: %v", err)
 	}
 }
+
+func TestCreateUserRunner(t *testing.T) {
+	mux, client := setup(t)
+
+	path := fmt.Sprintf("/%suser/runners", apiVersionPath)
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte(`{"id": 1234, "runner_type": "project_type"}`))
+	})
+
+	createRunnerOpts := &CreateUserRunnerOptions{
+		RunnerType: "project_type",
+		ProjectID:  1,
+	}
+
+	response, _, err := client.Users.CreateUserRunner(createRunnerOpts)
+	if err != nil {
+		t.Errorf("Users.CreateUserRunner returned an error: %v", err)
+	}
+
+	require.Equal(t, "project_type", response.RunnerType)
+}

--- a/users_test.go
+++ b/users_test.go
@@ -661,7 +661,7 @@ func TestCreateUserRunner(t *testing.T) {
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
 		w.WriteHeader(http.StatusCreated)
-		w.Write([]byte(`{"id": 1234, "runner_type": "project_type"}`))
+		w.Write([]byte(`{"id": 1234, "token": "glrt-1234567890ABCD", "token_expires_at":null}`))
 	})
 
 	createRunnerOpts := &CreateUserRunnerOptions{
@@ -674,5 +674,7 @@ func TestCreateUserRunner(t *testing.T) {
 		t.Errorf("Users.CreateUserRunner returned an error: %v", err)
 	}
 
-	require.Equal(t, "project_type", response.RunnerType)
+	require.Equal(t, 1234, response.ID)
+	require.Equal(t, "glrt-1234567890ABCD", response.Token)
+	require.Equal(t, "", response.TokenExpiresAt)
 }

--- a/users_test.go
+++ b/users_test.go
@@ -616,8 +616,7 @@ func TestGetSingleSSHKeyForUser(t *testing.T) {
 			"title": "Public key",
 			"key": "ssh-rsa AAAA...",
 			"created_at": "2014-08-01T14:47:39.080Z"
-		  }
-`)
+		}`)
 	})
 
 	sshKey, _, err := client.Users.GetSSHKeyForUser(1, 1)
@@ -661,12 +660,17 @@ func TestCreateUserRunner(t *testing.T) {
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
 		w.WriteHeader(http.StatusCreated)
-		w.Write([]byte(`{"id": 1234, "token": "glrt-1234567890ABCD", "token_expires_at":null}`))
+		w.Write([]byte(`
+    {
+      "id": 1234,
+      "token": "glrt-1234567890ABCD",
+      "token_expires_at":null
+    }`))
 	})
 
 	createRunnerOpts := &CreateUserRunnerOptions{
-		RunnerType: "project_type",
-		ProjectID:  1,
+		ProjectID:  Int(1),
+		RunnerType: String("project_type"),
 	}
 
 	response, _, err := client.Users.CreateUserRunner(createRunnerOpts)
@@ -676,5 +680,5 @@ func TestCreateUserRunner(t *testing.T) {
 
 	require.Equal(t, 1234, response.ID)
 	require.Equal(t, "glrt-1234567890ABCD", response.Token)
-	require.Equal(t, "", response.TokenExpiresAt)
+	require.Equal(t, (*time.Time)(nil), response.TokenExpiresAt)
 }


### PR DESCRIPTION
This MR adds support for the new user-based Gitlab Runner API, documented here: https://docs.gitlab.com/ee/api/users.html#create-a-runner

It's worth noting that it's in the `users.go` file even though it's creating a runner, because it's in the `/user` api space. I could be convinced to move it to the `runners.go` file pretty easily, but figured the default stance was to align to the upstream API space.

It's also worth noting that there is no `/users/runner` DELETE api, because it uses the existing APIs within `runners.go` to delete by ID.

Let me know if you have any questions! I'd appreciate cutting a new version after merging this MR so that I can start working on the tf provider resource :)