### PR TITLE
Add missing attribute to group push rules

### DIFF
--- a/groups.go
+++ b/groups.go
@@ -999,6 +999,7 @@ type GroupPushRules struct {
 	FileNameRegex              string     `json:"file_name_regex"`
 	MaxFileSize                int        `json:"max_file_size"`
 	CommitCommitterCheck       bool       `json:"commit_committer_check"`
+	CommitCommitterNameCheck   bool       `json:"commit_committer_name_check"`
 	RejectUnsignedCommits      bool       `json:"reject_unsigned_commits"`
 }
 
@@ -1036,6 +1037,7 @@ type AddGroupPushRuleOptions struct {
 	AuthorEmailRegex           *string `url:"author_email_regex,omitempty" json:"author_email_regex,omitempty"`
 	BranchNameRegex            *string `url:"branch_name_regex,omitempty" json:"branch_name_regex,omitempty"`
 	CommitCommitterCheck       *bool   `url:"commit_committer_check,omitempty" json:"commit_committer_check,omitempty"`
+	CommitCommitterNameCheck   *bool   `url:"commit_committer_name_check,omitempty" json:"commit_committer_name_check,omitempty"`
 	CommitMessageNegativeRegex *string `url:"commit_message_negative_regex,omitempty" json:"commit_message_negative_regex,omitempty"`
 	CommitMessageRegex         *string `url:"commit_message_regex,omitempty" json:"commit_message_regex,omitempty"`
 	DenyDeleteTag              *bool   `url:"deny_delete_tag,omitempty" json:"deny_delete_tag,omitempty"`
@@ -1080,6 +1082,7 @@ type EditGroupPushRuleOptions struct {
 	AuthorEmailRegex           *string `url:"author_email_regex,omitempty" json:"author_email_regex,omitempty"`
 	BranchNameRegex            *string `url:"branch_name_regex,omitempty" json:"branch_name_regex,omitempty"`
 	CommitCommitterCheck       *bool   `url:"commit_committer_check,omitempty" json:"commit_committer_check,omitempty"`
+	CommitCommitterNameCheck   *bool   `url:"commit_committer_name_check,omitempty" json:"commit_committer_name_check,omitempty"`
 	CommitMessageNegativeRegex *string `url:"commit_message_negative_regex,omitempty" json:"commit_message_negative_regex,omitempty"`
 	CommitMessageRegex         *string `url:"commit_message_regex,omitempty" json:"commit_message_regex,omitempty"`
 	DenyDeleteTag              *bool   `url:"deny_delete_tag,omitempty" json:"deny_delete_tag,omitempty"`

--- a/groups_test.go
+++ b/groups_test.go
@@ -706,3 +706,177 @@ func TestUpdateGroupWithEmailsEnabled(t *testing.T) {
 		t.Errorf("Groups.UpdateGroup returned error: %v", err)
 	}
 }
+
+func TestGetGroupPushRules(t *testing.T) {
+	mux, client := setup(t)
+
+	mux.HandleFunc("/api/v4/groups/1/push_rule", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, `{
+			"id": 1,
+			"commit_message_regex": "Fixes \\d+\\..*",
+			"commit_message_negative_regex": "ssh\\:\\/\\/",
+			"branch_name_regex": "(feat|fix)\\/*",
+			"deny_delete_tag": false,
+			"member_check": false,
+			"prevent_secrets": false,
+			"author_email_regex": "@company.com$",
+			"file_name_regex": "(jar|exe)$",
+			"max_file_size": 5,
+			"commit_committer_check": false,
+			"commit_committer_name_check": false,
+			"reject_unsigned_commits": false
+		  }`)
+	})
+
+	rule, _, err := client.Groups.GetGroupPushRules(1)
+	if err != nil {
+		t.Errorf("Groups.GetGroupPushRules returned error: %v", err)
+	}
+
+	want := &GroupPushRules{
+		ID:                         1,
+		CommitMessageRegex:         "Fixes \\d+\\..*",
+		CommitMessageNegativeRegex: "ssh\\:\\/\\/",
+		BranchNameRegex:            "(feat|fix)\\/*",
+		DenyDeleteTag:              false,
+		MemberCheck:                false,
+		PreventSecrets:             false,
+		AuthorEmailRegex:           "@company.com$",
+		FileNameRegex:              "(jar|exe)$",
+		MaxFileSize:                5,
+		CommitCommitterCheck:       false,
+		CommitCommitterNameCheck:   false,
+		RejectUnsignedCommits:      false,
+	}
+
+	if !reflect.DeepEqual(want, rule) {
+		t.Errorf("Groups.GetGroupPushRules returned %+v, want %+v", rule, want)
+	}
+}
+
+func TestAddGroupPushRules(t *testing.T) {
+	mux, client := setup(t)
+
+	mux.HandleFunc("/api/v4/groups/1/push_rule", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		fmt.Fprint(w, `{
+			"id": 1,
+			"commit_message_regex": "Fixes \\d+\\..*",
+			"commit_message_negative_regex": "ssh\\:\\/\\/",
+			"branch_name_regex": "(feat|fix)\\/*",
+			"deny_delete_tag": false,
+			"member_check": false,
+			"prevent_secrets": false,
+			"author_email_regex": "@company.com$",
+			"file_name_regex": "(jar|exe)$",
+			"max_file_size": 5,
+			"commit_committer_check": false,
+			"commit_committer_name_check": false,
+			"reject_unsigned_commits": false
+		  }`)
+	})
+
+	opt := &AddGroupPushRuleOptions{
+		CommitMessageRegex:         Ptr("Fixes \\d+\\..*"),
+		CommitMessageNegativeRegex: Ptr("ssh\\:\\/\\/"),
+		BranchNameRegex:            Ptr("(feat|fix)\\/*"),
+		DenyDeleteTag:              Ptr(false),
+		MemberCheck:                Ptr(false),
+		PreventSecrets:             Ptr(false),
+		AuthorEmailRegex:           Ptr("@company.com$"),
+		FileNameRegex:              Ptr("(jar|exe)$"),
+		MaxFileSize:                Ptr(5),
+		CommitCommitterCheck:       Ptr(false),
+		CommitCommitterNameCheck:   Ptr(false),
+		RejectUnsignedCommits:      Ptr(false),
+	}
+
+	rule, _, err := client.Groups.AddGroupPushRule(1, opt)
+	if err != nil {
+		t.Errorf("Groups.AddGroupPushRule returned error: %v", err)
+	}
+
+	want := &GroupPushRules{
+		ID:                         1,
+		CommitMessageRegex:         "Fixes \\d+\\..*",
+		CommitMessageNegativeRegex: "ssh\\:\\/\\/",
+		BranchNameRegex:            "(feat|fix)\\/*",
+		DenyDeleteTag:              false,
+		MemberCheck:                false,
+		PreventSecrets:             false,
+		AuthorEmailRegex:           "@company.com$",
+		FileNameRegex:              "(jar|exe)$",
+		MaxFileSize:                5,
+		CommitCommitterCheck:       false,
+		CommitCommitterNameCheck:   false,
+		RejectUnsignedCommits:      false,
+	}
+
+	if !reflect.DeepEqual(want, rule) {
+		t.Errorf("Groups.AddGroupPushRule returned %+v, want %+v", rule, want)
+	}
+}
+
+func TestEditGroupPushRules(t *testing.T) {
+	mux, client := setup(t)
+
+	mux.HandleFunc("/api/v4/groups/1/push_rule", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPut)
+		fmt.Fprint(w, `{
+			"id": 1,
+			"commit_message_regex": "Fixes \\d+\\..*",
+			"commit_message_negative_regex": "ssh\\:\\/\\/",
+			"branch_name_regex": "(feat|fix)\\/*",
+			"deny_delete_tag": false,
+			"member_check": false,
+			"prevent_secrets": false,
+			"author_email_regex": "@company.com$",
+			"file_name_regex": "(jar|exe)$",
+			"max_file_size": 5,
+			"commit_committer_check": false,
+			"commit_committer_name_check": false,
+			"reject_unsigned_commits": false
+		  }`)
+	})
+
+	opt := &EditGroupPushRuleOptions{
+		CommitMessageRegex:         Ptr("Fixes \\d+\\..*"),
+		CommitMessageNegativeRegex: Ptr("ssh\\:\\/\\/"),
+		BranchNameRegex:            Ptr("(feat|fix)\\/*"),
+		DenyDeleteTag:              Ptr(false),
+		MemberCheck:                Ptr(false),
+		PreventSecrets:             Ptr(false),
+		AuthorEmailRegex:           Ptr("@company.com$"),
+		FileNameRegex:              Ptr("(jar|exe)$"),
+		MaxFileSize:                Ptr(5),
+		CommitCommitterCheck:       Ptr(false),
+		CommitCommitterNameCheck:   Ptr(false),
+		RejectUnsignedCommits:      Ptr(false),
+	}
+
+	rule, _, err := client.Groups.EditGroupPushRule(1, opt)
+	if err != nil {
+		t.Errorf("Groups.EditGroupPushRule returned error: %v", err)
+	}
+
+	want := &GroupPushRules{
+		ID:                         1,
+		CommitMessageRegex:         "Fixes \\d+\\..*",
+		CommitMessageNegativeRegex: "ssh\\:\\/\\/",
+		BranchNameRegex:            "(feat|fix)\\/*",
+		DenyDeleteTag:              false,
+		MemberCheck:                false,
+		PreventSecrets:             false,
+		AuthorEmailRegex:           "@company.com$",
+		FileNameRegex:              "(jar|exe)$",
+		MaxFileSize:                5,
+		CommitCommitterCheck:       false,
+		CommitCommitterNameCheck:   false,
+		RejectUnsignedCommits:      false,
+	}
+
+	if !reflect.DeepEqual(want, rule) {
+		t.Errorf("Groups.EditGroupPushRule returned %+v, want %+v", rule, want)
+	}
+}


### PR DESCRIPTION
The `commit_committer_name_check` was missing from the group push rules.  Similar to the recent update made to project push rules.