### PR TITLE
fix: correction in rest end point path

### DIFF
--- a/merge_requests.go
+++ b/merge_requests.go
@@ -510,7 +510,7 @@ func (s *MergeRequestsService) ListMergeRequesDiffs(pid interface{}, mergeReques
 		return nil, nil, err
 	}
 
-	u := fmt.Sprintf("/projects/%s/merge_requests/%d/diffs", PathEscape(project), mergeRequest)
+	u := fmt.Sprintf("projects/%s/merge_requests/%d/diffs", PathEscape(project), mergeRequest)
 
 	req, err := s.client.NewRequest(http.MethodGet, u, opt, options)
 	if err != nil {


### PR DESCRIPTION
library adds `/` at the beginning of the path by default, no need to add it manually