### PR TITLE
Add the approvals_before_merge parameter to CreateMergeRequestOptions

### DIFF
--- a/merge_requests.go
+++ b/merge_requests.go
@@ -682,19 +682,20 @@ func (s *MergeRequestsService) GetIssuesClosedOnMerge(pid interface{}, mergeRequ
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/merge_requests.html#create-mr
 type CreateMergeRequestOptions struct {
-	Title              *string       `url:"title,omitempty" json:"title,omitempty"`
-	Description        *string       `url:"description,omitempty" json:"description,omitempty"`
-	SourceBranch       *string       `url:"source_branch,omitempty" json:"source_branch,omitempty"`
-	TargetBranch       *string       `url:"target_branch,omitempty" json:"target_branch,omitempty"`
-	Labels             *LabelOptions `url:"labels,comma,omitempty" json:"labels,omitempty"`
-	AssigneeID         *int          `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
-	AssigneeIDs        *[]int        `url:"assignee_ids,omitempty" json:"assignee_ids,omitempty"`
-	ReviewerIDs        *[]int        `url:"reviewer_ids,omitempty" json:"reviewer_ids,omitempty"`
-	TargetProjectID    *int          `url:"target_project_id,omitempty" json:"target_project_id,omitempty"`
-	MilestoneID        *int          `url:"milestone_id,omitempty" json:"milestone_id,omitempty"`
-	RemoveSourceBranch *bool         `url:"remove_source_branch,omitempty" json:"remove_source_branch,omitempty"`
-	Squash             *bool         `url:"squash,omitempty" json:"squash,omitempty"`
-	AllowCollaboration *bool         `url:"allow_collaboration,omitempty" json:"allow_collaboration,omitempty"`
+	Title                *string       `url:"title,omitempty" json:"title,omitempty"`
+	Description          *string       `url:"description,omitempty" json:"description,omitempty"`
+	SourceBranch         *string       `url:"source_branch,omitempty" json:"source_branch,omitempty"`
+	TargetBranch         *string       `url:"target_branch,omitempty" json:"target_branch,omitempty"`
+	Labels               *LabelOptions `url:"labels,comma,omitempty" json:"labels,omitempty"`
+	AssigneeID           *int          `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
+	AssigneeIDs          *[]int        `url:"assignee_ids,omitempty" json:"assignee_ids,omitempty"`
+	ReviewerIDs          *[]int        `url:"reviewer_ids,omitempty" json:"reviewer_ids,omitempty"`
+	TargetProjectID      *int          `url:"target_project_id,omitempty" json:"target_project_id,omitempty"`
+	MilestoneID          *int          `url:"milestone_id,omitempty" json:"milestone_id,omitempty"`
+	RemoveSourceBranch   *bool         `url:"remove_source_branch,omitempty" json:"remove_source_branch,omitempty"`
+	Squash               *bool         `url:"squash,omitempty" json:"squash,omitempty"`
+	AllowCollaboration   *bool         `url:"allow_collaboration,omitempty" json:"allow_collaboration,omitempty"`
+	ApprovalsBeforeMerge *int          `url:"approvals_before_merge,omitempty" json:"approvals_before_merge,omitempty"`
 }
 
 // CreateMergeRequest creates a new merge request.


### PR DESCRIPTION
I use the `go-gitlab` project to interact with the GitLab API, but I found that some parameters are missing.

![image](https://github.com/xanzy/go-gitlab/assets/3860021/7ba43069-d963-4d20-b474-a7c913bba212)

https://docs.gitlab.com/ee/api/merge_requests.html#create-mr

I hope to add the parameter `approvals_before_merge` to control whether MR requires approvals.