### PR TITLE
Add missing name field to Pipelines struct

### DIFF
--- a/notifications_test.go
+++ b/notifications_test.go
@@ -86,7 +86,7 @@ func TestGetProjectSettings(t *testing.T) {
 	}
 
 	want := &NotificationSettings{
-		Level: 5, //custom
+		Level: 5, // custom
 		Events: &NotificationEvents{
 			NewEpic:                   true,
 			NewNote:                   true,

--- a/pipelines.go
+++ b/pipelines.go
@@ -49,6 +49,7 @@ type Pipeline struct {
 	Status         string          `json:"status"`
 	Source         string          `json:"source"`
 	Ref            string          `json:"ref"`
+	Name           string          `json:"name"`
 	SHA            string          `json:"sha"`
 	BeforeSHA      string          `json:"before_sha"`
 	Tag            bool            `json:"tag"`


### PR DESCRIPTION
This is used in the following functions:

- GetPipeline
- GetLatestPipeline
- CreatePipeline
- RetryPipelineBuild
- CancelPipelineBuild

`GetPipeline` and `GetLatestPipeline` return the name but the `Create`, `Retry`, and `Cancel` do not. But this will behave the same as `DetailedStatus` does and just not be set if it's not returned.

API docs for pipelines: https://docs.gitlab.com/ee/api/pipelines.html

Example JSON from GitLab for `get latest pipeline`:

```
{
    "id": 287,
    "iid": 144,
    "project_id": 21,
    "name": "Build pipeline",
    "sha": "50f0acb76a40e34a4ff304f7347dcc6587da8a14",
    "ref": "main",
    "status": "success",
    "source": "push",
    "created_at": "2022-09-21T01:05:07.200Z",
    "updated_at": "2022-09-21T01:05:50.185Z",
    "web_url": "http://127.0.0.1:3000/test-group/test-project/-/pipelines/287",
    "before_sha": "8a24fb3c5877a6d0b611ca41fc86edc174593e2b",
    "tag": false,
    "yaml_errors": null,
    "user": {
        "id": 1,
        "username": "root",
        "name": "Administrator",
        "state": "active",
        "avatar_url": "https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon",
        "web_url": "http://127.0.0.1:3000/root"
    },
    "started_at": "2022-09-21T01:05:14.197Z",
    "finished_at": "2022-09-21T01:05:50.175Z",
    "committed_at": null,
    "duration": 34,
    "queued_duration": 6,
    "coverage": null,
    "detailed_status": {
        "icon": "status_success",
        "text": "passed",
        "label": "passed",
        "group": "success",
        "tooltip": "passed",
        "has_details": false,
        "details_path": "/test-group/test-project/-/pipelines/287",
        "illustration": null,
        "favicon": "/assets/ci_favicons/favicon_status_success-8451333011eee8ce9f2ab25dc487fe24a8758c694827a582f17f42b0a90446a2.png"
    }
}
```

This also fixes a `go fmt` thing? I just followed the contributing guide and ran it and it produced this. 😄 