### PR TITLE
GitLab 17.0: Fix an issue where Settings errors when ContainerRegistry is not enabled

### DIFF
--- a/settings_test.go
+++ b/settings_test.go
@@ -64,13 +64,12 @@ func TestUpdateSettings(t *testing.T) {
 	}
 }
 
-// Test that a empty string on a date attribute is returned as nil properly
 func TestSettingsWithEmptyContainerRegistry(t *testing.T) {
 	mux, client := setup(t)
 
 	mux.HandleFunc("/api/v4/application/settings", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
-		fmt.Fprint(w, `{"id":1, "container_registry_import_created_before": "", "abuse_notification_email": "test@example.com"}`)
+		fmt.Fprint(w, `{"id":1, "container_registry_import_created_before": ""}`)
 	})
 
 	settings, _, err := client.Settings.GetSettings()
@@ -78,28 +77,7 @@ func TestSettingsWithEmptyContainerRegistry(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// We should have nil for the setting if "" is in the body
-	want := &Settings{ID: 1, ContainerRegistryImportCreatedBefore: nil, AbuseNotificationEmail: "test@example.com"}
-	if !reflect.DeepEqual(settings, want) {
-		t.Errorf("Settings.UpdateSettings returned %+v, want %+v", settings, want)
-	}
-}
-
-// Test that a completely empty string is parsed as an empty struct properly.
-func TestSettingsWithEmptyString(t *testing.T) {
-	mux, client := setup(t)
-
-	mux.HandleFunc("/api/v4/application/settings", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, http.MethodGet)
-		fmt.Fprint(w, `""`)
-	})
-
-	settings, _, err := client.Settings.GetSettings()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	want := &Settings{}
+	want := &Settings{ID: 1, ContainerRegistryImportCreatedBefore: nil}
 	if !reflect.DeepEqual(settings, want) {
 		t.Errorf("Settings.UpdateSettings returned %+v, want %+v", settings, want)
 	}

--- a/settings_test.go
+++ b/settings_test.go
@@ -63,3 +63,44 @@ func TestUpdateSettings(t *testing.T) {
 		t.Errorf("Settings.UpdateSettings returned %+v, want %+v", settings, want)
 	}
 }
+
+// Test that a empty string on a date attribute is returned as nil properly
+func TestSettingsWithEmptyContainerRegistry(t *testing.T) {
+	mux, client := setup(t)
+
+	mux.HandleFunc("/api/v4/application/settings", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, `{"id":1, "container_registry_import_created_before": "", "abuse_notification_email": "test@example.com"}`)
+	})
+
+	settings, _, err := client.Settings.GetSettings()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// We should have nil for the setting if "" is in the body
+	want := &Settings{ID: 1, ContainerRegistryImportCreatedBefore: nil, AbuseNotificationEmail: "test@example.com"}
+	if !reflect.DeepEqual(settings, want) {
+		t.Errorf("Settings.UpdateSettings returned %+v, want %+v", settings, want)
+	}
+}
+
+// Test that a completely empty string is parsed as an empty struct properly.
+func TestSettingsWithEmptyString(t *testing.T) {
+	mux, client := setup(t)
+
+	mux.HandleFunc("/api/v4/application/settings", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, `""`)
+	})
+
+	settings, _, err := client.Settings.GetSettings()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &Settings{}
+	if !reflect.DeepEqual(settings, want) {
+		t.Errorf("Settings.UpdateSettings returned %+v, want %+v", settings, want)
+	}
+}


### PR DESCRIPTION
In the 17.0-nightly build, the ContainerRegistryImportCreatedBefore attribute now returns "" when the container registry isn't enabled. This causes a parsing error because an empty string isn't parseable as a date in Go. As a result, `GetSettings` fails on every instance without a container registry enabled.

This PR implements custom parsing logic for the `Settings` struct that discards that value if it's set to an empty string to ensure that the Settings can continue to parse properly.

You can see this being detected in the Terraform Provider Nightly tests here: https://gitlab.com/gitlab-org/terraform-provider-gitlab/-/jobs/6827815421#L1850
