### PR TITLE
Place a floor of 1 on the rate limit burst to prevent x/time from throwing an error

### DIFF
--- a/gitlab.go
+++ b/gitlab.go
@@ -533,6 +533,11 @@ func (c *Client) configureLimiter(ctx context.Context, headers http.Header) {
 			limit := rate.Limit(rateLimit * 0.66)
 			burst := int(rateLimit * 0.33)
 
+			// Need at least one allowed to burst or x/time will throw an error
+			if burst == 0 {
+				burst = 1
+			}
+
 			// Create a new limiter using the calculated values.
 			c.limiter = rate.NewLimiter(limit, burst)
 


### PR DESCRIPTION
If GitLab is enforcing rate limits of fewer than 3 per second the existing logic will set burst to zero (it multiplies the per-second value by 0.33 and then casts to int).

`rate.Limiter.Wait` [will fail](https://github.com/golang/time/blob/b24d3b5e50f7b0e18486d18f0a240d04d254ea73/rate/rate.go#L257) if burst is zero because `Wait` [falls back](https://github.com/golang/time/blob/b24d3b5e50f7b0e18486d18f0a240d04d254ea73/rate/rate.go#L231) to `WaitN` with n=1:
