### PR TITLE
Expose PreReceiveSecretDetectionEnabled project setting

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -664,6 +664,7 @@ type CreateProjectOptions struct {
 	RequirementsAccessLevel                   *AccessControlValue                  `url:"requirements_access_level,omitempty" json:"requirements_access_level,omitempty"`
 	ResolveOutdatedDiffDiscussions            *bool                                `url:"resolve_outdated_diff_discussions,omitempty" json:"resolve_outdated_diff_discussions,omitempty"`
 	SecurityAndComplianceAccessLevel          *AccessControlValue                  `url:"security_and_compliance_access_level,omitempty" json:"security_and_compliance_access_level,omitempty"`
+	PreReceiveSecretDetectionEnabled          *bool                                `url:"pre_receive_secret_detection_enabled,omitempty" json:"pre_receive_secret_detection_enabled,omitempty"`
 	SharedRunnersEnabled                      *bool                                `url:"shared_runners_enabled,omitempty" json:"shared_runners_enabled,omitempty"`
 	GroupRunnersEnabled                       *bool                                `url:"group_runners_enabled,omitempty" json:"group_runners_enabled,omitempty"`
 	ShowDefaultAwardEmojis                    *bool                                `url:"show_default_award_emojis,omitempty" json:"show_default_award_emojis,omitempty"`


### PR DESCRIPTION
This change adds the `PreReceiveSecretDetectionEnabled` field to the `Project` struct. This boolean reflects the state of the project Secret Push Protection feature: https://docs.gitlab.com/ee/user/application_security/secret_detection/secret_push_protection/

See also https://gitlab.com/gitlab-org/gitlab/-/merge_requests/160960