### PR TITLE
Adds `HookEventToken` helper function for X-Gitlab-Token

### DIFF
--- a/event_parsing.go
+++ b/event_parsing.go
@@ -72,6 +72,13 @@ type serviceEvent struct {
 	ObjectKind string `json:"object_kind"`
 }
 
+const eventTokenHeader = "X-Gitlab-Token"
+
+// HookEventToken returns the token for the given request.
+func HookEventToken(r *http.Request) string {
+	return r.Header.Get(eventTokenHeader)
+}
+
 const eventTypeHeader = "X-Gitlab-Event"
 
 // HookEventType returns the event type for the given request.

--- a/event_parsing_webhook_test.go
+++ b/event_parsing_webhook_test.go
@@ -37,6 +37,19 @@ func TestWebhookEventType(t *testing.T) {
 	}
 }
 
+func TestWebhookEventToken(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "https://gitlab.com", nil)
+	if err != nil {
+		t.Errorf("Error creating HTTP request: %s", err)
+	}
+	req.Header.Set("X-Gitlab-Token", "798d3dd3-67f5-41df-ad19-7882cc6263bf")
+
+	actualToken := HookEventToken(req)
+	if actualToken != "798d3dd3-67f5-41df-ad19-7882cc6263bf" {
+		t.Errorf("WebhookEventToken is %q, want %q", actualToken, "798d3dd3-67f5-41df-ad19-7882cc6263bf")
+	}
+}
+
 func TestParseBuildHook(t *testing.T) {
 	raw := loadFixture("testdata/webhooks/build.json")
 


### PR DESCRIPTION
- `HookEventToken` works just like `HookEventType` . Keeps the header in a const. 
- adds a test to ensure it can fetch it