### PR TITLE
Add an exponential backoff to the retry function

### DIFF
--- a/gitlab.go
+++ b/gitlab.go
@@ -525,12 +525,13 @@ func rateLimitBackoff(min, max time.Duration, attemptNum int, resp *http.Respons
 					min = wait
 				}
 			}
+		} else {
+			// For each attempt without the header, back off an additiona 100% exponentially. With the default milliseconds
+			// being set to 100 for `min`, this makes the 5th retry wait 3.2 seconds (3,200 ms) by default
+			min = time.Duration(float64(min) * math.Pow(2, float64(attemptNum)))
 		}
 	}
 
-	// For each attempt, back off an additiona 100% exponentially. With the default milliseconds
-	// being set to 100 for `min`, this makes the 5th retry wait 3.2 seconds (3,200 ms) by default
-	min = time.Duration(float64(min) * math.Pow(2, float64(attemptNum)))
 	return min + jitter
 }
 

--- a/gitlab.go
+++ b/gitlab.go
@@ -526,8 +526,9 @@ func rateLimitBackoff(min, max time.Duration, attemptNum int, resp *http.Respons
 				}
 			}
 		} else {
-			// For each attempt without the header, back off an additiona 100% exponentially. With the default milliseconds
-			// being set to 100 for `min`, this makes the 5th retry wait 3.2 seconds (3,200 ms) by default
+			// In case the RateLimit-Reset header is not set, back off an additional
+			// 100% exponentially. With the default milliseconds being set to 100 for
+			// `min`, this makes the 5th retry wait 3.2 seconds (3,200 ms) by default.
 			min = time.Duration(float64(min) * math.Pow(2, float64(attemptNum)))
 		}
 	}

--- a/gitlab_test.go
+++ b/gitlab_test.go
@@ -442,12 +442,15 @@ func TestExponentialBackoffLogic(t *testing.T) {
 
 	// Send a request (which will get a bunch of 429s)
 	// None of the responses matter, so ignore them all
-	_, _, _ = client.Projects.GetProject(1, nil)
+	_, resp, _ := client.Projects.GetProject(1, nil)
 	end := time.Now()
 
 	// The test should run for _at least_ 3,200 milliseconds
 	duration := float64(end.Sub(start))
 	if duration < float64(3200*time.Millisecond) {
 		t.Fatal("Wait was shorter than expected. Expected a minimum of 5 retries taking 3200 milliseconds, got:", duration)
+	}
+	if resp.StatusCode != 429 {
+		t.Fatal("Expected to get a 429 code given the server is hard-coded to return this. Received instead:", resp.StatusCode)
 	}
 }


### PR DESCRIPTION
This PR adds a 200% exponential backoff to the default retry function. This backoff only applies in situations where the Rate Limit header doesn't exist, which should be vanishingly few situations, but unfortunately does exist within the SaaS environment of GitLab: https://gitlab.com/gitlab-org/gitlab/-/issues/365728

Without the backoff, all 5 default retries would be exhausted in < 1-2 seconds, which would likely result in 429 errors being passed upstream since the API limits on SaaS are measured in requests per minute. With the backoff, the 100ms backoff translates to 3.2 seconds on the final wait (which isn't horrible). If a user increased the retry up to 10 requests, the final retry would wait just shy of 2 minutes.

This feels like a reasonable low impact change that would result in a good quality of life improvement for most users of the library :)

I also debated making the exponent configurable, but I'm not sure that's necessary, since you can already control the min and the max.