### PR TITLE
Resolves #1405: only one endpoint was missing

### DIFF
--- a/external_status_checks.go
+++ b/external_status_checks.go
@@ -198,27 +198,18 @@ func (s *ExternalStatusChecksService) UpdateExternalStatusCheck(pid interface{},
 	return s.client.Do(req, nil)
 }
 
-// RetryFailedStatusCheckForAMergeRequestOptions represents the available
-// RetryFailedStatusCheckForAMergeRequest() options.
-//
-// GitLab API docs:
-// https://docs.gitlab.com/ee/api/status_checks.html#retry-failed-status-check-for-a-merge-request
-type RetryFailedStatusCheckForAMergeRequestOptions struct {
-	ExternalStatusCheckID *int `url:"external_status_check_id,omitempty" json:"external_status_check_id,omitempty"`
-}
-
 // UpdateExternalStatusCheck updates an external status check.
 //
 // Gitlab API docs:
 // https://docs.gitlab.com/ee/api/status_checks.html#retry-failed-status-check-for-a-merge-request
-func (s *ExternalStatusChecksService) RetryFailedStatusCheckForAMergeRequest(pid interface{}, mergeRequest int, opt *RetryFailedStatusCheckForAMergeRequestOptions, options ...RequestOptionFunc) (*Response, error) {
+func (s *ExternalStatusChecksService) RetryFailedStatusCheckForAMergeRequest(pid interface{}, mergeRequest int, externalStatusCheckID int, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/merge_requests/%d/status_checks/%d/retry", PathEscape(project), mergeRequest, *opt.ExternalStatusCheckID)
+	u := fmt.Sprintf("projects/%s/merge_requests/%d/status_checks/%d/retry", PathEscape(project), mergeRequest, externalStatusCheckID)
 
-	req, err := s.client.NewRequest(http.MethodPost, u, opt, options)
+	req, err := s.client.NewRequest(http.MethodPost, u, nil, options)
 	if err != nil {
 		return nil, err
 	}

--- a/external_status_checks.go
+++ b/external_status_checks.go
@@ -197,3 +197,31 @@ func (s *ExternalStatusChecksService) UpdateExternalStatusCheck(pid interface{},
 
 	return s.client.Do(req, nil)
 }
+
+// RetryFailedStatusCheckForAMergeRequestOptions represents the available
+// RetryFailedStatusCheckForAMergeRequest() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/status_checks.html#retry-failed-status-check-for-a-merge-request
+type RetryFailedStatusCheckForAMergeRequestOptions struct {
+	ExternalStatusCheckID *int `url:"external_status_check_id,omitempty" json:"external_status_check_id,omitempty"`
+}
+
+// UpdateExternalStatusCheck updates an external status check.
+//
+// Gitlab API docs:
+// https://docs.gitlab.com/ee/api/status_checks.html#retry-failed-status-check-for-a-merge-request
+func (s *ExternalStatusChecksService) RetryFailedStatusCheckForAMergeRequest(pid interface{}, mergeRequest int, opt *RetryFailedStatusCheckForAMergeRequestOptions, options ...RequestOptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/merge_requests/%d/status_checks/%d/retry", PathEscape(project), mergeRequest, *opt.ExternalStatusCheckID)
+
+	req, err := s.client.NewRequest(http.MethodPost, u, opt, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}

--- a/external_status_checks.go
+++ b/external_status_checks.go
@@ -202,12 +202,12 @@ func (s *ExternalStatusChecksService) UpdateExternalStatusCheck(pid interface{},
 //
 // Gitlab API docs:
 // https://docs.gitlab.com/ee/api/status_checks.html#retry-failed-status-check-for-a-merge-request
-func (s *ExternalStatusChecksService) RetryFailedStatusCheckForAMergeRequest(pid interface{}, mergeRequest int, externalStatusCheckID int, options ...RequestOptionFunc) (*Response, error) {
+func (s *ExternalStatusChecksService) RetryFailedStatusCheckForAMergeRequest(pid interface{}, mergeRequest int, externalStatusCheck int, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("projects/%s/merge_requests/%d/status_checks/%d/retry", PathEscape(project), mergeRequest, externalStatusCheckID)
+	u := fmt.Sprintf("projects/%s/merge_requests/%d/status_checks/%d/retry", PathEscape(project), mergeRequest, externalStatusCheck)
 
 	req, err := s.client.NewRequest(http.MethodPost, u, nil, options)
 	if err != nil {

--- a/external_status_checks_test.go
+++ b/external_status_checks_test.go
@@ -88,11 +88,7 @@ func TestRetryFailedStatusCheckForAMergeRequest(t *testing.T) {
 		fmt.Fprint(w, `{"message": "202 Accepted"}`)
 	})
 
-	opt := &RetryFailedStatusCheckForAMergeRequestOptions{
-		ExternalStatusCheckID: Ptr(3),
-	}
-
-	resp, err := client.ExternalStatusChecks.RetryFailedStatusCheckForAMergeRequest(1, 2, opt)
+	resp, err := client.ExternalStatusChecks.RetryFailedStatusCheckForAMergeRequest(1, 2, 3)
 	if err != nil {
 		t.Fatalf("ExternalStatusChecks.RetryFailedStatusCheckForAMergeRequest returns an error: %v", err)
 	}

--- a/external_status_checks_test.go
+++ b/external_status_checks_test.go
@@ -79,3 +79,23 @@ func TestListProjectStatusChecks(t *testing.T) {
 
 	assert.Equal(t, expectedProjectStatusChecks, projectStatusChecks)
 }
+
+func TestRetryFailedStatusCheckForAMergeRequest(t *testing.T) {
+	mux, client := setup(t)
+
+	mux.HandleFunc("/api/v4/projects/1/merge_requests/2/status_checks/3/retry", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		fmt.Fprint(w, `{"message": "202 Accepted"}`)
+	})
+
+	opt := &RetryFailedStatusCheckForAMergeRequestOptions{
+		ExternalStatusCheckID: Ptr(3),
+	}
+
+	resp, err := client.ExternalStatusChecks.RetryFailedStatusCheckForAMergeRequest(1, 2, opt)
+	if err != nil {
+		t.Fatalf("ExternalStatusChecks.RetryFailedStatusCheckForAMergeRequest returns an error: %v", err)
+	}
+
+	assert.NotNil(t, resp)
+}


### PR DESCRIPTION
Comparing the endpoints to the documentation here: https://docs.gitlab.com/ee/api/status_checks.html there is only one endpoint not currently supported. This is https://docs.gitlab.com/ee/api/status_checks.html#retry-failed-status-check-for-a-merge-request

I've added a new function for this endpoint and a very basic test.