### PR TITLE
Add full_path to project file

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -1521,6 +1521,7 @@ func (s *ProjectsService) DeleteProjectForkRelation(pid interface{}, options ...
 type ProjectFile struct {
 	Alt      string `json:"alt"`
 	URL      string `json:"url"`
+	FullPath string `json:"full_path"`
 	Markdown string `json:"markdown"`
 }
 


### PR DESCRIPTION
Uploading a project file in the GitLab API returns `full_path` containing the full path to the file on the GitLab server.
See https://docs.gitlab.com/ee/api/projects.html#upload-a-file

This PR adds the field to the ProjectFile struct.