### PR TITLE
Add delete group milestone functionality and tests

### DIFF
--- a/group_milestones.go
+++ b/group_milestones.go
@@ -188,6 +188,24 @@ func (s *GroupMilestonesService) UpdateGroupMilestone(gid interface{}, milestone
 	return m, resp, nil
 }
 
+// DeleteGroupMilestone deletes a specified group milestone.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/group_milestones.html#delete-group-milestone
+func (s *GroupMilestonesService) DeleteGroupMilestone(pid interface{}, milestone int, options ...RequestOptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("groups/%s/milestones/%d", PathEscape(project), milestone)
+
+	req, err := s.client.NewRequest(http.MethodDelete, u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+	return s.client.Do(req, nil)
+}
+
 // GetGroupMilestoneIssuesOptions represents the available GetGroupMilestoneIssues() options.
 //
 // GitLab API docs:

--- a/group_milestones_test.go
+++ b/group_milestones_test.go
@@ -210,6 +210,30 @@ func TestGroupMilestonesService_UpdateGroupMilestone(t *testing.T) {
 	require.Equal(t, http.StatusNotFound, resp.StatusCode)
 }
 
+func TestGroupMilestonesService_DeleteGroupMilestone(t *testing.T) {
+	mux, client := setup(t)
+
+	mux.HandleFunc("/api/v4/groups/5/milestones/12", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodDelete)
+	})
+
+	resp, err := client.GroupMilestones.DeleteGroupMilestone(5, 12, nil)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	resp, err = client.GroupMilestones.DeleteGroupMilestone(5.01, 12, nil)
+	require.EqualError(t, err, "invalid ID type 5.01, the ID must be an int or a string")
+	require.Nil(t, resp)
+
+	resp, err = client.GroupMilestones.DeleteGroupMilestone(5, 12, nil, errorOption)
+	require.EqualError(t, err, "RequestOptionFunc returns an error")
+	require.Nil(t, resp)
+
+	resp, err = client.GroupMilestones.DeleteGroupMilestone(3, 12, nil)
+	require.Error(t, err)
+	require.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
 func TestGroupMilestonesService_GetGroupMilestoneIssues(t *testing.T) {
 	mux, client := setup(t)
 


### PR DESCRIPTION
Added a new function, DeleteGroupMilestone, to the GroupMilestonesService which allows for the deletion of a specified group milestone.

Ref: https://docs.gitlab.com/ee/api/group_milestones.html#delete-group-milestone