### PR TITLE
The snippets API was failing due to improper URL encoding of the filename parameter

### DIFF
--- a/snippets.go
+++ b/snippets.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
-	"net/url"
 	"time"
 )
 
@@ -136,7 +135,7 @@ func (s *SnippetsService) SnippetContent(snippet int, options ...RequestOptionFu
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/snippets.html#snippet-repository-file-content
 func (s *SnippetsService) SnippetFileContent(snippet int, ref, filename string, options ...RequestOptionFunc) ([]byte, *Response, error) {
-	filepath := url.QueryEscape(filename)
+	filepath := PathEscape(filename)
 	u := fmt.Sprintf("snippets/%d/files/%s/%s/raw", snippet, ref, filepath)
 
 	req, err := s.client.NewRequest(http.MethodGet, u, nil, options)


### PR DESCRIPTION
GitLab api error:

```
GET https://gitlab.ZZZ.com/api/v4/snippets/YYY/files/HEAD/version 1/raw: 404 {message: 404 File Not Found}'
```

Root Cause: 
 
The filename contains spaces which need to be properly encoded in the URL path. url.QueryEscape was being used instead of PathEscape.

Resolution:  

Use PathEscape when encoding the filename since it is part of the URL path rather than query parameters. After applying this change, the snippets API works correctly.

Please let me know if you have any other questions!