### PR TITLE
Add ExtendedTrailers to snippets struct

### DIFF
--- a/commits.go
+++ b/commits.go
@@ -52,6 +52,7 @@ type Commit struct {
 	LastPipeline   *PipelineInfo     `json:"last_pipeline"`
 	ProjectID      int               `json:"project_id"`
 	Trailers       map[string]string `json:"trailers"`
+	Extended_trailers map[string]string `json:"extended_trailers"`
 	WebURL         string            `json:"web_url"`
 }
 

--- a/commits.go
+++ b/commits.go
@@ -35,25 +35,25 @@ type CommitsService struct {
 //
 // GitLab API docs: https://docs.gitlab.com/ee/api/commits.html
 type Commit struct {
-	ID             string            `json:"id"`
-	ShortID        string            `json:"short_id"`
-	Title          string            `json:"title"`
-	AuthorName     string            `json:"author_name"`
-	AuthorEmail    string            `json:"author_email"`
-	AuthoredDate   *time.Time        `json:"authored_date"`
-	CommitterName  string            `json:"committer_name"`
-	CommitterEmail string            `json:"committer_email"`
-	CommittedDate  *time.Time        `json:"committed_date"`
-	CreatedAt      *time.Time        `json:"created_at"`
-	Message        string            `json:"message"`
-	ParentIDs      []string          `json:"parent_ids"`
-	Stats          *CommitStats      `json:"stats"`
-	Status         *BuildStateValue  `json:"status"`
-	LastPipeline   *PipelineInfo     `json:"last_pipeline"`
-	ProjectID      int               `json:"project_id"`
-	Trailers       map[string]string `json:"trailers"`
+	ID               string            `json:"id"`
+	ShortID          string            `json:"short_id"`
+	Title            string            `json:"title"`
+	AuthorName       string            `json:"author_name"`
+	AuthorEmail      string            `json:"author_email"`
+	AuthoredDate     *time.Time        `json:"authored_date"`
+	CommitterName    string            `json:"committer_name"`
+	CommitterEmail   string            `json:"committer_email"`
+	CommittedDate    *time.Time        `json:"committed_date"`
+	CreatedAt        *time.Time        `json:"created_at"`
+	Message          string            `json:"message"`
+	ParentIDs        []string          `json:"parent_ids"`
+	Stats            *CommitStats      `json:"stats"`
+	Status           *BuildStateValue  `json:"status"`
+	LastPipeline     *PipelineInfo     `json:"last_pipeline"`
+	ProjectID        int               `json:"project_id"`
+	Trailers         map[string]string `json:"trailers"`
 	ExtendedTrailers map[string]string `json:"extended_trailers"`
-	WebURL         string            `json:"web_url"`
+	WebURL           string            `json:"web_url"`
 }
 
 // CommitStats represents the number of added and deleted files in a commit.

--- a/commits.go
+++ b/commits.go
@@ -52,7 +52,7 @@ type Commit struct {
 	LastPipeline   *PipelineInfo     `json:"last_pipeline"`
 	ProjectID      int               `json:"project_id"`
 	Trailers       map[string]string `json:"trailers"`
-	Extended_trailers map[string]string `json:"extended_trailers"`
+	ExtendedTrailers map[string]string `json:"extended_trailers"`
 	WebURL         string            `json:"web_url"`
 }
 


### PR DESCRIPTION
The version of gitlab I am using is v17.0.1, and while modifying the gitlab file using the go-gitlab library, I encountered an error "json: cannot unmarshal array into Go value of type gitlab.Commit",Screening is found that the new gitlab interface/projects / : id/repository/commits Extended_trailers increases the field, so you need to in commits. Go in the structure of the Commit increase to solve this problem. See https://docs.gitlab.com/ee/api/commits.html gitlab document