### PR TITLE
Support CreatePersonalAccessTokenForCurrentUser endpoint

### DIFF
--- a/testdata/post_user_personal_access_tokens.json
+++ b/testdata/post_user_personal_access_tokens.json
@@ -1,0 +1,13 @@
+{
+  "id": 3,
+  "name": "mytoken",
+  "revoked": false,
+  "created_at": "2020-10-14T11:58:53.526Z",
+  "scopes": [
+    "k8s_proxy"
+  ],
+  "user_id": 42,
+  "active": true,
+  "expires_at": "2020-10-15",
+  "token": "glpat-aaaaaaaa-bbbbbbbbb"
+}

--- a/users.go
+++ b/users.go
@@ -1301,6 +1301,38 @@ func (s *UsersService) CreatePersonalAccessToken(user int, opt *CreatePersonalAc
 	return t, resp, nil
 }
 
+// CreatePersonalAccessTokenForCurrentUserOptions represents the available
+// CreatePersonalAccessTokenForCurrentUser() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/users.html#create-a-personal-access-token-with-limited-scopes-for-the-currently-authenticated-user
+type CreatePersonalAccessTokenForCurrentUserOptions struct {
+	Name      *string   `url:"name,omitempty" json:"name,omitempty"`
+	Scopes    *[]string `url:"scopes,omitempty" json:"scopes,omitempty"`
+	ExpiresAt *ISOTime  `url:"expires_at,omitempty" json:"expires_at,omitempty"`
+}
+
+// CreatePersonalAccessTokenForCurrentUser creates a personal access token with limited scopes for the currently authenticated user.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/users.html#create-a-personal-access-token-with-limited-scopes-for-the-currently-authenticated-user
+func (s *UsersService) CreatePersonalAccessTokenForCurrentUser(opt *CreatePersonalAccessTokenForCurrentUserOptions, options ...RequestOptionFunc) (*PersonalAccessToken, *Response, error) {
+	u := "user/personal_access_tokens"
+
+	req, err := s.client.NewRequest(http.MethodPost, u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	t := new(PersonalAccessToken)
+	resp, err := s.client.Do(req, &t)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return t, resp, nil
+}
+
 // UserActivity represents an entry in the user/activities response
 //
 // GitLab API docs:


### PR DESCRIPTION
Support new endpoint: https://docs.gitlab.com/ee/api/users.html#create-a-personal-access-token-with-limited-scopes-for-the-currently-authenticated-user
