### PR TITLE
Support deleting labels by label-id

### DIFF
--- a/group_labels.go
+++ b/group_labels.go
@@ -136,21 +136,32 @@ func (s *GroupLabelsService) CreateGroupLabel(gid interface{}, opt *CreateGroupL
 	return l, resp, nil
 }
 
-// DeleteGroupLabel deletes a group label given by its name.
+// DeleteGroupLabelOptions represents the available DeleteGroupLabel() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/group_labels.html#delete-a-group-label
-func (s *GroupLabelsService) DeleteGroupLabel(gid interface{}, labelID interface{}, options ...RequestOptionFunc) (*Response, error) {
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/group_labels.html#delete-a-group-label
+type DeleteGroupLabelOptions DeleteLabelOptions
+
+// DeleteGroupLabel deletes a group label given by its name or ID.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/group_labels.html#delete-a-group-label
+func (s *GroupLabelsService) DeleteGroupLabel(gid interface{}, lid interface{}, opt *DeleteGroupLabelOptions, options ...RequestOptionFunc) (*Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
 		return nil, err
 	}
-	label, err := parseID(labelID)
-	if err != nil {
-		return nil, err
-	}
-	u := fmt.Sprintf("groups/%s/labels/%s", PathEscape(group), PathEscape(label))
+	u := fmt.Sprintf("groups/%s/labels", PathEscape(group))
 
-	req, err := s.client.NewRequest(http.MethodDelete, u, nil, options)
+	if lid != nil {
+		label, err := parseID(lid)
+		if err != nil {
+			return nil, err
+		}
+		u = fmt.Sprintf("groups/%s/labels/%s", PathEscape(group), PathEscape(label))
+	}
+
+	req, err := s.client.NewRequest(http.MethodDelete, u, opt, options)
 	if err != nil {
 		return nil, err
 	}

--- a/group_labels.go
+++ b/group_labels.go
@@ -136,23 +136,21 @@ func (s *GroupLabelsService) CreateGroupLabel(gid interface{}, opt *CreateGroupL
 	return l, resp, nil
 }
 
-// DeleteGroupLabelOptions represents the available DeleteGroupLabel() options.
-//
-// GitLab API docs:
-// https://docs.gitlab.com/ee/api/group_labels.html#delete-a-group-label
-type DeleteGroupLabelOptions DeleteLabelOptions
-
 // DeleteGroupLabel deletes a group label given by its name.
 //
 // GitLab API docs: https://docs.gitlab.com/ee/api/group_labels.html#delete-a-group-label
-func (s *GroupLabelsService) DeleteGroupLabel(gid interface{}, opt *DeleteGroupLabelOptions, options ...RequestOptionFunc) (*Response, error) {
+func (s *GroupLabelsService) DeleteGroupLabel(gid interface{}, labelID interface{}, options ...RequestOptionFunc) (*Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("groups/%s/labels", PathEscape(group))
+	label, err := parseID(labelID)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("groups/%s/labels/%s", PathEscape(group), PathEscape(label))
 
-	req, err := s.client.NewRequest(http.MethodDelete, u, opt, options)
+	req, err := s.client.NewRequest(http.MethodDelete, u, nil, options)
 	if err != nil {
 		return nil, err
 	}

--- a/group_labels_test.go
+++ b/group_labels_test.go
@@ -49,15 +49,11 @@ func TestCreateGroupGroupLabel(t *testing.T) {
 func TestDeleteGroupLabel(t *testing.T) {
 	mux, client := setup(t)
 
-	mux.HandleFunc("/api/v4/groups/1/labels", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v4/groups/1/labels/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
 	})
 
-	label := &DeleteGroupLabelOptions{
-		Name: Ptr("My / GroupLabel"),
-	}
-
-	_, err := client.GroupLabels.DeleteGroupLabel("1", label)
+	_, err := client.GroupLabels.DeleteGroupLabel("1", "1")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/group_labels_test.go
+++ b/group_labels_test.go
@@ -46,14 +46,31 @@ func TestCreateGroupGroupLabel(t *testing.T) {
 	}
 }
 
-func TestDeleteGroupLabel(t *testing.T) {
+func TestDeleteGroupLabelByID(t *testing.T) {
 	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/groups/1/labels/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
 	})
 
-	_, err := client.GroupLabels.DeleteGroupLabel("1", "1")
+	_, err := client.GroupLabels.DeleteGroupLabel("1", "1", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func TestDeleteGroupLabelByName(t *testing.T) {
+	mux, client := setup(t)
+
+	mux.HandleFunc("/api/v4/groups/1/labels", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodDelete)
+	})
+
+	label := &DeleteGroupLabelOptions{
+		Name: Ptr("My / GroupLabel"),
+	}
+
+	_, err := client.GroupLabels.DeleteGroupLabel("1", nil, label)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/labels.go
+++ b/labels.go
@@ -168,24 +168,21 @@ func (s *LabelsService) CreateLabel(pid interface{}, opt *CreateLabelOptions, op
 	return l, resp, nil
 }
 
-// DeleteLabelOptions represents the available DeleteLabel() options.
+// DeleteLabel deletes a label given by its id.
 //
 // GitLab API docs: https://docs.gitlab.com/ee/api/labels.html#delete-a-label
-type DeleteLabelOptions struct {
-	Name *string `url:"name,omitempty" json:"name,omitempty"`
-}
-
-// DeleteLabel deletes a label given by its name.
-//
-// GitLab API docs: https://docs.gitlab.com/ee/api/labels.html#delete-a-label
-func (s *LabelsService) DeleteLabel(pid interface{}, opt *DeleteLabelOptions, options ...RequestOptionFunc) (*Response, error) {
+func (s *LabelsService) DeleteLabel(pid interface{}, labelID interface{}, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/labels", PathEscape(project))
+	label, err := parseID(labelID)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/labels/%s", PathEscape(project), PathEscape(label))
 
-	req, err := s.client.NewRequest(http.MethodDelete, u, opt, options)
+	req, err := s.client.NewRequest(http.MethodDelete, u, nil, options)
 	if err != nil {
 		return nil, err
 	}

--- a/labels.go
+++ b/labels.go
@@ -168,21 +168,32 @@ func (s *LabelsService) CreateLabel(pid interface{}, opt *CreateLabelOptions, op
 	return l, resp, nil
 }
 
-// DeleteLabel deletes a label given by its id.
+// DeleteLabelOptions represents the available DeleteLabel() options.
 //
 // GitLab API docs: https://docs.gitlab.com/ee/api/labels.html#delete-a-label
-func (s *LabelsService) DeleteLabel(pid interface{}, labelID interface{}, options ...RequestOptionFunc) (*Response, error) {
+type DeleteLabelOptions struct {
+	Name *string `url:"name,omitempty" json:"name,omitempty"`
+}
+
+// DeleteLabel deletes a label given by its name or ID.
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/labels.html#delete-a-label
+func (s *LabelsService) DeleteLabel(pid interface{}, lid interface{}, opt *DeleteLabelOptions, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, err
 	}
-	label, err := parseID(labelID)
-	if err != nil {
-		return nil, err
-	}
-	u := fmt.Sprintf("projects/%s/labels/%s", PathEscape(project), PathEscape(label))
+	u := fmt.Sprintf("projects/%s/labels", PathEscape(project))
 
-	req, err := s.client.NewRequest(http.MethodDelete, u, nil, options)
+	if lid != nil {
+		label, err := parseID(lid)
+		if err != nil {
+			return nil, err
+		}
+		u = fmt.Sprintf("projects/%s/labels/%s", PathEscape(project), PathEscape(label))
+	}
+
+	req, err := s.client.NewRequest(http.MethodDelete, u, opt, options)
 	if err != nil {
 		return nil, err
 	}

--- a/labels_test.go
+++ b/labels_test.go
@@ -48,7 +48,7 @@ func TestCreateLabel(t *testing.T) {
 	}
 }
 
-func TestDeleteLabel(t *testing.T) {
+func TestDeleteLabelbyID(t *testing.T) {
 	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/projects/1/labels/1", func(w http.ResponseWriter, r *http.Request) {
@@ -56,7 +56,25 @@ func TestDeleteLabel(t *testing.T) {
 	})
 
 	// Delete label
-	_, err := client.Labels.DeleteLabel("1", "1")
+	_, err := client.Labels.DeleteLabel("1", "1", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func TestDeleteLabelbyName(t *testing.T) {
+	mux, client := setup(t)
+
+	mux.HandleFunc("/api/v4/projects/1/labels", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodDelete)
+	})
+
+	// Delete label
+	label := &DeleteLabelOptions{
+		Name: Ptr("My Label"),
+	}
+
+	_, err := client.Labels.DeleteLabel("1", nil, label)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/labels_test.go
+++ b/labels_test.go
@@ -51,16 +51,12 @@ func TestCreateLabel(t *testing.T) {
 func TestDeleteLabel(t *testing.T) {
 	mux, client := setup(t)
 
-	mux.HandleFunc("/api/v4/projects/1/labels", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v4/projects/1/labels/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
 	})
 
 	// Delete label
-	label := &DeleteLabelOptions{
-		Name: Ptr("My Label"),
-	}
-
-	_, err := client.Labels.DeleteLabel("1", label)
+	_, err := client.Labels.DeleteLabel("1", "1")
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Closes #1823 

This implements the Gitlab Label API for deleting a label as described in https://docs.gitlab.com/ee/api/labels.html#delete-a-label