### PR TITLE
Adds `mirror_branch_regex` option for project push and pull mirrors

### DIFF
--- a/project_mirror.go
+++ b/project_mirror.go
@@ -108,9 +108,9 @@ func (s *ProjectMirrorService) GetProjectMirror(pid interface{}, mirror int, opt
 type AddProjectMirrorOptions struct {
 	URL                   *string `url:"url,omitempty" json:"url,omitempty"`
 	Enabled               *bool   `url:"enabled,omitempty" json:"enabled,omitempty"`
-	MirrorBranchRegex     *string `url:"mirror_branch_regex,omitempty" json:"mirror_branch_regex,omitempty"`
-	OnlyProtectedBranches *bool   `url:"only_protected_branches,omitempty" json:"only_protected_branches,omitempty"`
 	KeepDivergentRefs     *bool   `url:"keep_divergent_refs,omitempty" json:"keep_divergent_refs,omitempty"`
+	OnlyProtectedBranches *bool   `url:"only_protected_branches,omitempty" json:"only_protected_branches,omitempty"`
+	MirrorBranchRegex     *string `url:"mirror_branch_regex,omitempty" json:"mirror_branch_regex,omitempty"`
 }
 
 // AddProjectMirror creates a new mirror on the project.
@@ -145,9 +145,9 @@ func (s *ProjectMirrorService) AddProjectMirror(pid interface{}, opt *AddProject
 // https://docs.gitlab.com/ee/api/remote_mirrors.html#update-a-remote-mirrors-attributes
 type EditProjectMirrorOptions struct {
 	Enabled               *bool   `url:"enabled,omitempty" json:"enabled,omitempty"`
-	MirrorBranchRegex     *string `url:"mirror_branch_regex,omitempty" json:"mirror_branch_regex,omitempty"`
-	OnlyProtectedBranches *bool   `url:"only_protected_branches,omitempty" json:"only_protected_branches,omitempty"`
 	KeepDivergentRefs     *bool   `url:"keep_divergent_refs,omitempty" json:"keep_divergent_refs,omitempty"`
+	OnlyProtectedBranches *bool   `url:"only_protected_branches,omitempty" json:"only_protected_branches,omitempty"`
+	MirrorBranchRegex     *string `url:"mirror_branch_regex,omitempty" json:"mirror_branch_regex,omitempty"`
 }
 
 // EditProjectMirror updates a project team member to a specified access level..

--- a/project_mirror.go
+++ b/project_mirror.go
@@ -40,6 +40,7 @@ type ProjectMirror struct {
 	LastSuccessfulUpdateAt *time.Time `json:"last_successful_update_at"`
 	LastUpdateAt           *time.Time `json:"last_update_at"`
 	LastUpdateStartedAt    *time.Time `json:"last_update_started_at"`
+	MirrorBranchRegex      string     `json:"mirror_branch_regex"`
 	OnlyProtectedBranches  bool       `json:"only_protected_branches"`
 	KeepDivergentRefs      bool       `json:"keep_divergent_refs"`
 	UpdateStatus           string     `json:"update_status"`
@@ -107,6 +108,7 @@ func (s *ProjectMirrorService) GetProjectMirror(pid interface{}, mirror int, opt
 type AddProjectMirrorOptions struct {
 	URL                   *string `url:"url,omitempty" json:"url,omitempty"`
 	Enabled               *bool   `url:"enabled,omitempty" json:"enabled,omitempty"`
+	MirrorBranchRegex     *string `url:"mirror_branch_regex,omitempty" json:"mirror_branch_regex,omitempty"`
 	OnlyProtectedBranches *bool   `url:"only_protected_branches,omitempty" json:"only_protected_branches,omitempty"`
 	KeepDivergentRefs     *bool   `url:"keep_divergent_refs,omitempty" json:"keep_divergent_refs,omitempty"`
 }
@@ -142,9 +144,10 @@ func (s *ProjectMirrorService) AddProjectMirror(pid interface{}, opt *AddProject
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/remote_mirrors.html#update-a-remote-mirrors-attributes
 type EditProjectMirrorOptions struct {
-	Enabled               *bool `url:"enabled,omitempty" json:"enabled,omitempty"`
-	OnlyProtectedBranches *bool `url:"only_protected_branches,omitempty" json:"only_protected_branches,omitempty"`
-	KeepDivergentRefs     *bool `url:"keep_divergent_refs,omitempty" json:"keep_divergent_refs,omitempty"`
+	Enabled               *bool   `url:"enabled,omitempty" json:"enabled,omitempty"`
+	MirrorBranchRegex     *string `url:"mirror_branch_regex,omitempty" json:"mirror_branch_regex,omitempty"`
+	OnlyProtectedBranches *bool   `url:"only_protected_branches,omitempty" json:"only_protected_branches,omitempty"`
+	KeepDivergentRefs     *bool   `url:"keep_divergent_refs,omitempty" json:"keep_divergent_refs,omitempty"`
 }
 
 // EditProjectMirror updates a project team member to a specified access level..

--- a/projects.go
+++ b/projects.go
@@ -862,6 +862,7 @@ type EditProjectOptions struct {
 	MergeRequestsTemplate                     *string                              `url:"merge_requests_template,omitempty" json:"merge_requests_template,omitempty"`
 	MergeTrainsEnabled                        *bool                                `url:"merge_trains_enabled,omitempty" json:"merge_trains_enabled,omitempty"`
 	Mirror                                    *bool                                `url:"mirror,omitempty" json:"mirror,omitempty"`
+	MirrorBranchRegex                         *string                              `url:"mirror_branch_regex,omitempty" json:"mirror_branch_regex,omitempty"`
 	MirrorOverwritesDivergedBranches          *bool                                `url:"mirror_overwrites_diverged_branches,omitempty" json:"mirror_overwrites_diverged_branches,omitempty"`
 	MirrorTriggerBuilds                       *bool                                `url:"mirror_trigger_builds,omitempty" json:"mirror_trigger_builds,omitempty"`
 	MirrorUserID                              *int                                 `url:"mirror_user_id,omitempty" json:"mirror_user_id,omitempty"`


### PR DESCRIPTION
Allows the `mirror_branch_regex` option to be set on project push and pull mirrors. Note that `mirror_branch_regex` can only be set after a project is created for pull mirrors, so I've only set it in the `EditProjectOptions` struct. It also isn't retured when getting a projects details.

Closes #1832

https://gitlab.com/gitlab-org/gitlab/-/merge_requests/102608
https://docs.gitlab.com/ee/api/remote_mirrors.html#create-a-pull-mirror