### PR TITLE
Reorder issue

### DIFF
--- a/issues.go
+++ b/issues.go
@@ -786,3 +786,35 @@ func (s *IssuesService) GetParticipants(pid interface{}, issue int, options ...R
 
 	return bu, resp, nil
 }
+
+// ReorderIssueOptions represents the available ReorderIssue() options.
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/issues.html#reorder-an-issue
+type ReorderIssueOptions struct {
+	MoveAfterID  *int `url:"move_after_id,omitempty" json:"move_after_id,omitempty"`
+	MoveBeforeID *int `url:"move_before_id,omitempty" json:"move_before_id,omitempty"`
+}
+
+// ReorderIssue reorders an issue.
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/issues.html#reorder-an-issue
+func (s *IssuesService) ReorderIssue(pid interface{}, issue int, opt *ReorderIssueOptions, options ...RequestOptionFunc) (*Issue, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/issues/%d/reorder", PathEscape(project), issue)
+
+	req, err := s.client.NewRequest(http.MethodPut, u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	i := new(Issue)
+	resp, err := s.client.Do(req, i)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return i, resp, nil
+}

--- a/issues.go
+++ b/issues.go
@@ -540,6 +540,38 @@ func (s *IssuesService) DeleteIssue(pid interface{}, issue int, options ...Reque
 	return s.client.Do(req, nil)
 }
 
+// ReorderIssueOptions represents the available ReorderIssue() options.
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/issues.html#reorder-an-issue
+type ReorderIssueOptions struct {
+	MoveAfterID  *int `url:"move_after_id,omitempty" json:"move_after_id,omitempty"`
+	MoveBeforeID *int `url:"move_before_id,omitempty" json:"move_before_id,omitempty"`
+}
+
+// ReorderIssue reorders an issue.
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/issues.html#reorder-an-issue
+func (s *IssuesService) ReorderIssue(pid interface{}, issue int, opt *ReorderIssueOptions, options ...RequestOptionFunc) (*Issue, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/issues/%d/reorder", PathEscape(project), issue)
+
+	req, err := s.client.NewRequest(http.MethodPut, u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	i := new(Issue)
+	resp, err := s.client.Do(req, i)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return i, resp, nil
+}
+
 // MoveIssueOptions represents the available MoveIssue() options.
 //
 // GitLab API docs: https://docs.gitlab.com/ee/api/issues.html#move-an-issue
@@ -785,36 +817,4 @@ func (s *IssuesService) GetParticipants(pid interface{}, issue int, options ...R
 	}
 
 	return bu, resp, nil
-}
-
-// ReorderIssueOptions represents the available ReorderIssue() options.
-//
-// GitLab API docs: https://docs.gitlab.com/ee/api/issues.html#reorder-an-issue
-type ReorderIssueOptions struct {
-	MoveAfterID  *int `url:"move_after_id,omitempty" json:"move_after_id,omitempty"`
-	MoveBeforeID *int `url:"move_before_id,omitempty" json:"move_before_id,omitempty"`
-}
-
-// ReorderIssue reorders an issue.
-//
-// GitLab API docs: https://docs.gitlab.com/ee/api/issues.html#reorder-an-issue
-func (s *IssuesService) ReorderIssue(pid interface{}, issue int, opt *ReorderIssueOptions, options ...RequestOptionFunc) (*Issue, *Response, error) {
-	project, err := parseID(pid)
-	if err != nil {
-		return nil, nil, err
-	}
-	u := fmt.Sprintf("projects/%s/issues/%d/reorder", PathEscape(project), issue)
-
-	req, err := s.client.NewRequest(http.MethodPut, u, opt, options)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	i := new(Issue)
-	resp, err := s.client.Do(req, i)
-	if err != nil {
-		return nil, resp, err
-	}
-
-	return i, resp, nil
 }

--- a/issues_test.go
+++ b/issues_test.go
@@ -931,3 +931,34 @@ func TestGetIssueGroupMilestone(t *testing.T) {
 		t.Errorf("Issues.GetIssue returned %+v, want %+v", issue, want)
 	}
 }
