### PR TITLE
Add ObjectAttributes.Name to PipelineEvent

### DIFF
--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -794,6 +794,7 @@ type PipelineEvent struct {
 	ObjectAttributes struct {
 		ID             int      `json:"id"`
 		IID            int      `json:"iid"`
+		Name           string   `json:"name"`
 		Ref            string   `json:"ref"`
 		Tag            bool     `json:"tag"`
 		SHA            string   `json:"sha"`


### PR DESCRIPTION
Quoting the documentation [here](https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#pipeline-events):

"
In [GitLab 16.1](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/123639) and later, pipeline webhooks started to expose object_attributes.name.
"

For anyone using a previous version, the unmarshaling of the event payload will just leave ObjectAttributes.Name with an empty string value (""). While for applications connecting to gitlab.com or a hosted version of gitlab with version 16.1 or later will be able to use this field.