### PR TITLE
Add support for SHA256 in PackageFile

### DIFF
--- a/packages.go
+++ b/packages.go
@@ -89,13 +89,14 @@ func (s PackageTag) String() string {
 //
 // GitLab API docs: https://docs.gitlab.com/ee/api/packages.html
 type PackageFile struct {
-	ID        int         `json:"id"`
-	PackageID int         `json:"package_id"`
-	CreatedAt *time.Time  `json:"created_at"`
-	FileName  string      `json:"file_name"`
-	Size      int         `json:"size"`
-	FileMD5   string      `json:"file_md5"`
-	FileSHA1  string      `json:"file_sha1"`
+	ID         int         `json:"id"`
+	PackageID  int         `json:"package_id"`
+	CreatedAt  *time.Time  `json:"created_at"`
+	FileName   string      `json:"file_name"`
+	Size       int         `json:"size"`
+	FileMD5    string      `json:"file_md5"`
+	FileSHA1   string      `json:"file_sha1,omitempty"`
+	FileSHA256 string      `json:"file_sha256,omitempty"`
 	Pipeline  *[]Pipeline `json:"pipelines"`
 }
 

--- a/packages.go
+++ b/packages.go
@@ -95,9 +95,9 @@ type PackageFile struct {
 	FileName   string      `json:"file_name"`
 	Size       int         `json:"size"`
 	FileMD5    string      `json:"file_md5"`
-	FileSHA1   string      `json:"file_sha1,omitempty"`
-	FileSHA256 string      `json:"file_sha256,omitempty"`
-	Pipeline  *[]Pipeline `json:"pipelines"`
+	FileSHA1   string      `json:"file_sha1"`
+	FileSHA256 string      `json:"file_sha256"`
+	Pipeline   *[]Pipeline `json:"pipelines"`
 }
 
 func (s PackageFile) String() string {

--- a/packages_test.go
+++ b/packages_test.go
@@ -105,12 +105,13 @@ func TestPackagesService_ListPackageFiles(t *testing.T) {
 	})
 
 	want := []*PackageFile{{
-		ID:        25,
-		PackageID: 4,
-		FileName:  "my-app-1.5-20181107.152550-1.jar",
-		Size:      2421,
-		FileMD5:   "58e6a45a629910c6ff99145a688971ac",
-		FileSHA1:  "ebd193463d3915d7e22219f52740056dfd26cbfe",
+		ID:         25,
+		PackageID:  4,
+		FileName:   "my-app-1.5-20181107.152550-1.jar",
+		Size:       2421,
+		FileMD5:    "58e6a45a629910c6ff99145a688971ac",
+		FileSHA1:   "ebd193463d3915d7e22219f52740056dfd26cbfe",
+		FileSHA256: "a903393463d3915d7e22219f52740056dfd26cbfeff321b",
 	}}
 
 	ps, resp, err := client.Packages.ListPackageFiles(3, 4, nil)


### PR DESCRIPTION
This information is needed when trying to directly download Pypi packages. Check https://docs.gitlab.com/ee/api/packages/pypi.html#download-a-package-file-from-a-project

Fixes #1901 