### PR TITLE
Add repositories archive path support

### DIFF
--- a/examples/repository_archive.go
+++ b/examples/repository_archive.go
@@ -40,5 +40,5 @@ func repositoryArchiveExample() {
 		log.Fatal(err)
 	}
 
-	log.Printf("File contains %d byte(s)", content)
+	log.Printf("Repository archive contains %d byte(s)", len(content))
 }

--- a/examples/repository_archive.go
+++ b/examples/repository_archive.go
@@ -1,0 +1,44 @@
+//
+// Copyright 2021, Sander van Harmelen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package main
+
+import (
+	"log"
+
+	"github.com/xanzy/go-gitlab"
+)
+
+func repositoryArchiveExample() {
+	git, err := gitlab.NewClient("yourtokengoeshere")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Get repository archive
+	opt := &gitlab.ArchiveOptions{
+		Format: gitlab.String("tar.gz"),
+		// Gitlab API supports archiving first level directories at the moment, e.g. "mygroup/myproject/mydir".
+		// If you pass 2+ level directory in path, whole repository will be archived and downloaded.
+		Path: gitlab.String("mydir"),
+	}
+	content, _, err := git.Repositories.Archive("mygroup/myproject", opt, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Printf("File contains %d byte(s)", content)
+}

--- a/repositories.go
+++ b/repositories.go
@@ -140,6 +140,7 @@ func (s *RepositoriesService) RawBlobContent(pid interface{}, sha string, option
 // https://docs.gitlab.com/ee/api/repositories.html#get-file-archive
 type ArchiveOptions struct {
 	Format *string `url:"-" json:"-"`
+	Path   *string `url:"path,omitempty" json:"path,omitempty"`
 	SHA    *string `url:"sha,omitempty" json:"sha,omitempty"`
 }
 


### PR DESCRIPTION
According to [Gitlab Repositories API](https://docs.gitlab.com/ee/api/repositories.html#get-file-archive) it is possible to set subpath of the repository to download (optional `path` field).

> The subpath of the repository to download. If an empty string, defaults to the whole repository.

This PR adds `path` field to Repositories Archive request options.
