### PR TITLE
Add new custom role permissions, allow GET to retrieve MemberRole

### DIFF
--- a/group_members.go
+++ b/group_members.go
@@ -56,6 +56,7 @@ type GroupMember struct {
 	AccessLevel       AccessLevelValue         `json:"access_level"`
 	Email             string                   `json:"email,omitempty"`
 	GroupSAMLIdentity *GroupMemberSAMLIdentity `json:"group_saml_identity"`
+	MemberRole        *MemberRole              `json:"member_role"`
 }
 
 // ListGroupMembersOptions represents the available ListGroupMembers() and

--- a/member_roles.go
+++ b/member_roles.go
@@ -23,13 +23,13 @@ type MemberRole struct {
 	GroupId                  int              `json:"group_id"`
 	BaseAccessLevel          AccessLevelValue `json:"base_access_level"`
 	AdminCICDVariables       bool             `json:"admin_cicd_variables,omitempty"`
-	AdminMergeRequests       bool             `json:"admin_merge_requests,omitempty"`
+	AdminMergeRequests       bool             `json:"admin_merge_request,omitempty"`
 	AdminTerraformState      bool             `json:"admin_terraform_state,omitempty"`
 	AdminVulnerability       bool             `json:"admin_vulnerability,omitempty"`
 	ReadCode                 bool             `json:"read_code,omitempty"`
 	ReadDependency           bool             `json:"read_dependency,omitempty"`
 	ReadVulnerability        bool             `json:"read_vulnerability,omitempty"`
-	AdminGroupMembers        bool             `json:"admin_group_members,omitempty"`
+	AdminGroupMembers        bool             `json:"admin_group_member,omitempty"`
 	ManageProjectAccessToken bool             `json:"manage_project_access_tokens,omitempty"`
 	ArchiveProject           bool             `json:"archive_project,omitempty"`
 	RemoveProject            bool             `json:"remove_project,omitempty"`

--- a/member_roles.go
+++ b/member_roles.go
@@ -22,12 +22,18 @@ type MemberRole struct {
 	Description              string           `json:"description,omitempty"`
 	GroupId                  int              `json:"group_id"`
 	BaseAccessLevel          AccessLevelValue `json:"base_access_level"`
+	AdminCICDVariables       bool             `json:"admin_cicd_variables,omitempty"`
 	AdminMergeRequests       bool             `json:"admin_merge_requests,omitempty"`
+	AdminTerraformState      bool             `json:"admin_terraform_state,omitempty"`
 	AdminVulnerability       bool             `json:"admin_vulnerability,omitempty"`
 	ReadCode                 bool             `json:"read_code,omitempty"`
 	ReadDependency           bool             `json:"read_dependency,omitempty"`
 	ReadVulnerability        bool             `json:"read_vulnerability,omitempty"`
-	ManageProjectAccessToken bool             `json:"manage_project_access_token,omitempty"`
+	AdminGroupMembers        bool             `json:"admin_group_members,omitempty"`
+	ManageProjectAccessToken bool             `json:"manage_project_access_tokens,omitempty"`
+	ArchiveProject           bool             `json:"archive_project,omitempty"`
+	RemoveProject            bool             `json:"remove_project,omitempty"`
+	ManageGroupAccesToken    bool             `json:"manage_group_access_tokens,omitempty"`
 }
 
 // ListMemberRoles gets a list of member roles for a specified group.


### PR DESCRIPTION
This PR adds support for several new custom role permissions. It also resolves an issue where you could previous add or update customer roles, but you would be unable to read them from the API after they were set.

- Update `GroupMember` to include `MemberRole`, allowing the GET APIs to retrieve the custom roles
- Add the following new Permissions
  - Admin CI/CD Variables
  - Admin Terraform States
  - Admin Group Members
  - Manage Group Access Tokens
  - Archive Projects
  - Remove Projects
  
- Fixed typos in the JSON tags for 2 permissions
  - Manage Project Access Tokens (wasn't plural, should have been)
  - Admin Merge Requests (was plural, shouldn't have been)

There is one additional permission in the example JSON I got from the API (`admin_push_rules`) that I didn't include, because it's not documented in the member roles documentation yet: https://docs.gitlab.com/ee/api/member_roles.html