### PR TITLE
Add coverage to README

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -6,7 +6,7 @@ on:
     branches: [master]
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   lint_and_test:
@@ -34,3 +34,14 @@ jobs:
         run: |
           go test -v ./... -coverprofile=coverage.txt -covermode count
           go tool cover -func coverage.txt
+
+      - name: Update coverage report
+        uses: ncruces/go-coverage-report@v0.2.3
+        with:
+          report: 'true'
+          amend: 'true'
+          reuse-go: 'true'
+        if:
+          # Only run for the latest go version to avoid race conditions when updating the wiki 
+          github.event_name == 'push' && matrix.go-version == '1.20.x'
+        continue-on-error: true

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -5,9 +5,6 @@ on:
   push:
     branches: [master]
 
-permissions:
-  contents: write
-
 jobs:
   lint_and_test:
     name: Lint and Test - ${{ matrix.go-version }}
@@ -42,6 +39,6 @@ jobs:
           amend: 'true'
           reuse-go: 'true'
         if:
-          # Only run for the latest go version to avoid race conditions when updating the wiki 
+          # Only run for the latest Go version to avoid race conditions
           github.event_name == 'push' && matrix.go-version == '1.20.x'
         continue-on-error: true

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A GitLab API client enabling Go programs to interact with GitLab in a simple and
 [![Sourcegraph](https://sourcegraph.com/github.com/xanzy/go-gitlab/-/badge.svg)](https://sourcegraph.com/github.com/xanzy/go-gitlab?badge)
 [![GoDoc](https://godoc.org/github.com/xanzy/go-gitlab?status.svg)](https://godoc.org/github.com/xanzy/go-gitlab)
 [![Go Report Card](https://goreportcard.com/badge/github.com/xanzy/go-gitlab)](https://goreportcard.com/report/github.com/xanzy/go-gitlab)
+[![Coverage](https://github.com/xanzy/go-gitlab/wiki/coverage.svg)](https://raw.githack.com/wiki/xanzy/go-gitlab/coverage.html)
 
 ## NOTE
 


### PR DESCRIPTION
This PR adds a coverage job to the github actions and a coverage badge with a link to the coverage report to the README.
The coverage report is stored in the wiki of the project, for this action to work a wiki homepage must be created.