### PR TITLE
Support for the GitLab for Slack app

### DIFF
--- a/services.go
+++ b/services.go
@@ -756,6 +756,132 @@ func (s *ServicesService) DeleteGithubService(pid interface{}, options ...Reques
 	return s.client.Do(req, nil)
 }
 
+// SlackApplication represents GitLab for slack application settings.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/integrations.html#gitlab-for-slack-app
+type SlackApplication struct {
+	Service
+	Properties *SlackApplicationProperties `json:"properties"`
+}
+
+// SlackApplicationProperties represents GitLab for slack application specific properties.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/integrations.html#gitlab-for-slack-app
+type SlackApplicationProperties struct {
+	Channel                   string `json:"channel"`
+	NotifyOnlyBrokenPipelines bool   `json:"notify_only_broken_pipelines"`
+	BranchesToBeNotified      string `json:"branches_to_be_notified"`
+	AlertEvents               bool   `json:"alert_events"`
+	IssuesEvents              bool   `json:"issues_events"`
+	ConfidentialIssuesEvents  bool   `json:"confidential_issues_events"`
+	MergeRequestsEvents       bool   `json:"merge_requests_events"`
+	NoteEvents                bool   `json:"note_events"`
+	ConfidentialNoteEvents    bool   `json:"confidential_note_events"`
+	DeploymentEvents          bool   `json:"deployment_events"`
+	IncidentsEvents           bool   `json:"incidents_events"`
+	PipelineEvents            bool   `json:"pipeline_events"`
+	PushEvents                bool   `json:"push_events"`
+	TagPushEvents             bool   `json:"tag_push_events"`
+	VulnerabilityEvents       bool   `json:"vulnerability_events"`
+	WikiPageEvents            bool   `json:"wiki_page_events"`
+
+	// Deprecated: This parameter has been replaced with BranchesToBeNotified.
+	NotifyOnlyDefaultBranch bool `json:"notify_only_default_branch"`
+}
+
+// GetSlackApplication gets the GitLab for Slack app integration settings for a
+// project.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/integrations.html#get-gitlab-for-slack-app-settings
+func (s *ServicesService) GetSlackApplication(pid interface{}, options ...RequestOptionFunc) (*SlackApplication, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/integrations/gitlab-slack-application", PathEscape(project))
+
+	req, err := s.client.NewRequest(http.MethodGet, u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	svc := new(SlackApplication)
+	resp, err := s.client.Do(req, svc)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return svc, resp, nil
+}
+
+// SetSlackApplicationOptions represents the available SetSlackApplication()
+// options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/integrations.html#set-up-gitlab-for-slack-app
+type SetSlackApplicationOptions struct {
+	Channel                   *string `url:"channel,omitempty" json:"channel,omitempty"`
+	NotifyOnlyBrokenPipelines *bool   `url:"notify_only_broken_pipelines,omitempty" json:"notify_only_broken_pipelines,omitempty"`
+	BranchesToBeNotified      *string `url:"branches_to_be_notified,omitempty" json:"branches_to_be_notified,omitempty"`
+	AlertEvents               *bool   `url:"alert_events,omitempty" json:"alert_events,omitempty"`
+	IssuesEvents              *bool   `url:"issues_events,omitempty" json:"issues_events,omitempty"`
+	ConfidentialIssuesEvents  *bool   `url:"confidential_issues_events,omitempty" json:"confidential_issues_events,omitempty"`
+	MergeRequestsEvents       *bool   `url:"merge_requests_events,omitempty" json:"merge_requests_events,omitempty"`
+	NoteEvents                *bool   `url:"note_events,omitempty" json:"note_events,omitempty"`
+	ConfidentialNoteEvents    *bool   `url:"confidential_note_events,omitempty" json:"confidential_note_events,omitempty"`
+	DeploymentEvents          *bool   `url:"deployment_events,omitempty" json:"deployment_events,omitempty"`
+	IncidentsEvents           *bool   `url:"incidents_events,omitempty" json:"incidents_events,omitempty"`
+	PipelineEvents            *bool   `url:"pipeline_events,omitempty" json:"pipeline_events,omitempty"`
+	PushEvents                *bool   `url:"push_events,omitempty" json:"push_events,omitempty"`
+	TagPushEvents             *bool   `url:"tag_push_events,omitempty" json:"tag_push_events,omitempty"`
+	VulnerabilityEvents       *bool   `url:"vulnerability_events,omitempty" json:"vulnerability_events,omitempty"`
+	WikiPageEvents            *bool   `url:"wiki_page_events,omitempty" json:"wiki_page_events,omitempty"`
+
+	// Deprecated: This parameter has been replaced with BranchesToBeNotified.
+	NotifyOnlyDefaultBranch *bool `url:"notify_only_default_branch,omitempty" json:"notify_only_default_branch,omitempty"`
+}
+
+// SetSlackApplication update the GitLab for Slack app integration for a project.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/integrations.html#set-up-gitlab-for-slack-app
+func (s *ServicesService) SetSlackApplication(pid interface{}, opt *SetSlackApplicationOptions, options ...RequestOptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/integrations/gitlab-slack-application", PathEscape(project))
+
+	req, err := s.client.NewRequest(http.MethodPut, u, opt, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// DisableSlackApplication disable the GitLab for Slack app integration for a project.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/integrations.html#disable-gitlab-for-slack-app
+func (s *ServicesService) DisableSlackApplication(pid interface{}, options ...RequestOptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/integrations/gitlab-slack-application", PathEscape(project))
+
+	req, err := s.client.NewRequest(http.MethodDelete, u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
 // SetGitLabCIServiceOptions represents the available SetGitLabCIService()
 // options.
 //

--- a/services_test.go
+++ b/services_test.go
@@ -330,6 +330,52 @@ func TestDeleteEmailsOnPushService(t *testing.T) {
 	}
 }
 
+func TestGetSlackApplication(t *testing.T) {
+	mux, client := setup(t)
+
+	mux.HandleFunc("/api/v4/projects/1/integrations/gitlab-slack-application", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, `{"id":1}`)
+	})
+	want := &SlackApplication{Service: Service{ID: 1}}
+
+	service, _, err := client.Services.GetSlackApplication(1)
+	if err != nil {
+		t.Fatalf("Services.GetSlackApplication returns an error: %v", err)
+	}
+	if !reflect.DeepEqual(want, service) {
+		t.Errorf("Services.GetSlackApplication returned %+v, want %+v", service, want)
+	}
+}
+
+func TestSetSlackApplication(t *testing.T) {
+	mux, client := setup(t)
+
+	mux.HandleFunc("/api/v4/projects/1/integrations/gitlab-slack-application", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPut)
+	})
+
+	opt := &SetSlackApplicationOptions{Channel: Ptr("#channel1"), NoteEvents: Ptr(true), AlertEvents: Ptr(true)}
+
+	_, err := client.Services.SetSlackApplication(1, opt)
+	if err != nil {
+		t.Fatalf("Services.SetSlackApplication returns an error: %v", err)
+	}
+}
+
+func TestDisableSlackApplication(t *testing.T) {
+	mux, client := setup(t)
+
+	mux.HandleFunc("/api/v4/projects/1/integrations/gitlab-slack-application", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodDelete)
+	})
+
+	_, err := client.Services.DisableSlackApplication(1)
+	if err != nil {
+		t.Fatalf("Services.DisableSlackApplication returns an error: %v", err)
+	}
+}
+
 func TestGetJiraService(t *testing.T) {
 	mux, client := setup(t)
 


### PR DESCRIPTION
REST API support for the GitLab for Slack app in [Gitlab 16.9](https://about.gitlab.com/releases/2024/02/15/gitlab-16-9-released/#rest-api-support-for-the-gitlab-for-slack-app)

- You cannot create a GitLab for Slack app from the API. Instead, you must [install the app](https://docs.gitlab.com/ee/user/project/integrations/gitlab_slack_application.html#install-the-gitlab-for-slack-app) from the GitLab UI.

- You can then retrieve the integration settings and update or disable the app for a project.
