### PR TITLE
fix LinePosition fields for multiline CreateMergeRequestDiscussion API call

### DIFF
--- a/notes.go
+++ b/notes.go
@@ -95,8 +95,8 @@ type LineRange struct {
 type LinePosition struct {
 	LineCode string `json:"line_code"`
 	Type     string `json:"type"`
-	OldLine  int    `json:"old_line"`
-	NewLine  int    `json:"new_line"`
+	OldLine  int    `json:"old_line,omitempty"`
+	NewLine  int    `json:"new_line,omitempty"`
 }
 
 func (n Note) String() string {


### PR DESCRIPTION
Hi,
I am trying to use this module to create multiline comments on merge request but API calls ends with error 
```
{message: 400 Bad request - Note {:position=>["must be a valid json schema"]}}
```
The problem is that `LinePosition` contains fields `OldLine` and `NewLine` which are not defined in [documentation](https://docs.gitlab.com/ee/api/discussions.html#parameters-for-multiline-comments) for merge request comments. I added `omitempty` so that it can be used while keeping backward compatibility.