### PR TITLE
Add keyset pagination options

### DIFF
--- a/gitlab_test.go
+++ b/gitlab_test.go
@@ -20,11 +20,13 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -234,5 +236,170 @@ func TestPathEscape(t *testing.T) {
 	got := PathEscape("diaspora/diaspora")
 	if want != got {
 		t.Errorf("Expected: %s, got %s", want, got)
+	}
+}
+
+func TestParseLinkHeaderEmpty(t *testing.T) {
+	h := ``
+	want := map[string]string{}
+	got, err := parseLinkHeader(h)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err.Error())
+	}
+
+	if !reflect.DeepEqual(want, got) {
+		t.Errorf("Expected %s, got %s", want, got)
+	}
+}
+
+func TestPaginationPopulatePageValuesEmpty(t *testing.T) {
+	wantPageHeaders := map[string]int{
+		xTotal:      0,
+		xTotalPages: 0,
+		xPerPage:    0,
+		xPage:       0,
+		xNextPage:   0,
+		xPrevPage:   0,
+	}
+	wantLinkHeaders := map[string]string{
+		linkPrev:  "",
+		linkNext:  "",
+		linkFirst: "",
+		linkLast:  "",
+	}
+
+	r := newResponse(&http.Response{
+		Header: http.Header{},
+	})
+
+	gotPageHeaders := map[string]int{
+		xTotal:      r.TotalItems,
+		xTotalPages: r.TotalPages,
+		xPerPage:    r.ItemsPerPage,
+		xPage:       r.CurrentPage,
+		xNextPage:   r.NextPage,
+		xPrevPage:   r.PreviousPage,
+	}
+	for k, v := range wantPageHeaders {
+		if v != gotPageHeaders[k] {
+			t.Errorf("For %s, expected %d, got %d", k, v, gotPageHeaders[k])
+		}
+	}
+
+	gotLinkHeaders := map[string]string{
+		linkPrev:  r.PreviousLink,
+		linkNext:  r.NextLink,
+		linkFirst: r.FirstLink,
+		linkLast:  r.LastLink,
+	}
+	for k, v := range wantLinkHeaders {
+		if v != gotLinkHeaders[k] {
+			t.Errorf("For %s, expected %s, got %s", k, v, gotLinkHeaders[k])
+		}
+	}
+}
+
+func TestPaginationPopulatePageValuesOffset(t *testing.T) {
+	wantPageHeaders := map[string]int{
+		xTotal:      100,
+		xTotalPages: 5,
+		xPerPage:    20,
+		xPage:       2,
+		xNextPage:   3,
+		xPrevPage:   1,
+	}
+	wantLinkHeaders := map[string]string{
+		linkPrev:  "https://gitlab.example.com/api/v4/projects/8/issues/8/notes?page=1&per_page=3",
+		linkNext:  "https://gitlab.example.com/api/v4/projects/8/issues/8/notes?page=3&per_page=3",
+		linkFirst: "https://gitlab.example.com/api/v4/projects/8/issues/8/notes?page=1&per_page=3",
+		linkLast:  "https://gitlab.example.com/api/v4/projects/8/issues/8/notes?page=3&per_page=3",
+	}
+
+	h := http.Header{}
+	for k, v := range wantPageHeaders {
+		h.Add(k, fmt.Sprint(v))
+	}
+	var linkHeaderComponents []string
+	for k, v := range wantLinkHeaders {
+		if v != "" {
+			linkHeaderComponents = append(linkHeaderComponents, fmt.Sprintf("<%s>; rel=\"%s\"", v, k))
+		}
+	}
+	h.Add("Link", strings.Join(linkHeaderComponents, ", "))
+
+	r := newResponse(&http.Response{
+		Header: h,
+	})
+
+	gotPageHeaders := map[string]int{
+		xTotal:      r.TotalItems,
+		xTotalPages: r.TotalPages,
+		xPerPage:    r.ItemsPerPage,
+		xPage:       r.CurrentPage,
+		xNextPage:   r.NextPage,
+		xPrevPage:   r.PreviousPage,
+	}
+	for k, v := range wantPageHeaders {
+		if v != gotPageHeaders[k] {
+			t.Errorf("For %s, expected %d, got %d", k, v, gotPageHeaders[k])
+		}
+	}
+
+	gotLinkHeaders := map[string]string{
+		linkPrev:  r.PreviousLink,
+		linkNext:  r.NextLink,
+		linkFirst: r.FirstLink,
+		linkLast:  r.LastLink,
+	}
+	for k, v := range wantLinkHeaders {
+		if v != gotLinkHeaders[k] {
+			t.Errorf("For %s, expected %s, got %s", k, v, gotLinkHeaders[k])
+		}
+	}
+}
+
+func TestPaginationPopulatePageValuesKeyset(t *testing.T) {
+	wantPageHeaders := map[string]int{
+		xTotal:      0,
+		xTotalPages: 0,
+		xPerPage:    0,
+		xPage:       0,
+		xNextPage:   0,
+		xPrevPage:   0,
+	}
+	wantLinkHeaders := map[string]string{
+		linkPrev:  "",
+		linkFirst: "",
+		linkLast:  "",
+	}
+
+	h := http.Header{}
+	for k, v := range wantPageHeaders {
+		h.Add(k, fmt.Sprint(v))
+	}
+	var linkHeaderComponents []string
+	for k, v := range wantLinkHeaders {
+		if v != "" {
+			linkHeaderComponents = append(linkHeaderComponents, fmt.Sprintf("<%s>; rel=\"%s\"", v, k))
+		}
+	}
+	h.Add("Link", strings.Join(linkHeaderComponents, ", "))
+
+	r := newResponse(&http.Response{
+		Header: h,
+	})
+
+	gotPageHeaders := map[string]int{
+		xTotal:      r.TotalItems,
+		xTotalPages: r.TotalPages,
+		xPerPage:    r.ItemsPerPage,
+		xPage:       r.CurrentPage,
+		xNextPage:   r.NextPage,
+		xPrevPage:   r.PreviousPage,
+	}
+	for k, v := range wantPageHeaders {
+		if v != gotPageHeaders[k] {
+			t.Errorf("For %s, expected %d, got %d", k, v, gotPageHeaders[k])
+		}
 	}
 }

