### PR TITLE
Update versions of github actions used in lint_and_test

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
+          cache: false
 
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -15,15 +15,15 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Lint package
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v5
         with:
           version: latest
 
@@ -33,7 +33,7 @@ jobs:
           go tool cover -func coverage.txt
 
       - name: Update coverage report
-        uses: ncruces/go-coverage-report@v0.2.3
+        uses: ncruces/go-coverage-report@v0.3.0
         with:
           report: 'true'
           amend: 'true'


### PR DESCRIPTION
Updating the versions of the github actions used in the lint and test pipeline.

This should remediate the warnings that appear when running the pipeline, e.g.:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/setup-go@v4, actions/checkout@v3, golangci/golangci-lint-action@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.