### PR TITLE
Add support for CIJobTokenScopeEnabled edit

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -847,6 +847,7 @@ type EditProjectOptions struct {
 	CIForwardDeploymentEnabled                *bool                                `url:"ci_forward_deployment_enabled,omitempty" json:"ci_forward_deployment_enabled,omitempty"`
 	CIForwardDeploymentRollbackAllowed        *bool                                `url:"ci_forward_deployment_rollback_allowed,omitempty" json:"ci_forward_deployment_rollback_allowed,omitempty"`
 	CISeperateCache                           *bool                                `url:"ci_separated_caches,omitempty" json:"ci_separated_caches,omitempty"`
+	CIJobTokenScopeEnabled                    *bool                                `url:"ci_job_token_scope_enabled,omitempty" json:"ci_job_token_scope_enabled,omitempty"`
 	CIRestrictPipelineCancellationRole        *AccessControlValue                  `url:"ci_restrict_pipeline_cancellation_role,omitempty" json:"ci_restrict_pipeline_cancellation_role,omitempty"`
 	ContainerExpirationPolicyAttributes       *ContainerExpirationPolicyAttributes `url:"container_expiration_policy_attributes,omitempty" json:"container_expiration_policy_attributes,omitempty"`
 	ContainerRegistryAccessLevel              *AccessControlValue                  `url:"container_registry_access_level,omitempty" json:"container_registry_access_level,omitempty"`


### PR DESCRIPTION
This PR adds support for editing CIJobTokenScopeEnabled attribute to the Projects APIs. 
Reference https://docs.gitlab.com/ee/api/project_job_token_scopes.html#patch-a-projects-cicd-job-token-access-settings

Once this is merged I'll be creating another MR for the Terraform Provider GitLab here https://gitlab.com/gitlab-org/terraform-provider-gitlab/-/issues/6081