### PR TITLE
Add LFS field to GetRawFileOptions

### DIFF
--- a/repository_files.go
+++ b/repository_files.go
@@ -215,6 +215,7 @@ func (s *RepositoryFilesService) GetFileBlame(pid interface{}, file string, opt 
 // https://docs.gitlab.com/ee/api/repository_files.html#get-raw-file-from-repository
 type GetRawFileOptions struct {
 	Ref *string `url:"ref,omitempty" json:"ref,omitempty"`
+	LFS *bool   `url:"lfs,omitempty" json:"lfs,omitempty"`
 }
 
 // GetRawFile allows you to receive the raw file in repository.


### PR DESCRIPTION
Small PR adding a missing field to the `GetRawFileOptions` struct.

https://docs.gitlab.com/ee/api/repository_files.html#get-raw-file-from-repository
<img width="863" alt="gitlab lfs field" src="https://github.com/xanzy/go-gitlab/assets/3055319/e825c0fd-b51d-4144-83bc-e1896873f2cb">
