### PR TITLE
Fix an issue with environment names not being encoded

### DIFF
--- a/protected_environments.go
+++ b/protected_environments.go
@@ -242,7 +242,7 @@ func (s *ProtectedEnvironmentsService) UpdateProtectedEnvironments(pid interface
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("projects/%s/protected_environments/%s", PathEscape(project), environment)
+	u := fmt.Sprintf("projects/%s/protected_environments/%s", PathEscape(project), PathEscape(environment))
 
 	req, err := s.client.NewRequest(http.MethodPut, u, opt, options)
 	if err != nil {


### PR DESCRIPTION
This PR fixes an issue where environments that have slashes in their name cause an error because the URL isn't encoded. 

Upstream TF provider issue: https://gitlab.com/gitlab-org/terraform-provider-gitlab/-/issues/6198