### PR TITLE
Support `shared_runners_setting` in Group response

### DIFF
--- a/groups.go
+++ b/groups.go
@@ -68,7 +68,7 @@ type Group struct {
 	MentionsDisabled        bool                       `json:"mentions_disabled"`
 	RunnersToken            string                     `json:"runners_token"`
 	SharedProjects          []*Project                 `json:"shared_projects"`
-	SharedRunnersEnabled    bool                       `json:"shared_runners_enabled"`
+	SharedRunnersSetting    SharedRunnersSettingValue  `json:"shared_runners_setting"`
 	SharedWithGroups        []struct {
 		GroupID          int      `json:"group_id"`
 		GroupName        string   `json:"group_name"`

--- a/types.go
+++ b/types.go
@@ -607,8 +607,11 @@ type SharedRunnersSettingValue string
 // https://docs.gitlab.com/ee/api/groups.html#options-for-shared_runners_setting
 const (
 	EnabledSharedRunnersSettingValue                  SharedRunnersSettingValue = "enabled"
-	DisabledWithOverrideSharedRunnersSettingValue     SharedRunnersSettingValue = "disabled_with_override"
+	DisabledAndOverridableSharedRunnersSettingValue   SharedRunnersSettingValue = "disabled_and_overridable"
 	DisabledAndUnoverridableSharedRunnersSettingValue SharedRunnersSettingValue = "disabled_and_unoverridable"
+
+	// Deprecated: DisabledWithOverrideSharedRunnersSettingValue is deprecated in favor of DisabledAndOverridableSharedRunnersSettingValue
+	DisabledWithOverrideSharedRunnersSettingValue SharedRunnersSettingValue = "disabled_with_override"
 )
 
 // SharedRunnersSetting is a helper routine that allocates a new SharedRunnersSettingValue


### PR DESCRIPTION
Add `shared_runners_setting` in Group response, and removed `shared_runners_enabled` because it was not included in the response. (`shared_runners_enabled` is returned in the Project resources, not Group.)

I confirmed with the `curl` response and had a look at the gitlab source code as well. In addition, I created a MR to add `shared_runners_setting` to the API doc: https://gitlab.com/gitlab-org/gitlab/-/merge_requests/132831

Ref:
- API doc: https://docs.gitlab.com/ee/api/groups.html
- [Options for shared_runners_setting](https://docs.gitlab.com/ee/api/groups.html#options-for-shared_runners_setting)
