### PR TITLE
add missing fields in Note struct

### DIFF
--- a/notes.go
+++ b/notes.go
@@ -50,18 +50,18 @@ type Note struct {
 		WebURL    string `json:"web_url"`
 	} `json:"author"`
 	System       bool          `json:"system"`
-	Internal     bool          `json:"internal"`
-	Confidential bool          `json:"confidential"`
-	ExpiresAt    *time.Time    `json:"expires_at"`
-	UpdatedAt    *time.Time    `json:"updated_at"`
 	CreatedAt    *time.Time    `json:"created_at"`
-	ProjectID    int           `json:"project_id"`
-	NoteableID   int           `json:"noteable_id"`
-	NoteableType string        `json:"noteable_type"`
+	UpdatedAt    *time.Time    `json:"updated_at"`
+	ExpiresAt    *time.Time    `json:"expires_at"`
 	CommitID     string        `json:"commit_id"`
 	Position     *NotePosition `json:"position"`
+	NoteableID   int           `json:"noteable_id"`
+	NoteableType string        `json:"noteable_type"`
+	ProjectID    int           `json:"project_id"`
+	NoteableIID  int           `json:"noteable_iid"`
 	Resolvable   bool          `json:"resolvable"`
 	Resolved     bool          `json:"resolved"`
+	ResolvedAt   *time.Time    `json:"resolved_at"`
 	ResolvedBy   struct {
 		ID        int    `json:"id"`
 		Username  string `json:"username"`
@@ -71,8 +71,8 @@ type Note struct {
 		AvatarURL string `json:"avatar_url"`
 		WebURL    string `json:"web_url"`
 	} `json:"resolved_by"`
-	ResolvedAt  *time.Time `json:"resolved_at"`
-	NoteableIID int        `json:"noteable_iid"`
+	Confidential bool `json:"confidential"`
+	Internal     bool `json:"internal"`
 }
 
 // NotePosition represents the position attributes of a note.

--- a/notes.go
+++ b/notes.go
@@ -50,9 +50,12 @@ type Note struct {
 		WebURL    string `json:"web_url"`
 	} `json:"author"`
 	System       bool          `json:"system"`
+	Internal     bool          `json:"internal"`
+	Confidential bool          `json:"confidential"`
 	ExpiresAt    *time.Time    `json:"expires_at"`
 	UpdatedAt    *time.Time    `json:"updated_at"`
 	CreatedAt    *time.Time    `json:"created_at"`
+	ProjectID    int           `json:"project_id"`
 	NoteableID   int           `json:"noteable_id"`
 	NoteableType string        `json:"noteable_type"`
 	CommitID     string        `json:"commit_id"`


### PR DESCRIPTION
https://docs.gitlab.com/ee/api/notes.html#issues

Example issue note (comment) from my GitLab instance:
```json
{
  "id": 3,
  "type": null,
  "body": "Comment 2",
  "attachment": null,
  "author": {
    "id": 1,
    "username": "root",
    "name": "Administrator",
    "state": "active",
    "locked": false,
    "avatar_url": "https://secure.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon",
    "web_url": "https://gitlab.c4.lab.atolio.team/root"
  },
  "created_at": "2024-01-15T22:32:55.785Z",
  "updated_at": "2024-01-15T22:32:55.785Z",
  "system": false,
  "noteable_id": 3,
  "noteable_type": "Issue",
  "project_id": 4,
  "resolvable": false,
  "confidential": false,
  "internal": false,
  "noteable_iid": 1,
  "commands_changes": {}
}
```