### PR TITLE
Add group access token rotation and project access token rotation.

### DIFF
--- a/group_access_tokens.go
+++ b/group_access_tokens.go
@@ -145,6 +145,30 @@ func (s *GroupAccessTokensService) CreateGroupAccessToken(gid interface{}, opt *
 	return pat, resp, nil
 }
 
+// RotateGroupAccessToken revokes a group access token and returns a new group
+// access token that expires in one week.
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/group_access_tokens.html#rotate-a-group-access-token
+func (s *GroupAccessTokensService) RotateGroupAccessToken(gid interface{}, id int, options ...RequestOptionFunc) (*GroupAccessToken, *Response, error) {
+	groups, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/access_tokens/%d/rotate", PathEscape(groups), id)
+	req, err := s.client.NewRequest(http.MethodPost, u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	gat := new(GroupAccessToken)
+	resp, err := s.client.Do(req, gat)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return gat, resp, nil
+}
+
 // RevokeGroupAccessToken revokes a group access token.
 //
 // GitLab API docs:

--- a/project_access_tokens.go
+++ b/project_access_tokens.go
@@ -146,6 +146,30 @@ func (s *ProjectAccessTokensService) CreateProjectAccessToken(pid interface{}, o
 	return pat, resp, nil
 }
 
+// RotateProjectAccessToken revokes a project access token and returns a new
+// project access token that expires in one week.
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/project_access_tokens.html#rotate-a-project-access-token
+func (s *ProjectAccessTokensService) RotateProjectAccessToken(pid interface{}, id int, options ...RequestOptionFunc) (*ProjectAccessToken, *Response, error) {
+	projects, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/access_tokens/%d/rotate", PathEscape(projects), id)
+	req, err := s.client.NewRequest(http.MethodPost, u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pat := new(ProjectAccessToken)
+	resp, err := s.client.Do(req, pat)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return pat, resp, nil
+}
+
 // RevokeProjectAccessToken revokes a project access token.
 //
 // GitLab API docs:


### PR DESCRIPTION
Project access token rotation and group access token rotation were introduced in GitLab 16.0.

References
[Rotate a group access token](https://docs.gitlab.com/ee/api/group_access_tokens.html#rotate-a-group-access-token)
[Rotate a project access token](https://docs.gitlab.com/ee/api/project_access_tokens.html#rotate-a-project-access-token)