### PR TITLE
Add support for rotating/revoking currently authenticated personal access token

### DIFF
--- a/personal_access_tokens.go
+++ b/personal_access_tokens.go
@@ -129,7 +129,12 @@ type RotatePersonalAccessTokenOptions struct {
 	ExpiresAt *ISOTime `url:"expires_at,omitempty" json:"expires_at,omitempty"`
 }
 
-// RotatePersonalAccessToken revokes a token and returns a new token that
+// RotatePersonalAccessToken is a backwards-compat shim for RotatePersonalAccessTokenByID.
+func (s *PersonalAccessTokensService) RotatePersonalAccessToken(token int, opt *RotatePersonalAccessTokenOptions, options ...RequestOptionFunc) (*PersonalAccessToken, *Response, error) {
+	return s.RotatePersonalAccessTokenByID(token, opt, options...)
+}
+
+// RotatePersonalAccessTokenByID revokes a token and returns a new token that
 // expires in one week per default.
 //
 // GitLab API docs:
@@ -151,12 +156,12 @@ func (s *PersonalAccessTokensService) RotatePersonalAccessTokenByID(token int, o
 	return pat, resp, nil
 }
 
-// RotatePersonalAccessToken revokes the currently authenticated token
+// RotatePersonalAccessTokenSelf revokes the currently authenticated token
 // and returns a new token that expires in one week per default.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/personal_access_tokens.html#use-a-request-header
