### PR TITLE
add WebURL field to LastPipeline

### DIFF
--- a/pipeline_schedules.go
+++ b/pipeline_schedules.go
@@ -56,6 +56,7 @@ type LastPipeline struct {
 	SHA    string `json:"sha"`
 	Ref    string `json:"ref"`
 	Status string `json:"status"`
+	WebURL string `json:"web_url"`
 }
 
 // ListPipelineSchedulesOptions represents the available ListPipelineTriggers() options.


### PR DESCRIPTION
https://docs.gitlab.com/ee/api/pipeline_schedules.html#get-a-single-pipeline-schedule

`GET /projects/:id/pipeline_schedules/:pipeline_schedule_id` response structure from GitLab 16.7:

```
{
  "id": "",
  "description": "",
  "ref": "",
  "cron": "",
  "cron_timezone": "",
  "next_run_at": "",
  "active": "",
  "created_at": "",
  "updated_at": "",
  "owner": {
    "id": "",
    "username": "",
    "name": "",
    "state": "",
    "locked": "",
    "avatar_url": "",
    "web_url": ""
  },
  "last_pipeline": {
    "id": "",
    "iid": "",
    "project_id": "",
    "sha": "",
    "ref": "",
    "status": "",
    "source": "",
    "created_at": "",
    "updated_at": "",
    "web_url": ""
  },
  "variables": []
}
```