### PR TITLE
Add pipeline ID to commit status

### DIFF
--- a/commits.go
+++ b/commits.go
@@ -402,6 +402,7 @@ type CommitStatus struct {
 	Name         string     `json:"name"`
 	AllowFailure bool       `json:"allow_failure"`
 	Coverage     float64    `json:"coverage"`
+	PipelineId   int        `json:"pipeline_id"`
 	Author       Author     `json:"author"`
 	Description  string     `json:"description"`
 	TargetURL    string     `json:"target_url"`


### PR DESCRIPTION
Latest GitLab release added Pipeline ID to the list commit status API. Although GitLab's documentation wasn't updated yet, this [merge request](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/127559) added the new field.