### PR TITLE
Added missing fields for flexibleRollout feature flag strategy

### DIFF
--- a/project_feature_flags.go
+++ b/project_feature_flags.go
@@ -53,6 +53,12 @@ type ProjectFeatureFlagStrategyParameter struct {
 	GroupID    string `json:"groupId,omitempty"`
 	UserIDs    string `json:"userIds,omitempty"`
 	Percentage string `json:"percentage,omitempty"`
+
+	// Following fields aren't documented in Gitlab API docs,
+	// but are present in Gitlab API since 13.5.
+	// Docs: https://docs.getunleash.io/reference/activation-strategies#gradual-rollout
+	Rollout    string `json:"rollout,omitempty"`
+	Stickiness string `json:"stickiness,omitempty"`
 }
 
 func (i ProjectFeatureFlag) String() string {

--- a/project_feature_flags_test.go
+++ b/project_feature_flags_test.go
@@ -117,6 +117,21 @@ func TestGetProjectFeatureFlag(t *testing.T) {
 					},
 				},
 			},
+			{
+				ID:   24,
+				Name: "flexibleRollout",
+				Parameters: &ProjectFeatureFlagStrategyParameter{
+					GroupID:    "default",
+					Rollout:    "50",
+					Stickiness: "default",
+				},
+				Scopes: []*ProjectFeatureFlagScope{
+					{
+						ID:               52,
+						EnvironmentScope: "*",
+					},
+				},
+			},
 		},
 	}
 

--- a/testdata/get_project_feature_flag.json
+++ b/testdata/get_project_feature_flag.json
@@ -17,6 +17,21 @@
           "environment_scope": "production"
         }
       ]
+    },
+    {
+      "id": 24,
+      "name": "flexibleRollout",
+      "parameters": {
+        "groupId": "default",
+        "rollout": "50",
+        "stickiness": "default"
+      },
+      "scopes": [
+        {
+          "id": 52,
+          "environment_scope": "*"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Feature flag model is missing a few fields for `flexibleRollout` strategy.

These fields aren't documented in Gitlab API docs for some reason, but they are described in [Unleash docs](https://docs.getunleash.io/reference/activation-strategies#gradual-rollout) and [Gitlab documentation](https://docs.gitlab.com/ee/api/feature_flags.html#create-a-feature-flag) has link to it (see `strategies:name`).