### PR TITLE
Add support for ci_forward_deployment_rollback_allowed to Projects

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -135,6 +135,7 @@ type Project struct {
 	ImportError                              string             `json:"import_error"`
 	CIDefaultGitDepth                        int                `json:"ci_default_git_depth"`
 	CIForwardDeploymentEnabled               bool               `json:"ci_forward_deployment_enabled"`
+	CIForwardDeploymentRollbackAllowed       bool               `json:"ci_forward_deployment_rollback_allowed"`
 	CISeperateCache                          bool               `json:"ci_separated_caches"`
 	CIJobTokenScopeEnabled                   bool               `json:"ci_job_token_scope_enabled"`
 	CIOptInJWT                               bool               `json:"ci_opt_in_jwt"`
@@ -842,6 +843,7 @@ type EditProjectOptions struct {
 	CIConfigPath                              *string                              `url:"ci_config_path,omitempty" json:"ci_config_path,omitempty"`
 	CIDefaultGitDepth                         *int                                 `url:"ci_default_git_depth,omitempty" json:"ci_default_git_depth,omitempty"`
 	CIForwardDeploymentEnabled                *bool                                `url:"ci_forward_deployment_enabled,omitempty" json:"ci_forward_deployment_enabled,omitempty"`
+	CIForwardDeploymentRollbackAllowed        *bool                                `url:"ci_forward_deployment_rollback_allowed,omitempty" json:"ci_forward_deployment_rollback_allowed,omitempty"`
 	CISeperateCache                           *bool                                `url:"ci_separated_caches,omitempty" json:"ci_separated_caches,omitempty"`
 	CIRestrictPipelineCancellationRole        *AccessControlValue                  `url:"ci_restrict_pipeline_cancellation_role,omitempty" json:"ci_restrict_pipeline_cancellation_role,omitempty"`
 	ContainerExpirationPolicyAttributes       *ContainerExpirationPolicyAttributes `url:"container_expiration_policy_attributes,omitempty" json:"container_expiration_policy_attributes,omitempty"`

--- a/projects_test.go
+++ b/projects_test.go
@@ -371,6 +371,8 @@ func TestGetProjectByID(t *testing.T) {
 			  "name_regex_keep": null,
 			  "next_run_at": "2020-01-07T21:42:58.658Z"
 			},
+			"ci_forward_deployment_enabled": true,
+			"ci_forward_deployment_rollback_allowed": true,
 			"ci_restrict_pipeline_cancellation_role": "developer",
 			"packages_enabled": false,
 			"build_coverage_regex": "Total.*([0-9]{1,3})%"
@@ -387,6 +389,8 @@ func TestGetProjectByID(t *testing.T) {
 		},
 		PackagesEnabled:                    false,
 		BuildCoverageRegex:                 `Total.*([0-9]{1,3})%`,
+		CIForwardDeploymentEnabled:         true,
+		CIForwardDeploymentRollbackAllowed: true,
 		CIRestrictPipelineCancellationRole: "developer",
 	}
 


### PR DESCRIPTION
GitLab 16.3 [added a new `ci_forward_deployment_rollback_allowed` attribute](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/126788) to the [List and Edit project APIs](https://docs.gitlab.com/ee/api/projects.html#list-all-projects). This option compliments the existing `ci_forward_deployment_enabled` option by [configuring whether job retries for rollback deployments should be allowed](https://docs.gitlab.com/ee/ci/pipelines/settings.html#prevent-outdated-deployment-jobs).

This PR adds support for reading and updating this attribute.