### PR TITLE
Add last used at to impersonation token

### DIFF
--- a/users.go
+++ b/users.go
@@ -1159,14 +1159,15 @@ func (s *UsersService) RejectUser(user int, options ...RequestOptionFunc) error 
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/users.html#get-all-impersonation-tokens-of-a-user
 type ImpersonationToken struct {
-	ID        int        `json:"id"`
-	Name      string     `json:"name"`
-	Active    bool       `json:"active"`
-	Token     string     `json:"token"`
-	Scopes    []string   `json:"scopes"`
-	Revoked   bool       `json:"revoked"`
-	CreatedAt *time.Time `json:"created_at"`
-	ExpiresAt *ISOTime   `json:"expires_at"`
+	ID         int        `json:"id"`
+	Name       string     `json:"name"`
+	Active     bool       `json:"active"`
+	Token      string     `json:"token"`
+	Scopes     []string   `json:"scopes"`
+	Revoked    bool       `json:"revoked"`
+	CreatedAt  *time.Time `json:"created_at"`
+	ExpiresAt  *ISOTime   `json:"expires_at"`
+	LastUsedAt *time.Time `json:"last_used_at"`
 }
 
 // GetAllImpersonationTokensOptions represents the available


### PR DESCRIPTION
Gitlab has the not documented field in the response of the [impersonation token api](https://docs.gitlab.com/ee/api/users.html#get-all-impersonation-tokens-of-a-user) 

I added this property to the ImpersonationToken struct.

Example for API response for impersonation token
```[{
    "id": 244,
    "name": "VSBOT_IT_PS1",
    "revoked": false,
    "created_at": "2023-07-13T15:55:45.728+02:00",
    "scopes": [
      "api",
      "admin_mode"
    ],
    "user_id": 51,
    "last_used_at": "2023-08-10T05:40:46.999+02:00",
    "active": true,
    "expires_at": "2024-07-12",
    "impersonation": true
  }]
```

P.s.: I found no tests for this struct, so I was unsure how to add tests without bloating the test harness.