### PR TITLE
chore: add report type to MergeRequestApprovalRule

### DIFF
--- a/merge_request_approvals.go
+++ b/merge_request_approvals.go
@@ -96,7 +96,7 @@ type MergeRequestApprovalRule struct {
 	RuleType             string               `json:"rule_type"`
 	ReportType           string               `json:"report_type"`
 	EligibleApprovers    []*BasicUser         `json:"eligible_approvers"`
-	ApprovalsRequired    int                  `json:"appro:wvals_required"`
+	ApprovalsRequired    int                  `json:"approvals_required"`
 	SourceRule           *ProjectApprovalRule `json:"source_rule"`
 	Users                []*BasicUser         `json:"users"`
 	Groups               []*Group             `json:"groups"`

--- a/merge_request_approvals.go
+++ b/merge_request_approvals.go
@@ -94,8 +94,9 @@ type MergeRequestApprovalRule struct {
 	ID                   int                  `json:"id"`
 	Name                 string               `json:"name"`
 	RuleType             string               `json:"rule_type"`
+	ReportType           string               `json:"report_type"`
 	EligibleApprovers    []*BasicUser         `json:"eligible_approvers"`
-	ApprovalsRequired    int                  `json:"approvals_required"`
+	ApprovalsRequired    int                  `json:"appro:wvals_required"`
 	SourceRule           *ProjectApprovalRule `json:"source_rule"`
 	Users                []*BasicUser         `json:"users"`
 	Groups               []*Group             `json:"groups"`


### PR DESCRIPTION
This attribute has been added to the approval_rules object - 

https://docs.gitlab.com/ee/api/merge_request_approvals.html#get-merge-request-level-rules

It should be returned by the enterprise edition and was added to gitlab with this PR - https://gitlab.com/gitlab-org/gitlab/-/merge_requests/155772.
That functionality was required as part of this PR against the terraform provider - https://gitlab.com/gitlab-org/terraform-provider-gitlab/-/merge_requests/1913

Happy to add a test but was wondering about it being an EE only feature?
