### PR TITLE
feat: add Reset approvals of a merge request method

### DIFF
--- a/merge_request_approvals.go
+++ b/merge_request_approvals.go
@@ -180,6 +180,26 @@ func (s *MergeRequestApprovalsService) UnapproveMergeRequest(pid interface{}, mr
 	return s.client.Do(req, nil)
 }
 
+// ResetApprovalsOfMergeRequest clear all approvals of merge request on GitLab.
+// Available only for bot users based on project or group tokens.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/merge_request_approvals.html#reset-approvals-of-a-merge-request
+func (s *MergeRequestApprovalsService) ResetApprovalsOfMergeRequest(pid interface{}, mr int, options ...RequestOptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/merge_requests/%d/reset_approvals", PathEscape(project), mr)
+
+	req, err := s.client.NewRequest(http.MethodPut, u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
 // ChangeMergeRequestApprovalConfigurationOptions represents the available
 // ChangeMergeRequestApprovalConfiguration() options.
 //


### PR DESCRIPTION
This pull request **implements the ability to clear all approvals of merge request**.

In example, you may need to use this to reset approvals from merge request when new commit added to it (because now gitlab does not reset approvals automaticly).

Gitlab documentation: https://docs.gitlab.com/ee/api/merge_request_approvals.html#reset-approvals-of-a-merge-request