### PR TITLE
Add group_inheritance_type attribute to project/group protected environments

### DIFF
--- a/group_protected_environments.go
+++ b/group_protected_environments.go
@@ -52,6 +52,7 @@ type GroupEnvironmentAccessDescription struct {
 	AccessLevelDescription string           `json:"access_level_description"`
 	UserID                 int              `json:"user_id"`
 	GroupID                int              `json:"group_id"`
+	GroupInheritanceType   int              `json:"group_inheritance_type"`
 }
 
 // GroupEnvironmentApprovalRule represents the approval rules for a group-level
@@ -146,9 +147,10 @@ type ProtectGroupEnvironmentOptions struct {
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/group_protected_environments.html#protect-a-single-environment
 type GroupEnvironmentAccessOptions struct {
-	AccessLevel *AccessLevelValue `url:"access_level,omitempty" json:"access_level,omitempty"`
-	UserID      *int              `url:"user_id,omitempty" json:"user_id,omitempty"`
-	GroupID     *int              `url:"group_id,omitempty" json:"group_id,omitempty"`
+	AccessLevel          *AccessLevelValue `url:"access_level,omitempty" json:"access_level,omitempty"`
+	UserID               *int              `url:"user_id,omitempty" json:"user_id,omitempty"`
+	GroupID              *int              `url:"group_id,omitempty" json:"group_id,omitempty"`
+	GroupInheritanceType *int              `url:"group_inheritance_type,omitempty" json:"group_inheritance_type,omitempty"`
 }
 
 // GroupEnvironmentApprovalRuleOptions represents the approval rules for a
@@ -208,11 +210,12 @@ type UpdateGroupProtectedEnvironmentOptions struct {
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/group_protected_environments.html#update-a-protected-environment
 type UpdateGroupEnvironmentAccessOptions struct {
-	AccessLevel *AccessLevelValue `url:"access_level,omitempty" json:"access_level,omitempty"`
-	ID          *int              `url:"id,omitempty" json:"id,omitempty"`
-	UserID      *int              `url:"user_id,omitempty" json:"user_id,omitempty"`
-	GroupID     *int              `url:"group_id,omitempty" json:"group_id,omitempty"`
-	Destroy     *bool             `url:"_destroy,omitempty" json:"_destroy,omitempty"`
+	AccessLevel          *AccessLevelValue `url:"access_level,omitempty" json:"access_level,omitempty"`
+	ID                   *int              `url:"id,omitempty" json:"id,omitempty"`
+	UserID               *int              `url:"user_id,omitempty" json:"user_id,omitempty"`
+	GroupID              *int              `url:"group_id,omitempty" json:"group_id,omitempty"`
+	GroupInheritanceType *int              `url:"group_inheritance_type,omitempty" json:"group_inheritance_type,omitempty"`
+	Destroy              *bool             `url:"_destroy,omitempty" json:"_destroy,omitempty"`
 }
 
 // UpdateGroupEnvironmentApprovalRuleOptions represents the updates to the

--- a/group_protected_environments_test.go
+++ b/group_protected_environments_test.go
@@ -34,7 +34,8 @@ func TestGroupListProtectedEnvironments(t *testing.T) {
       "deploy_access_levels": [
         {
           "access_level": 40,
-          "access_level_description": "Maintainers"
+          "access_level_description": "Maintainers",
+          "group_inheritance_type": 0
         }
       ],
       "required_approval_count": 1,
@@ -126,7 +127,8 @@ func TestGroupGetProtectedEnvironment(t *testing.T) {
       "deploy_access_levels": [
         {
           "access_level": 30,
-          "access_level_description": "Developers + Maintainers"
+          "access_level_description": "Developers + Maintainers",
+          "group_inheritance_type": 1
         }
       ],
       "required_approval_count": 1,
@@ -150,6 +152,7 @@ func TestGroupGetProtectedEnvironment(t *testing.T) {
 			{
 				AccessLevel:            30,
 				AccessLevelDescription: "Developers + Maintainers",
+				GroupInheritanceType:   1,
 			},
 		},
 		RequiredApprovalCount: 1,
@@ -177,7 +180,8 @@ func TestGroupGetProtectedEnvironment(t *testing.T) {
       "deploy_access_levels": [
         {
           "access_level": 30,
-          "access_level_description": "Developers + Maintainers"
+          "access_level_description": "Developers + Maintainers",
+          "group_inheritance_type": 1
         }
       ]
     }`, environmentName)
@@ -189,6 +193,7 @@ func TestGroupGetProtectedEnvironment(t *testing.T) {
 			{
 				AccessLevel:            30,
 				AccessLevelDescription: "Developers + Maintainers",
+				GroupInheritanceType:   1,
 			},
 		},
 	}
@@ -211,7 +216,8 @@ func TestGroupProtectEnvironments(t *testing.T) {
       "deploy_access_levels": [
         {
           "access_level": 30,
-          "access_level_description": "Developers + Maintainers"
+          "access_level_description": "Developers + Maintainers",
+          "group_inheritance_type": 0
         }
       ],
       "required_approval_count": 2,
@@ -318,7 +324,8 @@ func TestGroupUpdateProtectedEnvironments(t *testing.T) {
         {
           "id": 42,
           "access_level": 30,
-          "access_level_description": "Developers + Maintainers"
+          "access_level_description": "Developers + Maintainers",
+          "group_inheritance_type": 1
         }
       ],
       "required_approval_count": 2,
@@ -343,6 +350,7 @@ func TestGroupUpdateProtectedEnvironments(t *testing.T) {
 				ID:                     42,
 				AccessLevel:            30,
 				AccessLevelDescription: "Developers + Maintainers",
+				GroupInheritanceType:   1,
 			},
 		},
 		RequiredApprovalCount: 2,
@@ -359,13 +367,16 @@ func TestGroupUpdateProtectedEnvironments(t *testing.T) {
 	opt := &UpdateGroupProtectedEnvironmentOptions{
 		Name: Ptr(environmentName),
 		DeployAccessLevels: &[]*UpdateGroupEnvironmentAccessOptions{
-			{AccessLevel: Ptr(AccessLevelValue(30))},
+			{
+				AccessLevel:          Ptr(AccessLevelValue(30)),
+				GroupInheritanceType: Ptr(1),
+			},
 		},
 		RequiredApprovalCount: Ptr(2),
 		ApprovalRules: &[]*UpdateGroupEnvironmentApprovalRuleOptions{
 			{
 				GroupID:                Ptr(10),
-				AccessLevel:            Ptr(AccessLevelValue(0)),
+				AccessLevel:            Ptr(AccessLevelValue(5)),
 				AccessLevelDescription: Ptr("devops"),
 			},
 		},
@@ -420,7 +431,8 @@ func TestGroupUpdateProtectedEnvironments(t *testing.T) {
         {
           "id": 42,
           "access_level": 30,
-          "access_level_description": "Developers + Maintainers"
+          "access_level_description": "Developers + Maintainers",
+          "group_inheritance_type": 0
         }
       ],
 	  "required_approval_count": 2
@@ -434,6 +446,7 @@ func TestGroupUpdateProtectedEnvironments(t *testing.T) {
 				ID:                     42,
 				AccessLevel:            30,
 				AccessLevelDescription: "Developers + Maintainers",
+				GroupInheritanceType:   0,
 			},
 		},
 		RequiredApprovalCount: 2,
@@ -443,8 +456,9 @@ func TestGroupUpdateProtectedEnvironments(t *testing.T) {
 		Name: Ptr(environmentName),
 		DeployAccessLevels: &[]*UpdateGroupEnvironmentAccessOptions{
 			{
-				ID:          Ptr(42),
-				AccessLevel: Ptr(AccessLevelValue(30)),
+				ID:                   Ptr(42),
+				AccessLevel:          Ptr(AccessLevelValue(30)),
+				GroupInheritanceType: Ptr(0),
 			},
 		},
 	}
@@ -505,7 +519,7 @@ func TestGroupUpdateProtectedEnvironments(t *testing.T) {
 			{
 				ID:                     Ptr(1),
 				GroupID:                Ptr(10),
-				AccessLevel:            Ptr(AccessLevelValue(0)),
+				AccessLevel:            Ptr(AccessLevelValue(5)),
 				AccessLevelDescription: Ptr("devops"),
 			},
 		},

--- a/protected_environments.go
+++ b/protected_environments.go
@@ -52,6 +52,7 @@ type EnvironmentAccessDescription struct {
 	AccessLevelDescription string           `json:"access_level_description"`
 	UserID                 int              `json:"user_id"`
 	GroupID                int              `json:"group_id"`
+	GroupInheritanceType   int              `json:"group_inheritance_type"`
 }
 
 // EnvironmentApprovalRule represents the approval rules for a protected
@@ -146,9 +147,10 @@ type ProtectRepositoryEnvironmentsOptions struct {
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/protected_environments.html#protect-a-single-environment
 type EnvironmentAccessOptions struct {
-	AccessLevel *AccessLevelValue `url:"access_level,omitempty" json:"access_level,omitempty"`
-	UserID      *int              `url:"user_id,omitempty" json:"user_id,omitempty"`
-	GroupID     *int              `url:"group_id,omitempty" json:"group_id,omitempty"`
+	AccessLevel          *AccessLevelValue `url:"access_level,omitempty" json:"access_level,omitempty"`
+	UserID               *int              `url:"user_id,omitempty" json:"user_id,omitempty"`
+	GroupID              *int              `url:"group_id,omitempty" json:"group_id,omitempty"`
+	GroupInheritanceType *int              `url:"group_inheritance_type,omitempty" json:"group_inheritance_type,omitempty"`
 }
 
 // EnvironmentApprovalRuleOptions represents the approval rules for a protected
@@ -209,11 +211,12 @@ type UpdateProtectedEnvironmentsOptions struct {
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/protected_environments.html#update-a-protected-environment
 type UpdateEnvironmentAccessOptions struct {
-	AccessLevel *AccessLevelValue `url:"access_level,omitempty" json:"access_level,omitempty"`
-	ID          *int              `url:"id,omitempty" json:"id,omitempty"`
-	UserID      *int              `url:"user_id,omitempty" json:"user_id,omitempty"`
-	GroupID     *int              `url:"group_id,omitempty" json:"group_id,omitempty"`
-	Destroy     *bool             `url:"_destroy,omitempty" json:"_destroy,omitempty"`
+	AccessLevel          *AccessLevelValue `url:"access_level,omitempty" json:"access_level,omitempty"`
+	ID                   *int              `url:"id,omitempty" json:"id,omitempty"`
+	UserID               *int              `url:"user_id,omitempty" json:"user_id,omitempty"`
+	GroupID              *int              `url:"group_id,omitempty" json:"group_id,omitempty"`
+	GroupInheritanceType *int              `url:"group_inheritance_type,omitempty" json:"group_inheritance_type,omitempty"`
+	Destroy              *bool             `url:"_destroy,omitempty" json:"_destroy,omitempty"`
 }
 
 // UpdateEnvironmentApprovalRuleOptions represents the updates to the approval

--- a/protected_environments_test.go
+++ b/protected_environments_test.go
@@ -34,7 +34,8 @@ func TestListProtectedEnvironments(t *testing.T) {
       "deploy_access_levels": [
         {
           "access_level": 40,
-          "access_level_description": "Maintainers"
+          "access_level_description": "Maintainers",
+          "group_inheritance_type": 1
         }
       ],
       "required_approval_count": 1,
@@ -76,6 +77,7 @@ func TestListProtectedEnvironments(t *testing.T) {
 				{
 					AccessLevel:            40,
 					AccessLevelDescription: "Maintainers",
+					GroupInheritanceType:   1,
 				},
 			},
 			RequiredApprovalCount: 1,
@@ -209,7 +211,8 @@ func TestProtectRepositoryEnvironments(t *testing.T) {
       "deploy_access_levels": [
         {
           "access_level": 30,
-          "access_level_description": "Developers + Maintainers"
+          "access_level_description": "Developers + Maintainers",
+          "group_inheritance_type": 1
         }
       ],
       "required_approval_count": 2,
@@ -233,6 +236,7 @@ func TestProtectRepositoryEnvironments(t *testing.T) {
 			{
 				AccessLevel:            30,
 				AccessLevelDescription: "Developers + Maintainers",
+				GroupInheritanceType:   1,
 			},
 		},
 		RequiredApprovalCount: 2,
@@ -314,7 +318,8 @@ func TestUpdateProtectedEnvironments(t *testing.T) {
         {
           "id": 42,
           "access_level": 30,
-          "access_level_description": "Developers + Maintainers"
+          "access_level_description": "Developers + Maintainers",
+          "group_inheritance_type": 1
         }
       ],
       "required_approval_count": 2,
@@ -339,6 +344,7 @@ func TestUpdateProtectedEnvironments(t *testing.T) {
 				ID:                     42,
 				AccessLevel:            30,
 				AccessLevelDescription: "Developers + Maintainers",
+				GroupInheritanceType:   1,
 			},
 		},
 		RequiredApprovalCount: 2,
@@ -355,7 +361,10 @@ func TestUpdateProtectedEnvironments(t *testing.T) {
 	opt := &UpdateProtectedEnvironmentsOptions{
 		Name: Ptr(environmentName),
 		DeployAccessLevels: &[]*UpdateEnvironmentAccessOptions{
-			{AccessLevel: Ptr(AccessLevelValue(30))},
+			{
+				AccessLevel:          Ptr(AccessLevelValue(30)),
+				GroupInheritanceType: Ptr(1),
+			},
 		},
 		RequiredApprovalCount: Ptr(2),
 		ApprovalRules: &[]*UpdateEnvironmentApprovalRuleOptions{
@@ -380,7 +389,8 @@ func TestUpdateProtectedEnvironments(t *testing.T) {
         {
           "id": 42,
           "access_level": 30,
-          "access_level_description": "Developers + Maintainers"
+          "access_level_description": "Developers + Maintainers",
+          "group_inheritance_type": 1
         }
       ]
     }`, environmentName)
@@ -393,6 +403,7 @@ func TestUpdateProtectedEnvironments(t *testing.T) {
 				ID:                     42,
 				AccessLevel:            30,
 				AccessLevelDescription: "Developers + Maintainers",
+				GroupInheritanceType:   1,
 			},
 		},
 	}
@@ -416,7 +427,8 @@ func TestUpdateProtectedEnvironments(t *testing.T) {
         {
           "id": 42,
           "access_level": 30,
-          "access_level_description": "Developers + Maintainers"
+          "access_level_description": "Developers + Maintainers",
+          "group_inheritance_type": 0
         }
       ],
 	  "required_approval_count": 2


### PR DESCRIPTION
Added support for `group_inheritance_type` attribute to both project and group protected environment resources, specifically under `deploy_access_levels` where it was missing.

https://docs.gitlab.com/ee/api/protected_environments.html#group-inheritance-types