### PR TITLE
fix: Change VariableType type from string to VariableTypeValue

### DIFF
--- a/jobs.go
+++ b/jobs.go
@@ -516,9 +516,9 @@ type PlayJobOptions struct {
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/jobs.html#run-a-job
 type JobVariableOptions struct {
-	Key          *string `url:"key,omitempty" json:"key,omitempty"`
-	Value        *string `url:"value,omitempty" json:"value,omitempty"`
-	VariableType *string `url:"variable_type,omitempty" json:"variable_type,omitempty"`
+	Key          *string            `url:"key,omitempty" json:"key,omitempty"`
+	Value        *string            `url:"value,omitempty" json:"value,omitempty"`
+	VariableType *VariableTypeValue `url:"variable_type,omitempty" json:"variable_type,omitempty"`
 }
 
 // PlayJob triggers a manual action to start a job.

--- a/pipeline_schedules.go
+++ b/pipeline_schedules.go
@@ -294,9 +294,9 @@ func (s *PipelineSchedulesService) RunPipelineSchedule(pid interface{}, schedule
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/pipeline_schedules.html#create-a-new-pipeline-schedule
 type CreatePipelineScheduleVariableOptions struct {
-	Key          *string `url:"key" json:"key"`
-	Value        *string `url:"value" json:"value"`
-	VariableType *string `url:"variable_type,omitempty" json:"variable_type,omitempty"`
+	Key          *string            `url:"key" json:"key"`
+	Value        *string            `url:"value" json:"value"`
+	VariableType *VariableTypeValue `url:"variable_type,omitempty" json:"variable_type,omitempty"`
 }
 
 // CreatePipelineScheduleVariable creates a pipeline schedule variable.
@@ -330,8 +330,8 @@ func (s *PipelineSchedulesService) CreatePipelineScheduleVariable(pid interface{
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/pipeline_schedules.html#edit-a-pipeline-schedule-variable
 type EditPipelineScheduleVariableOptions struct {
-	Value        *string `url:"value" json:"value"`
-	VariableType *string `url:"variable_type,omitempty" json:"variable_type,omitempty"`
+	Value        *string            `url:"value" json:"value"`
+	VariableType *VariableTypeValue `url:"variable_type,omitempty" json:"variable_type,omitempty"`
 }
 
 // EditPipelineScheduleVariable creates a pipeline schedule variable.

--- a/pipelines.go
+++ b/pipelines.go
@@ -34,9 +34,9 @@ type PipelinesService struct {
 //
 // GitLab API docs: https://docs.gitlab.com/ee/api/pipelines.html
 type PipelineVariable struct {
-	Key          string `json:"key"`
-	Value        string `json:"value"`
-	VariableType string `json:"variable_type"`
+	Key          string            `json:"key"`
+	Value        string            `json:"value"`
+	VariableType VariableTypeValue `json:"variable_type"`
 }
 
 // Pipeline represents a GitLab pipeline.
@@ -309,9 +309,9 @@ type CreatePipelineOptions struct {
 //
 // GitLab API docs: https://docs.gitlab.com/ee/api/pipelines.html#create-a-new-pipeline
 type PipelineVariableOptions struct {
-	Key          *string `url:"key,omitempty" json:"key,omitempty"`
-	Value        *string `url:"value,omitempty" json:"value,omitempty"`
-	VariableType *string `url:"variable_type,omitempty" json:"variable_type,omitempty"`
+	Key          *string            `url:"key,omitempty" json:"key,omitempty"`
+	Value        *string            `url:"value,omitempty" json:"value,omitempty"`
+	VariableType *VariableTypeValue `url:"variable_type,omitempty" json:"variable_type,omitempty"`
 }
 
 // CreatePipeline creates a new project pipeline.


### PR DESCRIPTION
Hi,
I changed the type of VariableType in pipelines.go, jobs.go and pipeline_schedules.go PipelineVariable Object from string to VariableTypeValue.
Indeed in group_variables.go line 123 the CreateGroupVariableOptions had this type for VariableType for example and I didn't find a reason why it would be different.

It passes test and gofumpt. 
I hope it will be useful !
Have a nice day