-func (s *PersonalAccessTokensService) RotatePersonalAccessToken(opt *RotatePersonalAccessTokenOptions, options ...RequestOptionFunc) (*PersonalAccessToken, *Response, error) {
+func (s *PersonalAccessTokensService) RotatePersonalAccessTokenSelf(opt *RotatePersonalAccessTokenOptions, options ...RequestOptionFunc) (*PersonalAccessToken, *Response, error) {
 	u := "personal_access_tokens/self/rotate"
 
 	req, err := s.client.NewRequest(http.MethodPost, u, opt, options)
@@ -173,7 +178,12 @@ func (s *PersonalAccessTokensService) RotatePersonalAccessToken(opt *RotatePerso
 	return pat, resp, nil
 }
 
-// RevokePersonalAccessToken revokes a personal access token by its ID.
+// RevokePersonalAccessToken is a backwards-compat shim for RevokePersonalAccessTokenByID.
+func (s *PersonalAccessTokensService) RevokePersonalAccessToken(token int, options ...RequestOptionFunc) (*Response, error) {
+	return s.RevokePersonalAccessTokenByID(token, options...)
+}
+
+// RevokePersonalAccessTokenByID revokes a personal access token by its ID.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/personal_access_tokens.html#using-a-personal-access-token-id-1
@@ -188,12 +198,12 @@ func (s *PersonalAccessTokensService) RevokePersonalAccessTokenByID(token int, o
 	return s.client.Do(req, nil)
 }
 
-// RevokePersonalAccessToken revokes the currently authenticated
+// RevokePersonalAccessTokenSelf revokes the currently authenticated
 // personal access token.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/personal_access_tokens.html#using-a-personal-access-token-id-1
-func (s *PersonalAccessTokensService) RevokePersonalAccessToken(options ...RequestOptionFunc) (*Response, error) {
+// https://docs.gitlab.com/ee/api/personal_access_tokens.html#using-a-request-header-1
+func (s *PersonalAccessTokensService) RevokePersonalAccessTokenSelf(options ...RequestOptionFunc) (*Response, error) {
 	u := "personal_access_tokens/self"
 
 	req, err := s.client.NewRequest(http.MethodDelete, u, nil, options)

--- a/personal_access_tokens.go
+++ b/personal_access_tokens.go
@@ -133,8 +133,8 @@ type RotatePersonalAccessTokenOptions struct {
 // expires in one week per default.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/personal_access_tokens.html#rotate-a-personal-access-token
-func (s *PersonalAccessTokensService) RotatePersonalAccessToken(token int, opt *RotatePersonalAccessTokenOptions, options ...RequestOptionFunc) (*PersonalAccessToken, *Response, error) {
+// https://docs.gitlab.com/ee/api/personal_access_tokens.html#use-a-personal-access-token-id
+func (s *PersonalAccessTokensService) RotatePersonalAccessTokenByID(token int, opt *RotatePersonalAccessTokenOptions, options ...RequestOptionFunc) (*PersonalAccessToken, *Response, error) {
 	u := fmt.Sprintf("personal_access_tokens/%d/rotate", token)
 
 	req, err := s.client.NewRequest(http.MethodPost, u, opt, options)
@@ -151,12 +151,50 @@ func (s *PersonalAccessTokensService) RotatePersonalAccessToken(token int, opt *
 	return pat, resp, nil
 }
 
-// RevokePersonalAccessToken revokes a personal access token.
+// RotatePersonalAccessToken revokes the currently authenticated token
+// and returns a new token that expires in one week per default.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ee/api/personal_access_tokens.html#revoke-a-personal-access-token
-func (s *PersonalAccessTokensService) RevokePersonalAccessToken(token int, options ...RequestOptionFunc) (*Response, error) {
+// https://docs.gitlab.com/ee/api/personal_access_tokens.html#use-a-request-header
+func (s *PersonalAccessTokensService) RotatePersonalAccessToken(opt *RotatePersonalAccessTokenOptions, options ...RequestOptionFunc) (*PersonalAccessToken, *Response, error) {
+	u := "personal_access_tokens/self/rotate"
+
+	req, err := s.client.NewRequest(http.MethodPost, u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pat := new(PersonalAccessToken)
+	resp, err := s.client.Do(req, pat)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return pat, resp, nil
+}
+
+// RevokePersonalAccessToken revokes a personal access token by its ID.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/personal_access_tokens.html#using-a-personal-access-token-id-1
+func (s *PersonalAccessTokensService) RevokePersonalAccessTokenByID(token int, options ...RequestOptionFunc) (*Response, error) {
 	u := fmt.Sprintf("personal_access_tokens/%d", token)
+
+	req, err := s.client.NewRequest(http.MethodDelete, u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// RevokePersonalAccessToken revokes the currently authenticated
+// personal access token.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/personal_access_tokens.html#using-a-personal-access-token-id-1
+func (s *PersonalAccessTokensService) RevokePersonalAccessToken(options ...RequestOptionFunc) (*Response, error) {
+	u := "personal_access_tokens/self"
 
 	req, err := s.client.NewRequest(http.MethodDelete, u, nil, options)
 	if err != nil {

--- a/personal_access_tokens_test.go
+++ b/personal_access_tokens_test.go
@@ -31,7 +31,9 @@ func TestListPersonalAccessTokensWithUserFilter(t *testing.T) {
 		mustWriteHTTPResponse(t, w, "testdata/list_personal_access_tokens_with_user_filter.json")
 	})
 
-	personalAccessTokens, _, err := client.PersonalAccessTokens.ListPersonalAccessTokens(&ListPersonalAccessTokensOptions{UserID: Ptr(1), ListOptions: ListOptions{Page: 1, PerPage: 10}})
+	personalAccessTokens, _, err := client.PersonalAccessTokens.ListPersonalAccessTokens(
+		&ListPersonalAccessTokensOptions{UserID: Ptr(1), ListOptions: ListOptions{Page: 1, PerPage: 10}},
+	)
 	if err != nil {
 		t.Errorf("PersonalAccessTokens.ListPersonalAccessTokens returned error: %v", err)
 	}
@@ -81,7 +83,9 @@ func TestListPersonalAccessTokensWithUserFilter(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(want, personalAccessTokens) {
-		t.Errorf("PersonalAccessTokens.ListPersonalAccessTokens returned %+v, want %+v", personalAccessTokens, want)
+		t.Errorf(
+			"PersonalAccessTokens.ListPersonalAccessTokens returned %+v, want %+v", personalAccessTokens, want,
+		)
 	}
 }
 
@@ -93,7 +97,9 @@ func TestListPersonalAccessTokensNoUserFilter(t *testing.T) {
 		mustWriteHTTPResponse(t, w, "testdata/list_personal_access_tokens_without_user_filter.json")
 	})
 
-	personalAccessTokens, _, err := client.PersonalAccessTokens.ListPersonalAccessTokens(&ListPersonalAccessTokensOptions{ListOptions: ListOptions{Page: 1, PerPage: 10}})
+	personalAccessTokens, _, err := client.PersonalAccessTokens.ListPersonalAccessTokens(
+		&ListPersonalAccessTokensOptions{ListOptions: ListOptions{Page: 1, PerPage: 10}},
+	)
 	if err != nil {
 		t.Errorf("PersonalAccessTokens.ListPersonalAccessTokens returned error: %v", err)
 	}
@@ -143,7 +149,9 @@ func TestListPersonalAccessTokensNoUserFilter(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(want, personalAccessTokens) {
-		t.Errorf("PersonalAccessTokens.ListPersonalAccessTokens returned %+v, want %+v", personalAccessTokens, want)
+		t.Errorf(
+			"PersonalAccessTokens.ListPersonalAccessTokens returned %+v, want %+v", personalAccessTokens, want,
+		)
 	}
 }
 
@@ -253,7 +261,9 @@ func TestRotatePersonalAccessToken(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(want, rotatedToken) {
-		t.Errorf("PersonalAccessTokens.RotatePersonalAccessToken returned %+v, want %+v", rotatedToken, want)
+		t.Errorf(
+			"PersonalAccessTokens.RotatePersonalAccessToken returned %+v, want %+v", rotatedToken, want,
+		)
 	}
 }
 
@@ -285,7 +295,9 @@ func TestRotatePersonalAccessTokenByID(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(want, rotatedToken) {
-		t.Errorf("PersonalAccessTokens.RotatePersonalAccessTokenByID returned %+v, want %+v", rotatedToken, want)
+		t.Errorf(
+			"PersonalAccessTokens.RotatePersonalAccessTokenByID returned %+v, want %+v", rotatedToken, want,
+		)
 	}
 }
 


### PR DESCRIPTION
Relates to #1686.

This PR does the following:

1. Adds `RotatePersonalAccessTokenSelf` for invoking the [`POST /personal_access_tokens/self/rotate` endpoint](https://docs.gitlab.com/ee/api/personal_access_tokens.html#use-a-request-header);
2. Adds `RevokePersonalAccessTokenSelf` for invoking the [`DELETE /personal_access_tokens/self` endpoint](https://docs.gitlab.com/ee/api/personal_access_tokens.html#using-a-request-header-1);
3. Renames the ambiguous `RotatePersonalAccessToken` to `RotatePersonalAccessTokenByID`;
4. Renames the ambiguous `RevokePersonalAccessToken` to `RevokePersonalAccessTokenByID`;
5. Adds a backwards-compatibility shim `RotatePersonalAccessToken` that calls `RotatePersonalAccessTokenByID`; and,
6. Adds a backwards-compatibility shim `RevokePersonalAccessToken` that calls `RevokePersonalAccessTokenByID`.