### PR TITLE
Add new DCO attribute to project and group push rules

### DIFF
--- a/groups.go
+++ b/groups.go
@@ -1037,6 +1037,7 @@ type GroupPushRules struct {
 	CommitCommitterCheck       bool       `json:"commit_committer_check"`
 	CommitCommitterNameCheck   bool       `json:"commit_committer_name_check"`
 	RejectUnsignedCommits      bool       `json:"reject_unsigned_commits"`
+	RejectNonDCOCommits        bool       `json:"reject_non_dco_commits"`
 }
 
 // GetGroupPushRules gets the push rules of a group.
@@ -1082,6 +1083,7 @@ type AddGroupPushRuleOptions struct {
 	MemberCheck                *bool   `url:"member_check,omitempty" json:"member_check,omitempty"`
 	PreventSecrets             *bool   `url:"prevent_secrets,omitempty" json:"prevent_secrets,omitempty"`
 	RejectUnsignedCommits      *bool   `url:"reject_unsigned_commits,omitempty" json:"reject_unsigned_commits,omitempty"`
+	RejectNonDCOCommits        *bool   `url:"reject_non_dco_commits,omitempty" json:"reject_non_dco_commits,omitempty"`
 }
 
 // AddGroupPushRule adds push rules to the specified group.
@@ -1127,6 +1129,7 @@ type EditGroupPushRuleOptions struct {
 	MemberCheck                *bool   `url:"member_check,omitempty" json:"member_check,omitempty"`
 	PreventSecrets             *bool   `url:"prevent_secrets,omitempty" json:"prevent_secrets,omitempty"`
 	RejectUnsignedCommits      *bool   `url:"reject_unsigned_commits,omitempty" json:"reject_unsigned_commits,omitempty"`
+	RejectNonDCOCommits        *bool   `url:"reject_non_dco_commits,omitempty" json:"reject_non_dco_commits,omitempty"`
 }
 
 // EditGroupPushRule edits a push rule for a specified group.

--- a/groups_test.go
+++ b/groups_test.go
@@ -906,7 +906,8 @@ func TestGetGroupPushRules(t *testing.T) {
 			"max_file_size": 5,
 			"commit_committer_check": false,
 			"commit_committer_name_check": false,
-			"reject_unsigned_commits": false
+			"reject_unsigned_commits": false,
+			"reject_non_dco_commits": false
 		  }`)
 	})
 
@@ -929,6 +930,7 @@ func TestGetGroupPushRules(t *testing.T) {
 		CommitCommitterCheck:       false,
 		CommitCommitterNameCheck:   false,
 		RejectUnsignedCommits:      false,
+		RejectNonDCOCommits:        false,
 	}
 
 	if !reflect.DeepEqual(want, rule) {
@@ -954,7 +956,8 @@ func TestAddGroupPushRules(t *testing.T) {
 			"max_file_size": 5,
 			"commit_committer_check": false,
 			"commit_committer_name_check": false,
-			"reject_unsigned_commits": false
+			"reject_unsigned_commits": false,
+			"reject_non_dco_commits": false
 		  }`)
 	})
 
@@ -971,6 +974,7 @@ func TestAddGroupPushRules(t *testing.T) {
 		CommitCommitterCheck:       Ptr(false),
 		CommitCommitterNameCheck:   Ptr(false),
 		RejectUnsignedCommits:      Ptr(false),
+		RejectNonDCOCommits:        Ptr(false),
 	}
 
 	rule, _, err := client.Groups.AddGroupPushRule(1, opt)
