### PR TITLE
Add `ContainerRegistrySize` field to `Statistics` struct

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -292,6 +292,7 @@ type Statistics struct {
 	PackagesSize          int64 `json:"packages_size"`
 	SnippetsSize          int64 `json:"snippets_size"`
 	UploadsSize           int64 `json:"uploads_size"`
+	ContainerRegistrySize int64 `json:"container_registry_size"`
 }
 
 func (s Project) String() string {

--- a/projects_test.go
+++ b/projects_test.go
@@ -441,7 +441,8 @@ func TestGetProjectWithOptions(t *testing.T) {
 				"pipeline_artifacts_size": 0,
 				"packages_size": 238906167,
 				"snippets_size": 146800,
-				"uploads_size": 6523619
+				"uploads_size": 6523619,
+				"container_registry_size": 284453
 			}}`)
 	})
 	want := &Project{ID: 1, Statistics: &Statistics{
@@ -455,6 +456,7 @@ func TestGetProjectWithOptions(t *testing.T) {
 		PackagesSize:          238906167,
 		SnippetsSize:          146800,
 		UploadsSize:           6523619,
+		ContainerRegistrySize: 284453,
 	}}
 
 	project, _, err := client.Projects.GetProject(1, &GetProjectOptions{Statistics: Ptr(true)})


### PR DESCRIPTION
The `ContainerRegistrySize` field is missing from the `Statistics`  struct.

The public GitLab API returns the `container_registry_size` field for project data. E.g. https://docs.gitlab.com/ee/api/projects.html#list-user-projects.

The public GitLab API does not return the `container_registry_size` field for group data. Thus, this change would cause that we always return the null value for `ContainerRegistrySize` when fetching groups, which is not optimal. However, we already always return the null value for the `commit_count` field in the `Statistics`  struct when fetching groups, as we use the same `Statistics`  struct for project and group data.