### PR TITLE
Add snippet endpoint to get all snippets available to the user

### DIFF
--- a/snippets.go
+++ b/snippets.go
@@ -289,9 +289,9 @@ func (s *SnippetsService) ExploreSnippets(opt *ExploreSnippetsOptions, options .
 // https://docs.gitlab.com/ee/api/snippets.html#list-all-snippets
 type ListAllSnippetsOptions struct {
 	ListOptions
-	CreatedAfter      *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
-	CreatedBefore     *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
-	RepositoryStorage *string    `url:"repository_storage,omitempty" json:"repository_storage,omitempty"`
+	CreatedAfter      *ISOTime `url:"created_after,omitempty" json:"created_after,omitempty"`
+	CreatedBefore     *ISOTime `url:"created_before,omitempty" json:"created_before,omitempty"`
+	RepositoryStorage *string  `url:"repository_storage,omitempty" json:"repository_storage,omitempty"`
 }
 
 // ListAllSnippets gets all snippets the current user has access to.

--- a/snippets.go
+++ b/snippets.go
@@ -57,6 +57,7 @@ type Snippet struct {
 		Path   string `json:"path"`
 		RawURL string `json:"raw_url"`
 	} `json:"files"`
+	RepositoryStorage string `json:"repository_storage"`
 }
 
 func (s Snippet) String() string {
@@ -288,8 +289,9 @@ func (s *SnippetsService) ExploreSnippets(opt *ExploreSnippetsOptions, options .
 // https://docs.gitlab.com/ee/api/snippets.html#list-all-snippets
 type ListAllSnippetsOptions struct {
 	ListOptions
-	CreatedAfter  *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
-	CreatedBefore *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
+	CreatedAfter      *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
+	CreatedBefore     *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
+	RepositoryStorage *string    `url:"repository_storage,omitempty" json:"repository_storage,omitempty"`
 }
 
 // ListAllSnippets gets all snippets the current user has access to.

--- a/snippets.go
+++ b/snippets.go
@@ -281,3 +281,32 @@ func (s *SnippetsService) ExploreSnippets(opt *ExploreSnippetsOptions, options .
 
 	return ps, resp, nil
 }
+
+// ListAllSnippetsOptions represents the available ListAllSnippets() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/snippets.html#list-all-snippets
+type ListAllSnippetsOptions struct {
+	ListOptions
+	CreatedAfter  *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
+	CreatedBefore *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
+}
+
+// ListAllSnippets gets all snippets the current user has access to.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/snippets.html#list-all-snippets
+func (s *SnippetsService) ListAllSnippets(opt *ListAllSnippetsOptions, options ...RequestOptionFunc) ([]*Snippet, *Response, error) {
+	req, err := s.client.NewRequest(http.MethodGet, "snippets/all", opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var ps []*Snippet
+	resp, err := s.client.Do(req, &ps)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return ps, resp, nil
+}

--- a/snippets_test.go
+++ b/snippets_test.go
@@ -129,3 +129,20 @@ func TestSnippetsService_ExploreSnippets(t *testing.T) {
 	want := []*Snippet{{ID: 42, Title: "test"}}
 	require.Equal(t, want, ss)
 }
+
+func TestSnippetsService_ListAllSnippets(t *testing.T) {
+	mux, client := setup(t)
+
+	mux.HandleFunc("/api/v4/snippets/all", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, `[{"id":113,"title":"Internal Snippet"}, {"id":114,"title":"Private Snippet"}]`)
+	})
+
+	opt := &ListAllSnippetsOptions{ListOptions: ListOptions{Page: 1, PerPage: 10}}
+
+	ss, _, err := client.Snippets.ListAllSnippets(opt)
+	require.NoError(t, err)
+
+	want := []*Snippet{{ID: 113, Title: "Internal Snippet"}, {ID: 114, Title: "Private Snippet"}}
+	require.Equal(t, want, ss)
+}


### PR DESCRIPTION
Add endpoint to get all snippets available to the user. 

Docs: https://docs.gitlab.com/ee/api/snippets.html#list-all-snippets
MR: https://gitlab.com/gitlab-org/gitlab/-/merge_requests/127696