@@ -992,6 +996,7 @@ func TestAddGroupPushRules(t *testing.T) {
 		CommitCommitterCheck:       false,
 		CommitCommitterNameCheck:   false,
 		RejectUnsignedCommits:      false,
+		RejectNonDCOCommits:        false,
 	}
 
 	if !reflect.DeepEqual(want, rule) {
@@ -1017,7 +1022,8 @@ func TestEditGroupPushRules(t *testing.T) {
 			"max_file_size": 5,
 			"commit_committer_check": false,
 			"commit_committer_name_check": false,
-			"reject_unsigned_commits": false
+			"reject_unsigned_commits": false,
+			"reject_non_dco_commits": false
 		  }`)
 	})
 
@@ -1034,6 +1040,7 @@ func TestEditGroupPushRules(t *testing.T) {
 		CommitCommitterCheck:       Ptr(false),
 		CommitCommitterNameCheck:   Ptr(false),
 		RejectUnsignedCommits:      Ptr(false),
+		RejectNonDCOCommits:        Ptr(false),
 	}
 
 	rule, _, err := client.Groups.EditGroupPushRule(1, opt)
@@ -1055,6 +1062,7 @@ func TestEditGroupPushRules(t *testing.T) {
 		CommitCommitterCheck:       false,
 		CommitCommitterNameCheck:   false,
 		RejectUnsignedCommits:      false,
+		RejectNonDCOCommits:        false,
 	}
 
 	if !reflect.DeepEqual(want, rule) {

--- a/projects.go
+++ b/projects.go
@@ -1663,6 +1663,7 @@ type ProjectPushRules struct {
 	CommitCommitterCheck       bool       `json:"commit_committer_check"`
 	CommitCommitterNameCheck   bool       `json:"commit_committer_name_check"`
 	RejectUnsignedCommits      bool       `json:"reject_unsigned_commits"`
+	RejectNonDCOCommits        bool       `json:"reject_non_dco_commits"`
 }
 
 // GetProjectPushRules gets the push rules of a project.
@@ -1708,6 +1709,7 @@ type AddProjectPushRuleOptions struct {
 	MemberCheck                *bool   `url:"member_check,omitempty" json:"member_check,omitempty"`
 	PreventSecrets             *bool   `url:"prevent_secrets,omitempty" json:"prevent_secrets,omitempty"`
 	RejectUnsignedCommits      *bool   `url:"reject_unsigned_commits,omitempty" json:"reject_unsigned_commits,omitempty"`
+	RejectNonDCOCommits        *bool   `url:"reject_non_dco_commits,omitempty" json:"reject_non_dco_commits,omitempty"`
 }
 
 // AddProjectPushRule adds a push rule to a specified project.
@@ -1753,6 +1755,7 @@ type EditProjectPushRuleOptions struct {
 	MemberCheck                *bool   `url:"member_check,omitempty" json:"member_check,omitempty"`
 	PreventSecrets             *bool   `url:"prevent_secrets,omitempty" json:"prevent_secrets,omitempty"`
 	RejectUnsignedCommits      *bool   `url:"reject_unsigned_commits,omitempty" json:"reject_unsigned_commits,omitempty"`
+	RejectNonDCOCommits        *bool   `url:"reject_non_dco_commits,omitempty" json:"reject_non_dco_commits,omitempty"`
 }
 
 // EditProjectPushRule edits a push rule for a specified project.

--- a/projects_test.go
+++ b/projects_test.go
@@ -1596,7 +1596,8 @@ func TestGetProjectPushRules(t *testing.T) {
 			"max_file_size": 5,
 			"commit_committer_check": false,
 			"commit_committer_name_check": false,
-			"reject_unsigned_commits": false
+			"reject_unsigned_commits": false,
+			"reject_non_dco_commits": false
 		  }`)
 	})
 
@@ -1619,6 +1620,7 @@ func TestGetProjectPushRules(t *testing.T) {
 		CommitCommitterCheck:       false,
 		CommitCommitterNameCheck:   false,
 		RejectUnsignedCommits:      false,
+		RejectNonDCOCommits:        false,
 	}
 
 	if !reflect.DeepEqual(want, rule) {
@@ -1644,7 +1646,8 @@ func TestAddProjectPushRules(t *testing.T) {
 			"max_file_size": 5,
 			"commit_committer_check": false,
 			"commit_committer_name_check": false,
-			"reject_unsigned_commits": false
+			"reject_unsigned_commits": false,
+			"reject_non_dco_commits": false
 		  }`)
 	})
 
@@ -1661,6 +1664,7 @@ func TestAddProjectPushRules(t *testing.T) {
 		CommitCommitterCheck:       Ptr(false),
 		CommitCommitterNameCheck:   Ptr(false),
 		RejectUnsignedCommits:      Ptr(false),
+		RejectNonDCOCommits:        Ptr(false),
 	}
 
 	rule, _, err := client.Projects.AddProjectPushRule(1, opt)
@@ -1682,6 +1686,7 @@ func TestAddProjectPushRules(t *testing.T) {
 		CommitCommitterCheck:       false,
 		CommitCommitterNameCheck:   false,
 		RejectUnsignedCommits:      false,
+		RejectNonDCOCommits:        false,
 	}
 
 	if !reflect.DeepEqual(want, rule) {
@@ -1707,7 +1712,8 @@ func TestEditProjectPushRules(t *testing.T) {
 			"max_file_size": 5,
 			"commit_committer_check": false,
 			"commit_committer_name_check": false,
-			"reject_unsigned_commits": false
+			"reject_unsigned_commits": false,
+			"reject_non_dco_commits": false
 		  }`)
 	})
 
@@ -1724,6 +1730,7 @@ func TestEditProjectPushRules(t *testing.T) {
 		CommitCommitterCheck:       Ptr(false),
 		CommitCommitterNameCheck:   Ptr(false),
 		RejectUnsignedCommits:      Ptr(false),
+		RejectNonDCOCommits:        Ptr(false),
 	}
 
 	rule, _, err := client.Projects.EditProjectPushRule(1, opt)
@@ -1745,6 +1752,7 @@ func TestEditProjectPushRules(t *testing.T) {
 		CommitCommitterCheck:       false,
 		CommitCommitterNameCheck:   false,
 		RejectUnsignedCommits:      false,
+		RejectNonDCOCommits:        false,
 	}
 
 	if !reflect.DeepEqual(want, rule) {


### PR DESCRIPTION
The `reject_non_dco_commits` was recently added to the project and group push rules API; this adds support to the library.