### PR TITLE
Reinstate missing fields for emails on push integration

### DIFF
--- a/services.go
+++ b/services.go
@@ -504,6 +504,8 @@ type EmailsOnPushServiceProperties struct {
 	Recipients             string `json:"recipients"`
 	DisableDiffs           bool   `json:"disable_diffs"`
 	SendFromCommitterEmail bool   `json:"send_from_committer_email"`
+	PushEvents             bool   `json:"push_events"`
+	TagPushEvents          bool   `json:"tag_push_events"`
 	BranchesToBeNotified   string `json:"branches_to_be_notified"`
 }
 


### PR DESCRIPTION
These fields were removed under https://github.com/xanzy/go-gitlab/pull/1925 but are still present in the API documentation https://docs.gitlab.com/ee/api/integrations.html#emails-on-push.

Adding them back in as updating to the latest tag causes compilation errors in the GitLab Terraform Provider https://gitlab.com/gitlab-org/terraform-provider-gitlab/-/blob/main/internal/provider/sdk/resource_gitlab_integration_emails_on_push.go?ref_type=heads#L177