### PR TITLE
Add method to list projects a user has contributed to

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -390,6 +390,31 @@ func (s *ProjectsService) ListUserProjects(uid interface{}, opt *ListProjectsOpt
 	return p, resp, nil
 }
 
+// ListUserProjects gets a list of visible projects a given user has contributed to.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/projects.html#list-projects-a-user-has-contributed-to
+func (s *ProjectsService) ListUserContributedProjects(uid interface{}, opt *ListProjectsOptions, options ...RequestOptionFunc) ([]*Project, *Response, error) {
+	user, err := parseID(uid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("users/%s/contributed_projects", user)
+
+	req, err := s.client.NewRequest(http.MethodGet, u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var p []*Project
+	resp, err := s.client.Do(req, &p)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return p, resp, nil
+}
+
 // ListUserStarredProjects gets a list of projects starred by the given user.
 //
 // GitLab API docs:

--- a/projects_test.go
+++ b/projects_test.go
@@ -88,6 +88,35 @@ func TestListUserProjects(t *testing.T) {
 	}
 }
 
+func TestListUserContributedProjects(t *testing.T) {
+	mux, client := setup(t)
+
+	mux.HandleFunc("/api/v4/users/1/contributed_projects", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, `[{"id":1},{"id":2}]`)
+	})
+
+	opt := &ListProjectsOptions{
+		ListOptions: ListOptions{2, 3},
+		Archived:    Bool(true),
+		OrderBy:     String("name"),
+		Sort:        String("asc"),
+		Search:      String("query"),
+		Simple:      Bool(true),
+		Visibility:  Visibility(PublicVisibility),
+	}
+
+	projects, _, err := client.Projects.ListUserContributedProjects(1, opt)
+	if err != nil {
+		t.Errorf("Projects.ListUserContributedProjects returned error: %v", err)
+	}
+
+	want := []*Project{{ID: 1}, {ID: 2}}
+	if !reflect.DeepEqual(want, projects) {
+		t.Errorf("Projects.ListUserContributedProjects returned %+v, want %+v", projects, want)
+	}
+}
+
 func TestListUserStarredProjects(t *testing.T) {
 	mux, client := setup(t)
 


### PR DESCRIPTION
This PR adds a method to the Projects client to allow calling the `contributed_projects` endpoint: https://docs.gitlab.com/ee/api/projects.html#list-projects-a-user-has-contributed-to

This enables users of this library to fetch all projects that a user has contributed to