### PR TITLE
Ignore response body during HEAD request error handling

### DIFF
--- a/gitlab.go
+++ b/gitlab.go
@@ -953,8 +953,13 @@ type ErrorResponse struct {
 
 func (e *ErrorResponse) Error() string {
 	path, _ := url.QueryUnescape(e.Response.Request.URL.Path)
-	u := fmt.Sprintf("%s://%s%s", e.Response.Request.URL.Scheme, e.Response.Request.URL.Host, path)
-	return fmt.Sprintf("%s %s: %d %s", e.Response.Request.Method, u, e.Response.StatusCode, e.Message)
+	url := fmt.Sprintf("%s://%s%s", e.Response.Request.URL.Scheme, e.Response.Request.URL.Host, path)
+	str := fmt.Sprintf("%s %s: %d", e.Response.Request.Method, url, e.Response.StatusCode)
+	if e.Message != "" {
+		str += " " + e.Message
+	}
+
+	return str
 }
 
 // CheckResponse checks the API response for errors, and returns them if present.
@@ -965,6 +970,11 @@ func CheckResponse(r *http.Response) error {
 	}
 
 	errorResponse := &ErrorResponse{Response: r}
+
+	if r.Request.Method == http.MethodHead {
+		return errorResponse
+	}
+
 	data, err := io.ReadAll(r.Body)
 	if err == nil && data != nil {
 		errorResponse.Body = data

--- a/gitlab.go
+++ b/gitlab.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -64,6 +65,8 @@ const (
 	OAuthToken
 	PrivateToken
 )
+
+var ErrNotFound = errors.New("404 Not Found")
 
 // A Client manages communication with the GitLab API.
 type Client struct {
@@ -500,7 +503,7 @@ func (c *Client) retryHTTPBackoff(min, max time.Duration, attemptNum int, resp *
 // min and max are mainly used for bounding the jitter that will be added to
 // the reset time retrieved from the headers. But if the final wait time is
 // less then min, min will be used instead.
-func rateLimitBackoff(min, max time.Duration, attemptNum int, resp *http.Response) time.Duration {
+func rateLimitBackoff(min, max time.Duration, _ int, resp *http.Response) time.Duration {
 	// rnd is used to generate pseudo-random numbers.
 	rnd := rand.New(rand.NewSource(time.Now().UnixNano()))
 
@@ -954,12 +957,12 @@ type ErrorResponse struct {
 func (e *ErrorResponse) Error() string {
 	path, _ := url.QueryUnescape(e.Response.Request.URL.Path)
 	url := fmt.Sprintf("%s://%s%s", e.Response.Request.URL.Scheme, e.Response.Request.URL.Host, path)
-	str := fmt.Sprintf("%s %s: %d", e.Response.Request.Method, url, e.Response.StatusCode)
-	if e.Message != "" {
-		str += " " + e.Message
-	}
 
-	return str
+	if e.Message == "" {
+		return fmt.Sprintf("%s %s: %d", e.Response.Request.Method, url, e.Response.StatusCode)
+	} else {
+		return fmt.Sprintf("%s %s: %d %s", e.Response.Request.Method, url, e.Response.StatusCode, e.Message)
+	}
 }
 
 // CheckResponse checks the API response for errors, and returns them if present.
@@ -967,16 +970,14 @@ func CheckResponse(r *http.Response) error {
 	switch r.StatusCode {
 	case 200, 201, 202, 204, 304:
 		return nil
+	case 404:
+		return ErrNotFound
 	}
 
 	errorResponse := &ErrorResponse{Response: r}
 
-	if r.Request.Method == http.MethodHead {
-		return errorResponse
-	}
-
 	data, err := io.ReadAll(r.Body)
-	if err == nil && data != nil {
+	if err == nil && strings.TrimSpace(string(data)) != "" {
 		errorResponse.Body = data
 
 		var raw interface{}

--- a/gitlab_test.go
+++ b/gitlab_test.go
@@ -225,7 +225,7 @@ func TestCheckResponseOnHeadRequestError(t *testing.T) {
 		t.Fatal("Expected error response.")
 	}
 
-	want := "HEAD https://gitlab.com/api/v4/test: 404"
+	want := "404 Not Found"
 
 	if errResp.Error() != want {
 		t.Errorf("Expected error: %s, got %s", want, errResp.Error())

--- a/gitlab_test.go
+++ b/gitlab_test.go
@@ -203,6 +203,35 @@ func TestCheckResponseOnUnknownErrorFormat(t *testing.T) {
 	}
 }
 
+func TestCheckResponseOnHeadRequestError(t *testing.T) {
+	c, err := NewClient("")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	req, err := c.NewRequest(http.MethodHead, "test", nil, nil)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+
+	resp := &http.Response{
+		Request:    req.Request,
+		StatusCode: http.StatusNotFound,
+		Body:       nil,
+	}
+
+	errResp := CheckResponse(resp)
+	if errResp == nil {
+		t.Fatal("Expected error response.")
+	}
+
+	want := "HEAD https://gitlab.com/api/v4/test: 404"
+
+	if errResp.Error() != want {
+		t.Errorf("Expected error: %s, got %s", want, errResp.Error())
+	}
+}
+
 func TestRequestWithContext(t *testing.T) {
 	c, err := NewClient("")
 	if err != nil {


### PR DESCRIPTION
Fixes #1047

This improves the error handling of a HEAD request response. It avoids trying to parse the body entirely. To handle the error, you can still check for a `*gitlab.ErrorResponse`:

```go
_, _, err := gitlabClient.RepositoryFiles.GetFileMetaData(1, "not-there.txt", &gitlab.GetFileMetaDataOptions{Ref: gitlab.Ptr("main")})
if err != nil {
	var errResp *gitlab.ErrorResponse
	if errors.As(err, &errResp) {
		log.Println(errResp.Response.StatusCode)
	} else {
		log.Println(err)
	}
}
```