### PR TITLE
Add more GitHub import API support

### DIFF
--- a/import.go
+++ b/import.go
@@ -89,7 +89,8 @@ func (s *ImportService) ImportRepositoryFromGitHub(opt *ImportRepositoryFromGitH
 	return gi, resp, nil
 }
 
-// GitHubImport represents the response from an import from GitHub.
+// CancelledGitHubImport represents the response when cancelling
+// an import from GitHub.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/import.html#cancel-github-project-import

--- a/import.go
+++ b/import.go
@@ -89,7 +89,7 @@ func (s *ImportService) ImportRepositoryFromGitHub(opt *ImportRepositoryFromGitH
 	return gi, resp, nil
 }
 
-// CancelledGitHubImport represents the response when cancelling
+// CancelledGitHubImport represents the response when canceling
 // an import from GitHub.
 //
 // GitLab API docs:

--- a/import.go
+++ b/import.go
@@ -88,3 +88,72 @@ func (s *ImportService) ImportRepositoryFromGitHub(opt *ImportRepositoryFromGitH
 
 	return gi, resp, nil
 }
+
+// GitHubImport represents the response from an import from GitHub.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/import.html#cancel-github-project-import
+type CancelledGitHubImport struct {
+	ID                    int    `json:"id"`
+	Name                  string `json:"name"`
+	FullPath              string `json:"full_path"`
+	FullName              string `json:"full_name"`
+	ImportSource          string `json:"import_source"`
+	ImportStatus          string `json:"import_status"`
+	HumanImportStatusName string `json:"human_import_status_name"`
+	ProviderLink          string `json:"provider_link"`
+}
+
+func (s CancelledGitHubImport) String() string {
+	return Stringify(s)
+}
+
+// CancelGitHubProjectImportOptions represents the available
+// CancelGitHubProjectImport() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/import.html#cancel-github-project-import
+type CancelGitHubProjectImportOptions struct {
+	ProjectID *int `url:"project_id,omitempty" json:"project_id,omitempty"`
+}
+
+// Cancel an import of a repository from GitHub.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/import.html#cancel-github-project-import
+func (s *ImportService) CancelGitHubProjectImport(opt *CancelGitHubProjectImportOptions, options ...RequestOptionFunc) (*CancelledGitHubImport, *Response, error) {
+	req, err := s.client.NewRequest(http.MethodPost, "import/github/cancel", opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	cgi := new(CancelledGitHubImport)
+	resp, err := s.client.Do(req, cgi)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return cgi, resp, nil
+}
+
+// ImportGitHubGistsIntoGitLabSnippetsOptions represents the available
+// ImportGitHubGistsIntoGitLabSnippets() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/import.html#import-github-gists-into-gitlab-snippets
+type ImportGitHubGistsIntoGitLabSnippetsOptions struct {
+	PersonalAccessToken *string `url:"personal_access_token,omitempty" json:"personal_access_token,omitempty"`
+}
+
+// Import personal GitHub Gists into personal GitLab Snippets.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/import.html#import-github-gists-into-gitlab-snippets
+func (s *ImportService) ImportGitHubGistsIntoGitLabSnippets(opt *ImportGitHubGistsIntoGitLabSnippetsOptions, options ...RequestOptionFunc) (*Response, error) {
+	req, err := s.client.NewRequest(http.MethodPost, "import/github/gists", opt, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}

--- a/import_test.go
+++ b/import_test.go
@@ -3,8 +3,9 @@ package gitlab
 import (
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestImportService_ImportRepositoryFromGitHub(t *testing.T) {
@@ -47,12 +48,76 @@ func TestImportService_ImportRepositoryFromGitHub(t *testing.T) {
 		TargetNamespace:     Ptr("root"),
 	}
 
-	gi, _, err := client.Import.ImportRepositoryFromGitHub(opt)
-	if err != nil {
-		t.Errorf("Import.ImportRepositoryFromGitHub returned error: %v", err)
+	gi, resp, err := client.Import.ImportRepositoryFromGitHub(opt)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, want, gi)
+
+	gi, resp, err = client.Import.ImportRepositoryFromGitHub(opt, errorOption)
+	require.EqualError(t, err, "RequestOptionFunc returns an error")
+	require.Nil(t, resp)
+	require.Nil(t, gi)
+}
+
+func TestImportService_CancelGitHubProjectImport(t *testing.T) {
+	mux, client := setup(t)
+
+	mux.HandleFunc("/api/v4/import/github/cancel", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		fmt.Fprintf(w, `
+			{
+				"id": 27,
+				"name": "my-repo",
+				"full_path": "/root/my-repo",
+				"full_name": "Administrator / my-repo",
+				"import_source": "my-github/repo",
+				"import_status": "scheduled",
+				"human_import_status_name": "scheduled",
+				"provider_link": "/my-github/repo"
+			}
+		`)
+	})
+
+	want := &CancelledGitHubImport{
+		ID:                    27,
+		Name:                  "my-repo",
+		FullPath:              "/root/my-repo",
+		FullName:              "Administrator / my-repo",
+		ImportSource:          "my-github/repo",
+		ImportStatus:          "scheduled",
+		HumanImportStatusName: "scheduled",
+		ProviderLink:          "/my-github/repo",
 	}
 
-	if !reflect.DeepEqual(want, gi) {
-		t.Errorf("Import.ImportRepositoryFromGitHub return %+v, want %+v", gi, want)
+	opt := &CancelGitHubProjectImportOptions{
+		ProjectID: Ptr(27),
 	}
+
+	cgi, resp, err := client.Import.CancelGitHubProjectImport(opt)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, want, cgi)
+
+	cgi, resp, err = client.Import.CancelGitHubProjectImport(opt, errorOption)
+	require.EqualError(t, err, "RequestOptionFunc returns an error")
+	require.Nil(t, resp)
+	require.Nil(t, cgi)
+}
+
+func TestImportService_ImportGitHubGistsIntoGitLabSnippets(t *testing.T) {
+	mux, client := setup(t)
+
+	mux.HandleFunc("/api/v4/import/github/gists", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+	})
+
+	opt := &ImportGitHubGistsIntoGitLabSnippetsOptions{PersonalAccessToken: Ptr("token")}
+
+	resp, err := client.Import.ImportGitHubGistsIntoGitLabSnippets(opt)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	resp, err = client.Import.ImportGitHubGistsIntoGitLabSnippets(opt, errorOption)
+	require.EqualError(t, err, "RequestOptionFunc returns an error")
+	require.Nil(t, resp)
 }

--- a/types.go
+++ b/types.go
@@ -424,15 +424,6 @@ func GenericPackageStatus(v GenericPackageStatusValue) *GenericPackageStatusValu
 	return Ptr(v)
 }
 
-// ImportTimeoutStrategy represents the timeout strategy of an import.
-type ImportTimeoutStrategy string
-
-// The available import timeout strategies.
-const (
-	Optimistic  ImportTimeoutStrategy = "optimistic"
-	Pessimistic ImportTimeoutStrategy = "pessimistic"
-)
-
 // ISOTime represents an ISO 8601 formatted date.
 type ISOTime time.Time
 

--- a/types.go
+++ b/types.go
@@ -424,6 +424,15 @@ func GenericPackageStatus(v GenericPackageStatusValue) *GenericPackageStatusValu
 	return Ptr(v)
 }
 
+// ImportTimeoutStrategy represents the timeout strategy of an import.
+type ImportTimeoutStrategy string
+
+// The available import timeout strategies.
+const (
+	Optimistic  ImportTimeoutStrategy = "optimistic"
+	Pessimistic ImportTimeoutStrategy = "pessimistic"
+)
+
 // ISOTime represents an ISO 8601 formatted date.
 type ISOTime time.Time
 


### PR DESCRIPTION
Adds the Import API endpoints for cancelling a GitHub import and importing GitHub gists into personal GitLab snippets.