### PR TITLE
Add summary support in AddSpentTimeOptions

### DIFF
--- a/issues_test.go
+++ b/issues_test.go
@@ -775,10 +775,12 @@ func TestAddSpentTime(t *testing.T) {
 	mux.HandleFunc("/api/v4/projects/1/issues/5/add_spent_time", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
 		testURL(t, r, "/api/v4/projects/1/issues/5/add_spent_time")
+		testBody(t, r, `{"duration":"1h","summary":"test"}`)
 		fmt.Fprint(w, `{"human_time_estimate": null, "human_total_time_spent": "1h", "time_estimate": 0, "total_time_spent": 3600}`)
 	})
 	addSpentTimeOpt := &AddSpentTimeOptions{
 		Duration: String("1h"),
+		Summary:  String("test"),
 	}
 
 	timeState, _, err := client.Issues.AddSpentTime("1", 5, addSpentTimeOpt)

--- a/time_stats.go
+++ b/time_stats.go
@@ -104,6 +104,7 @@ func (s *timeStatsService) resetTimeEstimate(pid interface{}, entity string, iss
 // GitLab docs: https://docs.gitlab.com/ee/workflow/time_tracking.html
 type AddSpentTimeOptions struct {
 	Duration *string `url:"duration,omitempty" json:"duration,omitempty"`
+	Summary  *string `url:"summary,omitempty" json:"summary,omitempty"`
 }
 
 // addSpentTime adds spent time for a single project issue.


### PR DESCRIPTION
# Goal

This PR is adding a `summary` field in the `AddSpentTimeOptions` structure.

This structure is used to call the add spent API endpoints for merge requests and issues. 

Today we can only pass the duration of the time spent when calling gitlab API, however the 2 endpoints also accept a `summary` optional field (see [merge request][1] and [issues][2]).

Adding this new field in the structure will allow users to set a specific `summary` value while calling gitlab API.

[1]: https://docs.gitlab.com/ee/api/merge_requests.html#add-spent-time-for-a-merge-request
[2]: https://docs.gitlab.com/ee/api/issues.html#add-spent-time-for-an-issue