### PR TITLE
Implement DirectAssetPath for Release Assets Links

### DIFF
--- a/releaselinks.go
+++ b/releaselinks.go
@@ -101,10 +101,11 @@ func (s *ReleaseLinksService) GetReleaseLink(pid interface{}, tagName string, li
 //
 // GitLab API docs: https://docs.gitlab.com/ee/api/releases/links.html#create-a-release-link
 type CreateReleaseLinkOptions struct {
-	Name     *string        `url:"name,omitempty" json:"name,omitempty"`
-	URL      *string        `url:"url,omitempty" json:"url,omitempty"`
-	FilePath *string        `url:"filepath,omitempty" json:"filepath,omitempty"`
-	LinkType *LinkTypeValue `url:"link_type,omitempty" json:"link_type,omitempty"`
+	Name            *string        `url:"name,omitempty" json:"name,omitempty"`
+	URL             *string        `url:"url,omitempty" json:"url,omitempty"`
+	FilePath        *string        `url:"filepath,omitempty" json:"filepath,omitempty"`
+	DirectAssetPath *string        `url:"direct_asset_path,omitempty" json:"direct_asset_path,omitempty"`
+	LinkType        *LinkTypeValue `url:"link_type,omitempty" json:"link_type,omitempty"`
 }
 
 // CreateReleaseLink creates a link.
@@ -137,10 +138,11 @@ func (s *ReleaseLinksService) CreateReleaseLink(pid interface{}, tagName string,
 //
 // GitLab API docs: https://docs.gitlab.com/ee/api/releases/links.html#update-a-release-link
 type UpdateReleaseLinkOptions struct {
-	Name     *string        `url:"name,omitempty" json:"name,omitempty"`
-	URL      *string        `url:"url,omitempty" json:"url,omitempty"`
-	FilePath *string        `url:"filepath,omitempty" json:"filepath,omitempty"`
-	LinkType *LinkTypeValue `url:"link_type,omitempty" json:"link_type,omitempty"`
+	Name            *string        `url:"name,omitempty" json:"name,omitempty"`
+	URL             *string        `url:"url,omitempty" json:"url,omitempty"`
+	FilePath        *string        `url:"filepath,omitempty" json:"filepath,omitempty"`
+	DirectAssetPath *string        `url:"direct_asset_path,omitempty" json:"direct_asset_path,omitempty"`
+	LinkType        *LinkTypeValue `url:"link_type,omitempty" json:"link_type,omitempty"`
 }
 
 // UpdateReleaseLink updates an asset link.

--- a/releaselinks_test.go
+++ b/releaselinks_test.go
@@ -87,10 +87,10 @@ func TestReleaseLinksService_CreateReleaseLink(t *testing.T) {
 		{
 			description: "Optional Attributes",
 			options: &CreateReleaseLinkOptions{
-				Name:     Ptr("release-notes.md"),
-				URL:      Ptr("http://192.168.10.15:3000"),
-				FilePath: Ptr("docs/release-notes.md"),
-				LinkType: Ptr(OtherLinkType),
+				Name:            Ptr("release-notes.md"),
+				URL:             Ptr("http://192.168.10.15:3000"),
+				DirectAssetPath: Ptr("docs/release-notes.md"),
+				LinkType:        Ptr(OtherLinkType),
 			},
 			response: `{
 				"id":1,
@@ -159,9 +159,9 @@ func TestReleaseLinksService_UpdateReleaseLink(t *testing.T) {
 	releaseLink, _, err := client.ReleaseLinks.UpdateReleaseLink(
 		1, exampleTagName, 1,
 		&UpdateReleaseLinkOptions{
-			Name:     Ptr(exampleReleaseName),
-			FilePath: Ptr("http://192.168.10.15:3000/namespace/example/-/releases/v0.1/downloads/awesome-v0.2.dmg"),
-			LinkType: Ptr(OtherLinkType),
+			Name:            Ptr(exampleReleaseName),
+			DirectAssetPath: Ptr("http://192.168.10.15:3000/namespace/example/-/releases/v0.1/downloads/awesome-v0.2.dmg"),
+			LinkType:        Ptr(OtherLinkType),
 		})
 
 	require.NoError(t, err)

--- a/releases.go
+++ b/releases.go
@@ -187,10 +187,11 @@ type ReleaseAssetsOptions struct {
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/releases/index.html#create-a-release
 type ReleaseAssetLinkOptions struct {
-	Name     *string        `url:"name,omitempty" json:"name,omitempty"`
-	URL      *string        `url:"url,omitempty" json:"url,omitempty"`
-	FilePath *string        `url:"filepath,omitempty" json:"filepath,omitempty"`
-	LinkType *LinkTypeValue `url:"link_type,omitempty" json:"link_type,omitempty"`
+	Name            *string        `url:"name,omitempty" json:"name,omitempty"`
+	URL             *string        `url:"url,omitempty" json:"url,omitempty"`
+	FilePath        *string        `url:"filepath,omitempty" json:"filepath,omitempty"`
+	DirectAssetPath *string        `url:"direct_asset_path,omitempty" json:"direct_asset_path,omitempty"`
+	LinkType        *LinkTypeValue `url:"link_type,omitempty" json:"link_type,omitempty"`
 }
 
 // CreateRelease creates a release.

--- a/releases_test.go
+++ b/releases_test.go
@@ -141,7 +141,7 @@ func TestReleasesService_CreateReleaseWithAsset(t *testing.T) {
 		Description: Ptr("Description"),
 		Assets: &ReleaseAssetsOptions{
 			Links: []*ReleaseAssetLinkOptions{
-				{Ptr("sldkf"), Ptr("sldkfj"), Ptr("sldkfh"), Ptr(OtherLinkType)},
+				{Ptr("sldkf"), Ptr("sldkfj"), Ptr("sldkfh"), Ptr("direct-asset-path"), Ptr(OtherLinkType)},
 			},
 		},
 	}
@@ -190,7 +190,7 @@ func TestReleasesService_CreateReleaseWithAssetAndNameMetadata(t *testing.T) {
 		Description: Ptr("Description"),
 		Assets: &ReleaseAssetsOptions{
 			Links: []*ReleaseAssetLinkOptions{
-				{Ptr("sldkf"), Ptr("sldkfj"), Ptr("sldkfh"), Ptr(OtherLinkType)},
+				{Ptr("sldkf"), Ptr("sldkfj"), Ptr("sldkfh"), Ptr("direct-asset-path"), Ptr(OtherLinkType)},
 			},
 		},
 	}


### PR DESCRIPTION
This change set adds support for the `direct_asset_path` API field for Release Assets Links, see the API documentation here:

- https://docs.gitlab.com/ee/api/releases/#create-a-release
- https://docs.gitlab.com/ee/api/releases/links.html#create-a-release-link