### PR TITLE
Jenkins integration enable ssl verification

### DIFF
--- a/services.go
+++ b/services.go
@@ -900,7 +900,7 @@ func (s *ServicesService) GetJenkinsCIService(pid interface{}, options ...Reques
 // https://docs.gitlab.com/ee/api/services.html#jenkins-ci
 type SetJenkinsCIServiceOptions struct {
 	URL                   *string `url:"jenkins_url,omitempty" json:"jenkins_url,omitempty"`
-	EnableSSLVerification *string `url:"enable_ssl_verification,omitempty" json:"enable_ssl_verification,omitempty"`
+	EnableSSLVerification *bool   `url:"enable_ssl_verification,omitempty" json:"enable_ssl_verification,omitempty"`
 	ProjectName           *string `url:"project_name,omitempty" json:"project_name,omitempty"`
 	Username              *string `url:"username,omitempty" json:"username,omitempty"`
 	Password              *string `url:"password,omitempty" json:"password,omitempty"`

--- a/services.go
+++ b/services.go
@@ -899,13 +899,14 @@ func (s *ServicesService) GetJenkinsCIService(pid interface{}, options ...Reques
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/services.html#jenkins-ci
 type SetJenkinsCIServiceOptions struct {
-	URL                 *string `url:"jenkins_url,omitempty" json:"jenkins_url,omitempty"`
-	ProjectName         *string `url:"project_name,omitempty" json:"project_name,omitempty"`
-	Username            *string `url:"username,omitempty" json:"username,omitempty"`
-	Password            *string `url:"password,omitempty" json:"password,omitempty"`
-	PushEvents          *bool   `url:"push_events,omitempty" json:"push_events,omitempty"`
-	MergeRequestsEvents *bool   `url:"merge_requests_events,omitempty" json:"merge_requests_events,omitempty"`
-	TagPushEvents       *bool   `url:"tag_push_events,omitempty" json:"tag_push_events,omitempty"`
+	URL                   *string `url:"jenkins_url,omitempty" json:"jenkins_url,omitempty"`
+	EnableSSLVerification *string `url:"enable_ssl_verification,omitempty" json:"enable_ssl_verification,omitempty"`
+	ProjectName           *string `url:"project_name,omitempty" json:"project_name,omitempty"`
+	Username              *string `url:"username,omitempty" json:"username,omitempty"`
+	Password              *string `url:"password,omitempty" json:"password,omitempty"`
+	PushEvents            *bool   `url:"push_events,omitempty" json:"push_events,omitempty"`
+	MergeRequestsEvents   *bool   `url:"merge_requests_events,omitempty" json:"merge_requests_events,omitempty"`
+	TagPushEvents         *bool   `url:"tag_push_events,omitempty" json:"tag_push_events,omitempty"`
 }
 
 // SetJenkinsCIService sets Jenkins service for a project


### PR DESCRIPTION
This PR adds a missing `EnableSSLVerification` to`SetJenkinsCIServiceOptions`.

GitLab API docs: https://docs.gitlab.com/ee/api/integrations.html#set-up-jenkins