### PR TITLE
Add report_type to CreateProjectLevelRuleOptions

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -1809,6 +1809,7 @@ func (s *ProjectsService) GetProjectApprovalRule(pid interface{}, ruleID int, op
 type CreateProjectLevelRuleOptions struct {
 	Name                          *string `url:"name,omitempty" json:"name,omitempty"`
 	ApprovalsRequired             *int    `url:"approvals_required,omitempty" json:"approvals_required,omitempty"`
+	ReportType                    *string `url:"report_type,omitempty" json:"report_type,omitempty"`
 	RuleType                      *string `url:"rule_type,omitempty" json:"rule_type,omitempty"`
 	UserIDs                       *[]int  `url:"user_ids,omitempty" json:"user_ids,omitempty"`
 	GroupIDs                      *[]int  `url:"group_ids,omitempty" json:"group_ids,omitempty"`

--- a/projects_test.go
+++ b/projects_test.go
@@ -1194,6 +1194,7 @@ func TestCreateProjectApprovalRule(t *testing.T) {
 		ApprovalsRequired: Int(3),
 		UserIDs:           &[]int{5, 50},
 		GroupIDs:          &[]int{5},
+		ReportType:        String("code_coverage"),
 	}
 
 	rule, _, err := client.Projects.CreateProjectApprovalRule(1, opt)


### PR DESCRIPTION
This PR adds a missing `report_type` to `CreateProjectLevelRuleOptions`.

GitLab API docs: https://docs.gitlab.com/ee/api/merge_request_approvals.html#create-project-level-rule
