### PR TITLE
Add Draft Changes in MergeEvent type

### DIFF
--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -679,6 +679,10 @@ type MergeEvent struct {
 			Previous string `json:"previous"`
 			Current  string `json:"current"`
 		} `json:"description"`
+		Draft struct {
+			Previous bool `json:"previous"`
+			Current  bool `json:"current"`
+		} `json:"draft"`
 		Labels struct {
 			Previous []*EventLabel `json:"previous"`
 			Current  []*EventLabel `json:"current"`


### PR DESCRIPTION
MergeEvent.Changes type for Webhook types was missing the Draft attribute, which is present when a Merge Request is set to "Ready for review" when it was previously in "Draft" (e.g. when MergeEvent.ObjectAttributes.Draft goes from true to false).

An ugly workaround for detecting such change within the MergeEvent type itself (if no previous event was stored and can be compared to) is to check the Changes.Title and see if Previous started with "Draft:" and Current does not.