--- a/gitlab_test.go
+++ b/gitlab_test.go
@@ -26,7 +26,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -236,19 +235,6 @@ func TestPathEscape(t *testing.T) {
 	got := PathEscape("diaspora/diaspora")
 	if want != got {
 		t.Errorf("Expected: %s, got %s", want, got)
-	}
-}
-
-func TestParseLinkHeaderEmpty(t *testing.T) {
-	h := ``
-	want := map[string]string{}
-	got, err := parseLinkHeader(h)
-	if err != nil {
-		t.Errorf("unexpected error: %s", err.Error())
-	}
-
-	if !reflect.DeepEqual(want, got) {
-		t.Errorf("Expected %s, got %s", want, got)
 	}
 }
 

--- a/invites_test.go
+++ b/invites_test.go
@@ -16,7 +16,7 @@ func TestListGroupPendingInvites(t *testing.T) {
 	})
 
 	opt := &ListPendingInvitationsOptions{
-		ListOptions: ListOptions{2, 3},
+		ListOptions: ListOptions{Page: 2, PerPage: 3},
 	}
 
 	projects, _, err := client.Invites.ListPendingGroupInvitations("test", opt)
@@ -85,7 +85,7 @@ func TestListProjectPendingInvites(t *testing.T) {
 	})
 
 	opt := &ListPendingInvitationsOptions{
-		ListOptions: ListOptions{2, 3},
+		ListOptions: ListOptions{Page: 2, PerPage: 3},
 	}
 
 	projects, _, err := client.Invites.ListPendingProjectInvitations("test", opt)

--- a/notifications_test.go
+++ b/notifications_test.go
@@ -86,7 +86,7 @@ func TestGetProjectSettings(t *testing.T) {
 	}
 
 	want := &NotificationSettings{
-		Level: 5, //custom
+		Level: 5, // custom
 		Events: &NotificationEvents{
 			NewEpic:                   true,
 			NewNote:                   true,

--- a/project_vulnerabilities_test.go
+++ b/project_vulnerabilities_test.go
@@ -32,7 +32,7 @@ func TestListProjectVulnerabilities(t *testing.T) {
 	})
 
 	opt := &ListProjectVulnerabilitiesOptions{
-		ListOptions: ListOptions{2, 3},
+		ListOptions: ListOptions{Page: 2, PerPage: 3},
 	}
 
 	projectVulnerabilities, _, err := client.ProjectVulnerabilities.ListProjectVulnerabilities(1, opt)

--- a/projects_test.go
+++ b/projects_test.go
@@ -39,7 +39,7 @@ func TestListProjects(t *testing.T) {
 	})
 
 	opt := &ListProjectsOptions{
-		ListOptions: ListOptions{2, 3},
+		ListOptions: ListOptions{Page: 2, PerPage: 3},
 		Archived:    Bool(true),
 		OrderBy:     String("name"),
 		Sort:        String("asc"),
@@ -68,7 +68,7 @@ func TestListUserProjects(t *testing.T) {
 	})
 
 	opt := &ListProjectsOptions{
-		ListOptions: ListOptions{2, 3},
+		ListOptions: ListOptions{Page: 2, PerPage: 3},
 		Archived:    Bool(true),
 		OrderBy:     String("name"),
 		Sort:        String("asc"),
@@ -97,7 +97,7 @@ func TestListUserContributedProjects(t *testing.T) {
 	})
 
 	opt := &ListProjectsOptions{
-		ListOptions: ListOptions{2, 3},
+		ListOptions: ListOptions{Page: 2, PerPage: 3},
 		Archived:    Bool(true),
 		OrderBy:     String("name"),
 		Sort:        String("asc"),
@@ -126,7 +126,7 @@ func TestListUserStarredProjects(t *testing.T) {
 	})
 
 	opt := &ListProjectsOptions{
-		ListOptions: ListOptions{2, 3},
+		ListOptions: ListOptions{Page: 2, PerPage: 3},
 		Archived:    Bool(true),
 		OrderBy:     String("name"),
 		Sort:        String("asc"),
@@ -156,7 +156,7 @@ func TestListProjectsUsersByID(t *testing.T) {
 	})
 
 	opt := &ListProjectUserOptions{
-		ListOptions: ListOptions{2, 3},
+		ListOptions: ListOptions{Page: 2, PerPage: 3},
 		Search:      String("query"),
 	}
 
