### PR TITLE
feat(pagination): include id_after for all endpoints

### DIFF
--- a/audit_events.go
+++ b/audit_events.go
@@ -16,7 +16,7 @@ type AuditEvent struct {
 	EntityType string            `json:"entity_type"`
 	Details    AuditEventDetails `json:"details"`
 	CreatedAt  *time.Time        `json:"created_at"`
-	EventType  string 	     `json:"event_type"`
+	EventType  string            `json:"event_type"`
 }
 
 // AuditEventDetails represents the details portion of an audit event for

--- a/gitlab.go
+++ b/gitlab.go
@@ -234,6 +234,8 @@ type ListOptions struct {
 	// For offset-based and keyset-based paginated result sets, the number of results to include per page.
 	PerPage int `url:"per_page,omitempty" json:"per_page,omitempty"`
 
+	// For keyset-based paginated result sets, previous page last element id
+	IDAfter *int `url:"id_after,omitempty" json:"id_after,omitempty"`
 	// For keyset-based paginated result sets, name of the column by which to order
 	OrderBy string `url:"order_by,omitempty" json:"order_by,omitempty"`
 	// For keyset-based paginated result sets, the value must be `"keyset"`

--- a/projects.go
+++ b/projects.go
@@ -324,7 +324,6 @@ func (s ProjectApprovalRule) String() string {
 type ListProjectsOptions struct {
 	ListOptions
 	Archived                 *bool             `url:"archived,omitempty" json:"archived,omitempty"`
-	IDAfter                  *int              `url:"id_after,omitempty" json:"id_after,omitempty"`
 	IDBefore                 *int              `url:"id_before,omitempty" json:"id_before,omitempty"`
 	Imported                 *bool             `url:"imported,omitempty" json:"imported,omitempty"`
 	IncludeHidden            *bool             `url:"include_hidden,omitempty" json:"include_hidden,omitempty"`


### PR DESCRIPTION
**Purpose**

While using the library, I noticed that only `projects` endpoint was taking advantage of `id_after` query parameter on keyset based paginations.

While other endpoints like `jobs` can also use keyset based paginations, I thought "why not having `id_after` in global `ListOptions` struct with the rest of pagination query parameters ?"

As such, here's a minimal PR moving this query parameter, allowing all endpoints (in the limitation of developers using this library be aware that not all endpoints support keyset based pagination) to take advantage of `id_after` query parameter.