### PR TITLE
Get scoped group variables

### DIFF
--- a/group_variables.go
+++ b/group_variables.go
@@ -82,18 +82,27 @@ func (s *GroupVariablesService) ListVariables(gid interface{}, opt *ListGroupVar
 	return vs, resp, nil
 }
 
+// GetGroupVariableOptions represents the available GetVariable()
+// options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/group_level_variables.html#show-variable-details
+type GetGroupVariableOptions struct {
+	Filter *VariableFilter `url:"filter,omitempty" json:"filter,omitempty"`
+}
+
 // GetVariable gets a variable.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/group_level_variables.html#show-variable-details
-func (s *GroupVariablesService) GetVariable(gid interface{}, key string, options ...RequestOptionFunc) (*GroupVariable, *Response, error) {
+func (s *GroupVariablesService) GetVariable(gid interface{}, key string, opt *GetGroupVariableOptions, options ...RequestOptionFunc) (*GroupVariable, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("groups/%s/variables/%s", PathEscape(group), url.PathEscape(key))
 
-	req, err := s.client.NewRequest(http.MethodGet, u, nil, options)
+	req, err := s.client.NewRequest(http.MethodGet, u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/group_variables_test.go
+++ b/group_variables_test.go
@@ -57,10 +57,11 @@ func TestGetGroupVariable(t *testing.T) {
 	mux.HandleFunc("/api/v4/groups/1/variables/TEST_VARIABLE_1",
 		func(w http.ResponseWriter, r *http.Request) {
 			testMethod(t, r, http.MethodGet)
+			testParams(t, r, "filter%5Benvironment_scope%5D=prod")
 			fmt.Fprint(w, `{"key": "TEST_VARIABLE_1","value": "test1","protected": false,"masked": true}`)
 		})
 
-	variable, _, err := client.GroupVariables.GetVariable(1, "TEST_VARIABLE_1")
+	variable, _, err := client.GroupVariables.GetVariable(1, "TEST_VARIABLE_1", &GetGroupVariableOptions{Filter: &VariableFilter{EnvironmentScope: "prod"}})
 	if err != nil {
 		t.Errorf("GroupVariables.GetVariable returned error: %v", err)
 	}

--- a/projects.go
+++ b/projects.go
@@ -169,7 +169,7 @@ type Project struct {
 	MergeRequestDefaultTargetSelf            bool               `json:"mr_default_target_self"`
 	ModelExperimentsAccessLevel              AccessControlValue `json:"model_experiments_access_level"`
 	ModelRegistryAccessLevel                 AccessControlValue `json:"model_registry_access_level"`
-	PreReceiveSecretDetectionEnabled         bool              `json:"pre_receive_secret_detection_enabled"`
+	PreReceiveSecretDetectionEnabled         bool               `json:"pre_receive_secret_detection_enabled"`
 
 	// Deprecated: Use EmailsEnabled instead
 	EmailsDisabled bool `json:"emails_disabled"`


### PR DESCRIPTION
Added option to set scope when getting group-level variables. Changes were based on functionality which existed for `ProjectVariables` and added corresponding test. The change in `projects.go` came from `make fmt`. 