### PR TITLE
Add support for service account token expiration

### DIFF
--- a/group_serviceaccounts.go
+++ b/group_serviceaccounts.go
@@ -62,8 +62,9 @@ func (s *GroupsService) CreateServiceAccount(gid interface{}, options ...Request
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/groups.html#create-personal-access-token-for-service-account-user
 type CreateServiceAccountPersonalAccessTokenOptions struct {
-	Scopes *[]string `url:"scopes,omitempty" json:"scopes,omitempty"`
-	Name   *string   `url:"name,omitempty" json:"name,omitempty"`
+	Scopes    *[]string `url:"scopes,omitempty" json:"scopes,omitempty"`
+	Name      *string   `url:"name,omitempty" json:"name,omitempty"`
+	ExpiresAt *string   `url:"expires_at,omitempty" json:"expires_at,omitempty"`
 }
 
 // CreateServiceAccountPersonalAccessToken add a new Personal Access Token for a

--- a/group_serviceaccounts.go
+++ b/group_serviceaccounts.go
@@ -64,7 +64,7 @@ func (s *GroupsService) CreateServiceAccount(gid interface{}, options ...Request
 type CreateServiceAccountPersonalAccessTokenOptions struct {
 	Scopes    *[]string `url:"scopes,omitempty" json:"scopes,omitempty"`
 	Name      *string   `url:"name,omitempty" json:"name,omitempty"`
-	ExpiresAt *string   `url:"expires_at,omitempty" json:"expires_at,omitempty"`
+	ExpiresAt *ISOTime  `url:"expires_at,omitempty" json:"expires_at,omitempty"`
 }
 
 // CreateServiceAccountPersonalAccessToken add a new Personal Access Token for a

--- a/group_serviceaccounts_test.go
+++ b/group_serviceaccounts_test.go
@@ -73,8 +73,9 @@ func TestCreateServiceAccountPersonalAccessToken(t *testing.T) {
       }`)
 	})
 	options := &CreateServiceAccountPersonalAccessTokenOptions{
-		Scopes: Ptr([]string{"api"}),
-		Name:   Ptr("service_account_token"),
+		Scopes:    Ptr([]string{"api"}),
+		Name:      Ptr("service_account_token"),
+		ExpiresAt: Ptr("2024-06-12"),
 	}
 	pat, _, err := client.Groups.CreateServiceAccountPersonalAccessToken(1, 57, options)
 	if err != nil {

--- a/group_serviceaccounts_test.go
+++ b/group_serviceaccounts_test.go
@@ -18,11 +18,12 @@ package gitlab
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"net/http"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreateServiceAccount(t *testing.T) {

--- a/group_serviceaccounts_test.go
+++ b/group_serviceaccounts_test.go
@@ -18,6 +18,7 @@ package gitlab
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/require"
 	"net/http"
 	"reflect"
 	"testing"
@@ -72,10 +73,14 @@ func TestCreateServiceAccountPersonalAccessToken(t *testing.T) {
       	"token":"random_token"
       }`)
 	})
+
+	expireTime, err := ParseISOTime("2024-06-12")
+	require.NoError(t, err)
+
 	options := &CreateServiceAccountPersonalAccessTokenOptions{
 		Scopes:    Ptr([]string{"api"}),
 		Name:      Ptr("service_account_token"),
-		ExpiresAt: Ptr("2024-06-12"),
+		ExpiresAt: Ptr(expireTime),
 	}
 	pat, _, err := client.Groups.CreateServiceAccountPersonalAccessToken(1, 57, options)
 	if err != nil {


### PR DESCRIPTION
When creating a Personal Access Token for a Service Account, it's possible to also pass an expiry date (optional).
This PR adds support for this.