### PR TITLE
Add TriggerTestProjectHook function to ProjectsService

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -1411,28 +1411,13 @@ func (s *ProjectsService) DeleteProjectHook(pid interface{}, hook int, options .
 	return s.client.Do(req, nil)
 }
 
-type ProjectHookEvent string
-
-const (
-	ProjectHookEventPush                ProjectHookEvent = "push_events"
-	ProjectHookEventTagPush             ProjectHookEvent = "tag_push_events"
-	ProjectHookEventIssues              ProjectHookEvent = "issues_events"
-	ProjectHookEventConfidentialIssues  ProjectHookEvent = "confidential_issues_events"
-	ProjectHookEventNote                ProjectHookEvent = "note_events"
-	ProjectHookEventMergeRequests       ProjectHookEvent = "merge_requests_events"
-	ProjectHookEventJob                 ProjectHookEvent = "job_events"
-	ProjectHookEventPipeline            ProjectHookEvent = "pipeline_events"
-	ProjectHookEventWiki                ProjectHookEvent = "wiki_page_events"
-	ProjectHookEventReleases            ProjectHookEvent = "releases_events"
-	ProjectHookEventEmoji               ProjectHookEvent = "emoji_events"
-	ProjectHookEventResourceAccessToken ProjectHookEvent = "resource_access_token_events"
-)
-
 // TriggerTestProjectHook Trigger a test hook for a specified project.
 //
 // In GitLab 17.0 and later, this endpoint has a special rate limit.
 // In GitLab 17.0 the rate was three requests per minute for each project hook.
-// In GitLab 17.1 this was changed to five requests per minute for each project and authenticated user.
+// In GitLab 17.1 this was changed to five requests per minute for each project
+// and authenticated user.
+//
 // To disable this limit on self-managed GitLab and GitLab Dedicated,
 // an administrator can disable the feature flag named web_hook_test_api_endpoint_rate_limit.
 //

--- a/projects.go
+++ b/projects.go
@@ -1411,6 +1411,48 @@ func (s *ProjectsService) DeleteProjectHook(pid interface{}, hook int, options .
 	return s.client.Do(req, nil)
 }
 
+type ProjectHookEvent string
+
+const (
+	ProjectHookEventPush                ProjectHookEvent = "push_events"
+	ProjectHookEventTagPush             ProjectHookEvent = "tag_push_events"
+	ProjectHookEventIssues              ProjectHookEvent = "issues_events"
+	ProjectHookEventConfidentialIssues  ProjectHookEvent = "confidential_issues_events"
+	ProjectHookEventNote                ProjectHookEvent = "note_events"
+	ProjectHookEventMergeRequests       ProjectHookEvent = "merge_requests_events"
+	ProjectHookEventJob                 ProjectHookEvent = "job_events"
+	ProjectHookEventPipeline            ProjectHookEvent = "pipeline_events"
+	ProjectHookEventWiki                ProjectHookEvent = "wiki_page_events"
+	ProjectHookEventReleases            ProjectHookEvent = "releases_events"
+	ProjectHookEventEmoji               ProjectHookEvent = "emoji_events"
+	ProjectHookEventResourceAccessToken ProjectHookEvent = "resource_access_token_events"
+)
+
+// TriggerTestProjectHook Trigger a test hook for a specified project.
+//
+// In GitLab 17.0 and later, this endpoint has a special rate limit.
+// In GitLab 17.0 the rate was three requests per minute for each project hook.
+// In GitLab 17.1 this was changed to five requests per minute for each project and authenticated user.
+// To disable this limit on self-managed GitLab and GitLab Dedicated,
+// an administrator can disable the feature flag named web_hook_test_api_endpoint_rate_limit.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/projects.html#trigger-a-test-project-hook
+func (s *ProjectsService) TriggerTestProjectHook(pid interface{}, hook int, event ProjectHookEvent, options ...RequestOptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/hooks/%d/test/%s", PathEscape(project), hook, string(event))
+
+	req, err := s.client.NewRequest(http.MethodPost, u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
 // SetHookCustomHeaderOptions represents a project or group hook custom header.
 // If the header isn't present, it will be created.
 //

--- a/types.go
+++ b/types.go
@@ -697,6 +697,29 @@ func ProjectCreationLevel(v ProjectCreationLevelValue) *ProjectCreationLevelValu
 	return Ptr(v)
 }
 
+// ProjectHookEvent represents a project hook event.
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/projects.html#hook-events
+type ProjectHookEvent string
+
+// List of available project hook events.
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/projects.html#hook-events
+const (
+	ProjectHookEventPush                ProjectHookEvent = "push_events"
+	ProjectHookEventTagPush             ProjectHookEvent = "tag_push_events"
+	ProjectHookEventIssues              ProjectHookEvent = "issues_events"
+	ProjectHookEventConfidentialIssues  ProjectHookEvent = "confidential_issues_events"
+	ProjectHookEventNote                ProjectHookEvent = "note_events"
+	ProjectHookEventMergeRequests       ProjectHookEvent = "merge_requests_events"
+	ProjectHookEventJob                 ProjectHookEvent = "job_events"
+	ProjectHookEventPipeline            ProjectHookEvent = "pipeline_events"
+	ProjectHookEventWiki                ProjectHookEvent = "wiki_page_events"
+	ProjectHookEventReleases            ProjectHookEvent = "releases_events"
+	ProjectHookEventEmoji               ProjectHookEvent = "emoji_events"
+	ProjectHookEventResourceAccessToken ProjectHookEvent = "resource_access_token_events"
+)
+
 // ResourceGroupProcessMode represents a process mode for a resource group
 // within a GitLab project.
 //


### PR DESCRIPTION
From GitLab 17.0+ they add "Trigger a test project hook" to test project's hook