### PR TITLE
Support `action` property in all Note webhooks

### DIFF
--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -102,21 +102,22 @@ type CommitCommentEvent struct {
 	} `json:"project"`
 	Repository       *Repository `json:"repository"`
 	ObjectAttributes struct {
-		ID           int    `json:"id"`
-		Note         string `json:"note"`
-		NoteableType string `json:"noteable_type"`
-		AuthorID     int    `json:"author_id"`
-		CreatedAt    string `json:"created_at"`
-		UpdatedAt    string `json:"updated_at"`
-		ProjectID    int    `json:"project_id"`
-		Attachment   string `json:"attachment"`
-		LineCode     string `json:"line_code"`
-		CommitID     string `json:"commit_id"`
-		NoteableID   int    `json:"noteable_id"`
-		System       bool   `json:"system"`
-		StDiff       *Diff  `json:"st_diff"`
-		Description  string `json:"description"`
-		URL          string `json:"url"`
+		ID           int                `json:"id"`
+		Note         string             `json:"note"`
+		NoteableType string             `json:"noteable_type"`
+		AuthorID     int                `json:"author_id"`
+		CreatedAt    string             `json:"created_at"`
+		UpdatedAt    string             `json:"updated_at"`
+		ProjectID    int                `json:"project_id"`
+		Attachment   string             `json:"attachment"`
+		LineCode     string             `json:"line_code"`
+		CommitID     string             `json:"commit_id"`
+		NoteableID   int                `json:"noteable_id"`
+		System       bool               `json:"system"`
+		StDiff       *Diff              `json:"st_diff"`
+		Description  string             `json:"description"`
+		Action       CommentEventAction `json:"action"`
+		URL          string             `json:"url"`
 	} `json:"object_attributes"`
 	Commit *struct {
 		ID        string     `json:"id"`
@@ -254,22 +255,23 @@ type IssueCommentEvent struct {
 	} `json:"project"`
 	Repository       *Repository `json:"repository"`
 	ObjectAttributes struct {
-		ID           int     `json:"id"`
-		Note         string  `json:"note"`
-		NoteableType string  `json:"noteable_type"`
-		AuthorID     int     `json:"author_id"`
-		CreatedAt    string  `json:"created_at"`
-		UpdatedAt    string  `json:"updated_at"`
-		ProjectID    int     `json:"project_id"`
-		Attachment   string  `json:"attachment"`
-		LineCode     string  `json:"line_code"`
-		CommitID     string  `json:"commit_id"`
-		DiscussionID string  `json:"discussion_id"`
-		NoteableID   int     `json:"noteable_id"`
-		System       bool    `json:"system"`
-		StDiff       []*Diff `json:"st_diff"`
-		Description  string  `json:"description"`
-		URL          string  `json:"url"`
+		ID           int                `json:"id"`
+		Note         string             `json:"note"`
+		NoteableType string             `json:"noteable_type"`
+		AuthorID     int                `json:"author_id"`
+		CreatedAt    string             `json:"created_at"`
+		UpdatedAt    string             `json:"updated_at"`
+		ProjectID    int                `json:"project_id"`
+		Attachment   string             `json:"attachment"`
+		LineCode     string             `json:"line_code"`
+		CommitID     string             `json:"commit_id"`
+		DiscussionID string             `json:"discussion_id"`
+		NoteableID   int                `json:"noteable_id"`
+		System       bool               `json:"system"`
+		StDiff       []*Diff            `json:"st_diff"`
+		Description  string             `json:"description"`
+		Action       CommentEventAction `json:"action"`
+		URL          string             `json:"url"`
 	} `json:"object_attributes"`
 	Issue struct {
 		ID                  int           `json:"id"`
@@ -513,30 +515,31 @@ type MergeCommentEvent struct {
 		Visibility        VisibilityValue `json:"visibility"`
 	} `json:"project"`
 	ObjectAttributes struct {
-		Attachment       string        `json:"attachment"`
-		AuthorID         int           `json:"author_id"`
-		ChangePosition   *NotePosition `json:"change_position"`
-		CommitID         string        `json:"commit_id"`
-		CreatedAt        string        `json:"created_at"`
-		DiscussionID     string        `json:"discussion_id"`
-		ID               int           `json:"id"`
-		LineCode         string        `json:"line_code"`
-		Note             string        `json:"note"`
-		NoteableID       int           `json:"noteable_id"`
-		NoteableType     string        `json:"noteable_type"`
-		OriginalPosition *NotePosition `json:"original_position"`
-		Position         *NotePosition `json:"position"`
-		ProjectID        int           `json:"project_id"`
-		ResolvedAt       string        `json:"resolved_at"`
-		ResolvedByID     int           `json:"resolved_by_id"`
-		ResolvedByPush   bool          `json:"resolved_by_push"`
-		StDiff           *Diff         `json:"st_diff"`
-		System           bool          `json:"system"`
-		Type             string        `json:"type"`
-		UpdatedAt        string        `json:"updated_at"`
-		UpdatedByID      int           `json:"updated_by_id"`
-		Description      string        `json:"description"`
-		URL              string        `json:"url"`
+		Attachment       string             `json:"attachment"`
+		AuthorID         int                `json:"author_id"`
+		ChangePosition   *NotePosition      `json:"change_position"`
+		CommitID         string             `json:"commit_id"`
+		CreatedAt        string             `json:"created_at"`
+		DiscussionID     string             `json:"discussion_id"`
+		ID               int                `json:"id"`
+		LineCode         string             `json:"line_code"`
+		Note             string             `json:"note"`
+		NoteableID       int                `json:"noteable_id"`
+		NoteableType     string             `json:"noteable_type"`
+		OriginalPosition *NotePosition      `json:"original_position"`
+		Position         *NotePosition      `json:"position"`
+		ProjectID        int                `json:"project_id"`
+		ResolvedAt       string             `json:"resolved_at"`
+		ResolvedByID     int                `json:"resolved_by_id"`
+		ResolvedByPush   bool               `json:"resolved_by_push"`
+		StDiff           *Diff              `json:"st_diff"`
+		System           bool               `json:"system"`
+		Type             string             `json:"type"`
+		UpdatedAt        string             `json:"updated_at"`
+		UpdatedByID      int                `json:"updated_by_id"`
+		Description      string             `json:"description"`
+		Action           CommentEventAction `json:"action"`
+		URL              string             `json:"url"`
 	} `json:"object_attributes"`
 	Repository   *Repository `json:"repository"`
 	MergeRequest struct {
@@ -1096,21 +1099,22 @@ type SnippetCommentEvent struct {
 	} `json:"project"`
 	Repository       *Repository `json:"repository"`
 	ObjectAttributes struct {
-		ID           int    `json:"id"`
-		Note         string `json:"note"`
-		NoteableType string `json:"noteable_type"`
-		AuthorID     int    `json:"author_id"`
-		CreatedAt    string `json:"created_at"`
-		UpdatedAt    string `json:"updated_at"`
-		ProjectID    int    `json:"project_id"`
-		Attachment   string `json:"attachment"`
-		LineCode     string `json:"line_code"`
-		CommitID     string `json:"commit_id"`
-		NoteableID   int    `json:"noteable_id"`
-		System       bool   `json:"system"`
-		StDiff       *Diff  `json:"st_diff"`
-		Description  string `json:"description"`
-		URL          string `json:"url"`
+		ID           int                `json:"id"`
+		Note         string             `json:"note"`
+		NoteableType string             `json:"noteable_type"`
+		AuthorID     int                `json:"author_id"`
+		CreatedAt    string             `json:"created_at"`
+		UpdatedAt    string             `json:"updated_at"`
+		ProjectID    int                `json:"project_id"`
+		Attachment   string             `json:"attachment"`
+		LineCode     string             `json:"line_code"`
+		CommitID     string             `json:"commit_id"`
+		NoteableID   int                `json:"noteable_id"`
+		System       bool               `json:"system"`
+		StDiff       *Diff              `json:"st_diff"`
+		Description  string             `json:"description"`
+		Action       CommentEventAction `json:"action"`
+		URL          string             `json:"url"`
 	} `json:"object_attributes"`
 	Snippet *struct {
 		ID                 int    `json:"id"`

--- a/event_webhook_types_test.go
+++ b/event_webhook_types_test.go
@@ -101,6 +101,10 @@ func TestCommitCommentEventUnmarshal(t *testing.T) {
 		t.Errorf("NoteableType is %v, want %v", event.ObjectAttributes.NoteableType, "Commit")
 	}
 
+	if event.ObjectAttributes.Action != CommentEventActionCreate {
+		t.Errorf("Action is %v, want %v", event.ObjectAttributes.Action, "create")
+	}
+
 	if event.Commit.Title != "Add submodule" {
 		t.Errorf("Issue title is %v, want %v", event.Commit.Title, "Add submodule")
 	}
@@ -350,6 +354,10 @@ func TestIssueCommentEventUnmarshal(t *testing.T) {
 		t.Errorf("NoteableType is %v, want %v", event.ObjectAttributes.NoteableType, "Issue")
 	}
 
+	if event.ObjectAttributes.Action != CommentEventActionCreate {
+		t.Errorf("Action is %v, want %v", event.ObjectAttributes.Action, "create")
+	}
+
 	if event.Issue.Title != "test_issue" {
 		t.Errorf("Issue title is %v, want %v", event.Issue.Title, "test_issue")
 	}
@@ -545,6 +553,10 @@ func TestMergeCommentEventUnmarshal(t *testing.T) {
 
 	if event.ObjectAttributes.NoteableType != "MergeRequest" {
 		t.Errorf("ObjectAttributes.NoteableType is %v, want %v", event.ObjectAttributes.NoteableType, "MergeRequest")
+	}
+
+	if event.ObjectAttributes.Action != CommentEventActionCreate {
+		t.Errorf("Action is %v, want %v", event.ObjectAttributes.Action, "create")
 	}
 
 	if event.ObjectAttributes.AuthorID != 1 {

--- a/testdata/webhooks/note_commit.json
+++ b/testdata/webhooks/note_commit.json
@@ -56,6 +56,7 @@
       "deleted_file": false
     },
     "description": "This is a commit comment. How does this work?",
+    "action": "create",
     "url": "http://example.com/gitlab-org/gitlab-test/commit/cfe32cf61b73a0d5e9f13e774abde7ff789b1660#note_1243"
   },
   "commit": {

--- a/testdata/webhooks/note_issue.json
+++ b/testdata/webhooks/note_issue.json
@@ -47,6 +47,7 @@
     "system": false,
     "st_diff": null,
     "description": "Hello world",
+    "action": "create",
     "url": "http://example.com/gitlab-org/gitlab-test/issues/17#note_1241"
   },
   "issue": {

--- a/testdata/webhooks/note_merge_request.json
+++ b/testdata/webhooks/note_merge_request.json
@@ -46,6 +46,7 @@
     "noteable_id": 7,
     "system": false,
     "st_diff": null,
+    "action": "create",
     "url": "http://example.com/gitlab-org/gitlab-test/merge_requests/1#note_1244"
   },
   "merge_request": {

--- a/testdata/webhooks/note_snippet.json
+++ b/testdata/webhooks/note_snippet.json
@@ -56,6 +56,7 @@
     "type": null,
     "updated_by_id": null,
     "description": "Is this snippet doing what it's supposed to be doing?",
+    "action": "create",
     "url": "http://example.com/gitlab-org/gitlab-test/snippets/53#note_1245"
   },
   "snippet": {

--- a/types.go
+++ b/types.go
@@ -256,6 +256,17 @@ func BuildState(v BuildStateValue) *BuildStateValue {
 	return Ptr(v)
 }
 
+// CommentEventAction identifies if a comment has been newly created or updated.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#comment-events
+type CommentEventAction string
+
+const (
+	CommentEventActionCreate CommentEventAction = "create"
+	CommentEventActionUpdate CommentEventAction = "update"
+)
+
 // ContainerRegistryStatus represents the status of a Container Registry.
 //
 // GitLab API docs:


### PR DESCRIPTION
This was introduced in GitLab 16.11, see https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#comment-events