### PR TITLE
Add Author to ListCommitsOptions

### DIFF
--- a/commits.go
+++ b/commits.go
@@ -77,6 +77,7 @@ type ListCommitsOptions struct {
 	Since       *time.Time `url:"since,omitempty" json:"since,omitempty"`
 	Until       *time.Time `url:"until,omitempty" json:"until,omitempty"`
 	Path        *string    `url:"path,omitempty" json:"path,omitempty"`
+	Author      *string    `url:"author,omitempty" json:"author,omitempty"`
 	All         *bool      `url:"all,omitempty" json:"all,omitempty"`
 	WithStats   *bool      `url:"with_stats,omitempty" json:"with_stats,omitempty"`
 	FirstParent *bool      `url:"first_parent,omitempty" json:"first_parent,omitempty"`


### PR DESCRIPTION
GitLab added search by author for GET /projects/:id/repository/commits in GitLab 15.10.

MR: https://gitlab.com/gitlab-org/gitlab/-/merge_requests/114417
Relevant GitLab API docs: https://docs.gitlab.com/ee/api/commits.html#list-repository-commits