### PR TITLE
Make sure response is fully consumed

### DIFF
--- a/gitlab.go
+++ b/gitlab.go
@@ -813,6 +813,7 @@ func (c *Client) Do(req *retryablehttp.Request, v interface{}) (*Response, error
 		return c.Do(req, v)
 	}
 	defer resp.Body.Close()
+	defer io.Copy(io.Discard, resp.Body)
 
 	// If not yet configured, try to configure the rate limiter
 	// using the response headers we just received. Fail silently


### PR DESCRIPTION
This fully consumes a response body. I have learned through some other experiences that this is important to do in Go. This is especially useful if `nil` is provided as `v`, because then response body is just closed. But also when JSON decoder does not decode all data (and there is some extra bytes after the decoded JSON response) - JSON decoder does not necessary consume full input, just enough that `v` is decoded. Any errors returned by `io.Copy` are ignored on purpose.

See similar thing in go-github library: https://github.com/google/go-github/pull/317