+
+func TestReorderIssue(t *testing.T) {
+	mux, client := setup(t)
+
+	mux.HandleFunc("/api/v4/projects/1/issues/5/reorder", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPut)
+		fmt.Fprint(w, `{"id":1, "title" : "Reordered issue", "description": "This is the description of a reordered issue", "author" : {"id" : 1, "name": "corrie"}, "assignees":[{"id":1}]}`)
+	})
+
+	afterID := 100
+	beforeID := 200
+
+	opt := ReorderIssueOptions{MoveAfterID: &afterID, MoveBeforeID: &beforeID}
+
+	issue, _, err := client.Issues.ReorderIssue("1", 5, &opt)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	want := &Issue{
+		ID:          1,
+		Title:       "Reordered issue",
+		Description: "This is the description of a reordered issue",
+		Author:      &IssueAuthor{ID: 1, Name: "corrie"},
+		Assignees:   []*IssueAssignee{{ID: 1}},
+	}
+
+	if !reflect.DeepEqual(want, issue) {
+		t.Errorf("Issues.ReorderIssue returned %+v, want %+v", issue, want)
+	}
+}

--- a/issues_test.go
+++ b/issues_test.go
@@ -941,9 +941,7 @@ func TestReorderIssue(t *testing.T) {
 	})
 
 	afterID := 100
-	beforeID := 200
-
-	opt := ReorderIssueOptions{MoveAfterID: &afterID, MoveBeforeID: &beforeID}
+	opt := ReorderIssueOptions{MoveAfterID: &afterID}
 
 	issue, _, err := client.Issues.ReorderIssue("1", 5, &opt)
 	if err != nil {

--- a/issues_test.go
+++ b/issues_test.go
@@ -92,6 +92,35 @@ func TestDeleteIssue(t *testing.T) {
 	}
 }
 
+func TestReorderIssue(t *testing.T) {
+	mux, client := setup(t)
+
+	mux.HandleFunc("/api/v4/projects/1/issues/5/reorder", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPut)
+		fmt.Fprint(w, `{"id":1, "title" : "Reordered issue", "description": "This is the description of a reordered issue", "author" : {"id" : 1, "name": "corrie"}, "assignees":[{"id":1}]}`)
+	})
+
+	afterID := 100
+	opt := ReorderIssueOptions{MoveAfterID: &afterID}
+
+	issue, _, err := client.Issues.ReorderIssue("1", 5, &opt)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	want := &Issue{
+		ID:          1,
+		Title:       "Reordered issue",
+		Description: "This is the description of a reordered issue",
+		Author:      &IssueAuthor{ID: 1, Name: "corrie"},
+		Assignees:   []*IssueAssignee{{ID: 1}},
+	}
+
+	if !reflect.DeepEqual(want, issue) {
+		t.Errorf("Issues.ReorderIssue returned %+v, want %+v", issue, want)
+	}
+}
+
 func TestMoveIssue(t *testing.T) {
 	mux, client := setup(t)
 
@@ -929,34 +958,5 @@ func TestGetIssueGroupMilestone(t *testing.T) {
 
 	if !reflect.DeepEqual(want, issue) {
 		t.Errorf("Issues.GetIssue returned %+v, want %+v", issue, want)
-	}
-}
-
-func TestReorderIssue(t *testing.T) {
-	mux, client := setup(t)
-
-	mux.HandleFunc("/api/v4/projects/1/issues/5/reorder", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, http.MethodPut)
-		fmt.Fprint(w, `{"id":1, "title" : "Reordered issue", "description": "This is the description of a reordered issue", "author" : {"id" : 1, "name": "corrie"}, "assignees":[{"id":1}]}`)
-	})
-
-	afterID := 100
-	opt := ReorderIssueOptions{MoveAfterID: &afterID}
-
-	issue, _, err := client.Issues.ReorderIssue("1", 5, &opt)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	want := &Issue{
-		ID:          1,
-		Title:       "Reordered issue",
-		Description: "This is the description of a reordered issue",
-		Author:      &IssueAuthor{ID: 1, Name: "corrie"},
-		Assignees:   []*IssueAssignee{{ID: 1}},
-	}
-
-	if !reflect.DeepEqual(want, issue) {
-		t.Errorf("Issues.ReorderIssue returned %+v, want %+v", issue, want)
 	}
 }


### PR DESCRIPTION
This PR implements support for the reorder issue endpoint in the REST API (https://docs.gitlab.com/ee/api/issues.html#reorder-an-issue). You can use it to update the relative position to other issues, which is then reflected on the issue board (but also allows you to sort by "relative position" in the GraphQL API).