### PR TITLE
Add container registry status to response body

### DIFF
--- a/container_registry.go
+++ b/container_registry.go
@@ -41,6 +41,7 @@ type RegistryRepository struct {
 	Location               string                   `json:"location"`
 	CreatedAt              *time.Time               `json:"created_at"`
 	CleanupPolicyStartedAt *time.Time               `json:"cleanup_policy_started_at"`
+	Status                 *ContainerRegistryStatus `json:"status"`
 	TagsCount              int                      `json:"tags_count"`
 	Tags                   []*RegistryRepositoryTag `json:"tags"`
 }

--- a/types.go
+++ b/types.go
@@ -256,6 +256,22 @@ func BuildState(v BuildStateValue) *BuildStateValue {
 	return Ptr(v)
 }
 
+// ContainerRegistryStatus represents the status of a Container Registry
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/container_registry.html#list-registry-repositories
+type ContainerRegistryStatus string
+
+// ContainerRegistryStatus represents all valid statuses of a Container Registry
+//
+// Undocumented, see code at:
+// https://gitlab.com/gitlab-org/gitlab/-/blob/master/app/models/container_repository.rb?ref_type=heads#L35
+const (
+	ContainerRegistryStatusDeleteScheduled ContainerRegistryStatus = "delete_scheduled"
+	ContainerRegistryStatusDeleteFailed    ContainerRegistryStatus = "delete_failed"
+	ContainerRegistryStatusDeleteOngoing   ContainerRegistryStatus = "delete_ongoing"
+)
+
 // DeploymentApprovalStatus represents a Gitlab deployment approval status.
 type DeploymentApprovalStatus string
 

--- a/types.go
+++ b/types.go
@@ -256,13 +256,13 @@ func BuildState(v BuildStateValue) *BuildStateValue {
 	return Ptr(v)
 }
 
-// ContainerRegistryStatus represents the status of a Container Registry
+// ContainerRegistryStatus represents the status of a Container Registry.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/container_registry.html#list-registry-repositories
 type ContainerRegistryStatus string
 
-// ContainerRegistryStatus represents all valid statuses of a Container Registry
+// ContainerRegistryStatus represents all valid statuses of a Container Registry.
 //
 // Undocumented, see code at:
 // https://gitlab.com/gitlab-org/gitlab/-/blob/master/app/models/container_repository.rb?ref_type=heads#L35


### PR DESCRIPTION
Resolves https://github.com/xanzy/go-gitlab/issues/1928

Added the status field to the container repository object. The API documentation does not include a list of valid statuses but I think I've found the correct enum in GitLab's codebase and linked to it in the type declaration.