### PR TITLE
Fix golangci-lint `output.format` deprecation warning

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,7 +10,8 @@ run:
 
 # Output configuration options
 output:
-  format: line-number
+  formats:
+    - format: line-number
 
 # All available settings of specific linters
 linters-settings:


### PR DESCRIPTION
Fixes a deprecation during `make lint`:

```
WARN [config_reader] The configuration option `output.format` is deprecated, please use `output.formats`
```

[`output` Docs](https://golangci-lint.run/usage/configuration/#output-configuration)