@@ -181,7 +181,7 @@ func TestListProjectsUsersByName(t *testing.T) {
 	})
 
 	opt := &ListProjectUserOptions{
-		ListOptions: ListOptions{2, 3},
+		ListOptions: ListOptions{Page: 2, PerPage: 3},
 		Search:      String("query"),
 	}
 
@@ -206,7 +206,7 @@ func TestListProjectsGroupsByID(t *testing.T) {
 	})
 
 	opt := &ListProjectGroupOptions{
-		ListOptions: ListOptions{2, 3},
+		ListOptions: ListOptions{Page: 2, PerPage: 3},
 		Search:      String("query"),
 	}
 
@@ -231,7 +231,7 @@ func TestListProjectsGroupsByName(t *testing.T) {
 	})
 
 	opt := &ListProjectGroupOptions{
-		ListOptions: ListOptions{2, 3},
+		ListOptions: ListOptions{Page: 2, PerPage: 3},
 		Search:      String("query"),
 	}
 
@@ -255,7 +255,7 @@ func TestListOwnedProjects(t *testing.T) {
 	})
 
 	opt := &ListProjectsOptions{
-		ListOptions: ListOptions{2, 3},
+		ListOptions: ListOptions{Page: 2, PerPage: 3},
 		Archived:    Bool(true),
 		OrderBy:     String("name"),
 		Sort:        String("asc"),
@@ -285,7 +285,7 @@ func TestListStarredProjects(t *testing.T) {
 	})
 
 	opt := &ListProjectsOptions{
-		ListOptions: ListOptions{2, 3},
+		ListOptions: ListOptions{Page: 2, PerPage: 3},
 		Archived:    Bool(true),
 		OrderBy:     String("name"),
 		Sort:        String("asc"),
@@ -572,7 +572,7 @@ func TestListProjectForks(t *testing.T) {
 	})
 
 	opt := &ListProjectsOptions{}
-	opt.ListOptions = ListOptions{2, 3}
+	opt.ListOptions = ListOptions{Page: 2, PerPage: 3}
 	opt.Archived = Bool(true)
 	opt.OrderBy = String("name")
 	opt.Sort = String("asc")

--- a/request_options.go
+++ b/request_options.go
@@ -54,19 +54,16 @@ func WithHeaders(headers map[string]string) RequestOptionFunc {
 }
 
 // WithKeysetPaginationParameters takes a "next" link from the Link header of a
-// response to a keyset-based paginated request, and modifies the values of
-// each query parameter in the request with its corresponding parameter from
-// the response
-func WithKeysetPaginationParameters(rawNextLink string) RequestOptionFunc {
+// response to a keyset-based paginated request and modifies the values of each
+// query parameter in the request with its corresponding response parameter.
+func WithKeysetPaginationParameters(nextLink string) RequestOptionFunc {
 	return func(req *retryablehttp.Request) error {
-		nextUrl, err := url.Parse(rawNextLink)
+		nextUrl, err := url.Parse(nextLink)
 		if err != nil {
 			return err
 		}
-		params := nextUrl.Query()
-		// must make a copy of the query inside the func's scope
 		q := req.URL.Query()
-		for k, values := range params {
+		for k, values := range nextUrl.Query() {
 			q.Del(k)
 			for _, v := range values {
 				q.Add(k, v)


### PR DESCRIPTION
This is one possible implementation of keyset-based pagination, as suggested in #815.

The basic flow of offset-based pagination is that the client requests the first page, and the server returns information about the page in headers. The flow for keyset-based pagination differs in that the information for building a request for the next page is not returned in pieces, but in a pre-formatted URL in the `Link` header. The documentation recommends using that link to make the request, which doesn't seem like it will work cleanly with the existing code here. In particular, the link includes a number of query parameters that differ among endpoints that support keyset-based pagination.

So, the changes here provide a way to directly use all of the query parameters returned in the header when building the next request. `ListOptions` now includes fields that are shared among all keyset-based paginated endpoints. Other required parameters for paginated endpoints can be added by means of a `RequestOptionFunc`, for which there is a builder function included.

An alternative would be to have `ListOptions` enumerate each possible query parameter that could be included in a "next Link" header, and return them in the `Response` struct in the same way as existing header values. This would mean that the end-user code for each endpoint using this pagination might look different, i.e. there would be no single way to do all keyset-based paginated endpoints. But, it would make the code less opaque, and avoid using a "magic black box function" to add `RequestOptionFunc`s. 

This PR is mostly a suggestion/WIP to get the conversation moving about how this package might support keyset-based paginated endpoints, so please let me know how it looks!