### PR TITLE
Issue: #1936 fix Missing MemberRoleId for group link creation

### DIFF
--- a/groups.go
+++ b/groups.go
@@ -881,6 +881,7 @@ func (s *GroupsService) GetGroupSAMLLink(gid interface{}, samlGroupName string, 
 type AddGroupSAMLLinkOptions struct {
 	SAMLGroupName *string           `url:"saml_group_name,omitempty" json:"saml_group_name,omitempty"`
 	AccessLevel   *AccessLevelValue `url:"access_level,omitempty" json:"access_level,omitempty"`
+	MemberRoleID  *int              `url:"member_role_id,omitempty" json:"member_role_id,omitempty"`
 }
 
 // AddGroupSAMLLink creates a new group SAML link. Available only for users who

--- a/groups_test.go
+++ b/groups_test.go
@@ -569,6 +569,7 @@ func TestAddGroupSAMLLinkCustomRole(t *testing.T) {
 	opt := &AddGroupSAMLLinkOptions{
 		SAMLGroupName: Ptr("gitlab_group_example_developer"),
 		AccessLevel:   Ptr(DeveloperPermissions),
+		MemberRoleID:  Ptr(123),
 	}
 
 	link, _, err := client.Groups.AddGroupSAMLLink(1, opt)


### PR DESCRIPTION
Change to allow setting the MemberRoleID in the AddGroupSAMLLink api.

Fix issue #1936 