### PR TITLE
feature: add support for getting and patching project CI/CD job token

### DIFF
--- a/job_token_scope.go
+++ b/job_token_scope.go
@@ -26,6 +26,67 @@ type JobTokenScopeService struct {
 	client *Client
 }
 
+// JobTokenAccessSettings represents job token access attributes for this project.
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/project_job_token_scopes.html
+type JobTokenAccessSettings struct {
+	InboundEnabled  bool `json:"inbound_enabled"`
+	OutboundEnabled bool `json:"outbound_enabled"`
+}
+
+// GetProjectJobTokenAccessSettings fetch the CI/CD job token access settings (job token scope) of a project.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/project_job_token_scopes.html#get-a-projects-cicd-job-token-access-settings
+func (j *JobTokenScopeService) GetProjectJobTokenAccessSettings(pid interface{}, options ...RequestOptionFunc) (*JobTokenAccessSettings, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf(`projects/%s/job_token_scope`, PathEscape(project))
+
+	req, err := j.client.NewRequest(http.MethodGet, u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var settings *JobTokenAccessSettings
+	resp, err := j.client.Do(req, &settings)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return settings, resp, err
+}
+
+// PatchProjectJobTokenAccessSettingsOptions represents the available
+// PatchProjectJobTokenAccessSettings() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/project_job_token_scopes.html#patch-a-projects-cicd-job-token-access-settings
+type PatchProjectJobTokenAccessSettingsOptions struct {
+	Enabled bool `json:"enabled"`
+}
+
+// PatchProjectJobTokenAccessSettings patch the Limit access to this project setting (job token scope) of a project.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/project_job_token_scopes.html#patch-a-projects-cicd-job-token-access-settings
+func (j *JobTokenScopeService) PatchProjectJobTokenAccessSettings(pid interface{}, opt *PatchProjectJobTokenAccessSettingsOptions, options ...RequestOptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf(`projects/%s/job_token_scope`, PathEscape(project))
+
+	req, err := j.client.NewRequest(http.MethodPatch, u, opt, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return j.client.Do(req, nil)
+}
+
 // JobTokenInboundAllowItem represents a single job token inbound allowlist item.
 //
 // GitLab API docs: https://docs.gitlab.com/ee/api/project_job_token_scopes.html

--- a/job_token_scope.go
+++ b/job_token_scope.go
@@ -50,13 +50,13 @@ func (j *JobTokenScopeService) GetProjectJobTokenAccessSettings(pid interface{},
 		return nil, nil, err
 	}
 
-	var settings *JobTokenAccessSettings
-	resp, err := j.client.Do(req, &settings)
+	jt := new(JobTokenAccessSettings)
+	resp, err := j.client.Do(req, jt)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return settings, resp, err
+	return jt, resp, err
 }
 
 // PatchProjectJobTokenAccessSettingsOptions represents the available
@@ -156,13 +156,13 @@ func (j *JobTokenScopeService) AddProjectToJobScopeAllowList(pid interface{}, op
 		return nil, nil, err
 	}
 
-	ai := new(JobTokenInboundAllowItem)
-	resp, err := j.client.Do(req, ai)
+	jt := new(JobTokenInboundAllowItem)
+	resp, err := j.client.Do(req, jt)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return ai, resp, nil
+	return jt, resp, nil
 }
 
 // RemoveProjectFromJobScopeAllowList removes a project from a project's job


### PR DESCRIPTION
Add support for getting and patching project CI/CD job token

Gitlab document: https://docs.gitlab.com/ee/api/project_job_token_scopes.html