### PR TITLE
Add Draft boolean attribute to MergeType.ObjectAttributes

### DIFF
--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -618,7 +618,6 @@ type MergeEvent struct {
 		MilestoneID              int          `json:"milestone_id"`
 		StateID                  StateID      `json:"state_id"`
 		State                    string       `json:"state"`
-		Draft                    bool         `json:"draft"`
 		MergeStatus              string       `json:"merge_status"`
 		TargetProjectID          int          `json:"target_project_id"`
 		IID                      int          `json:"iid"`
@@ -653,6 +652,7 @@ type MergeEvent struct {
 		} `json:"last_commit"`
 		BlockingDiscussionsResolved bool          `json:"blocking_discussions_resolved"`
 		WorkInProgress              bool          `json:"work_in_progress"`
+		Draft                       bool          `json:"draft"`
 		TotalTimeSpent              int           `json:"total_time_spent"`
 		TimeChange                  int           `json:"time_change"`
 		HumanTotalTimeSpent         string        `json:"human_total_time_spent"`

--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -618,6 +618,7 @@ type MergeEvent struct {
 		MilestoneID              int          `json:"milestone_id"`
 		StateID                  StateID      `json:"state_id"`
 		State                    string       `json:"state"`
+		Draft                    bool         `json:"draft"`
 		MergeStatus              string       `json:"merge_status"`
 		TargetProjectID          int          `json:"target_project_id"`
 		IID                      int          `json:"iid"`


### PR DESCRIPTION
Earlier today I added the Draft attribute to the Changes of a MergeEvent webhook type. I also saw this attribute is not present in the ObjectAttributes itself.

So this is a small correction of that (should've added it to the earlier PR but I didn't notice ;) ).