### PR TITLE
Add more filters to List group milestones

### DIFF
--- a/group_milestones.go
+++ b/group_milestones.go
@@ -58,19 +58,19 @@ func (m GroupMilestone) String() string {
 // https://docs.gitlab.com/ee/api/group_milestones.html#list-group-milestones
 type ListGroupMilestonesOptions struct {
 	ListOptions
-	IIDs                    *[]int     `url:"iids[],omitempty" json:"iids,omitempty"`
-	State                   *string    `url:"state,omitempty" json:"state,omitempty"`
-	Title                   *string    `url:"title,omitempty" json:"title,omitempty"`
-	Search                  *string    `url:"search,omitempty" json:"search,omitempty"`
-	SearchTitle             *string    `url:"search_title,omitempty" json:"search_title,omitempty"`
-	IncludeParentMilestones *bool      `url:"include_parent_milestones,omitempty" json:"include_parent_milestones,omitempty"`
-	IncludeAncestors        *bool      `url:"include_ancestors,omitempty" json:"include_ancestors,omitempty"`
-	IncludeDescendents      *bool      `url:"include_descendents,omitempty" json:"include_descendents,omitempty"`
-	UpdatedBefore           *time.Time `url:"updated_before,omitempty" json:"updated_before,omitempty"`
-	UpdatedAfter            *time.Time `url:"updated_after,omitempty" json:"updated_after,omitempty"`
-	ContainingDate          *time.Time `url:"containing_date,omitempty" json:"containing_date,omitempty"`
-	StartDate               *time.Time `url:"start_date,omitempty" json:"start_date,omitempty"`
-	EndDate                 *time.Time `url:"end_date,omitempty" json:"end_date,omitempty"`
+	IIDs                    *[]int   `url:"iids[],omitempty" json:"iids,omitempty"`
+	State                   *string  `url:"state,omitempty" json:"state,omitempty"`
+	Title                   *string  `url:"title,omitempty" json:"title,omitempty"`
+	Search                  *string  `url:"search,omitempty" json:"search,omitempty"`
+	SearchTitle             *string  `url:"search_title,omitempty" json:"search_title,omitempty"`
+	IncludeParentMilestones *bool    `url:"include_parent_milestones,omitempty" json:"include_parent_milestones,omitempty"`
+	IncludeAncestors        *bool    `url:"include_ancestors,omitempty" json:"include_ancestors,omitempty"`
+	IncludeDescendents      *bool    `url:"include_descendents,omitempty" json:"include_descendents,omitempty"`
+	UpdatedBefore           *ISOTime `url:"updated_before,omitempty" json:"updated_before,omitempty"`
+	UpdatedAfter            *ISOTime `url:"updated_after,omitempty" json:"updated_after,omitempty"`
+	ContainingDate          *ISOTime `url:"containing_date,omitempty" json:"containing_date,omitempty"`
+	StartDate               *ISOTime `url:"start_date,omitempty" json:"start_date,omitempty"`
+	EndDate                 *ISOTime `url:"end_date,omitempty" json:"end_date,omitempty"`
 }
 
 // ListGroupMilestones returns a list of group milestones.

--- a/group_milestones.go
+++ b/group_milestones.go
@@ -58,11 +58,19 @@ func (m GroupMilestone) String() string {
 // https://docs.gitlab.com/ee/api/group_milestones.html#list-group-milestones
 type ListGroupMilestonesOptions struct {
 	ListOptions
-	IIDs                    *[]int  `url:"iids[],omitempty" json:"iids,omitempty"`
-	State                   *string `url:"state,omitempty" json:"state,omitempty"`
-	Title                   *string `url:"title,omitempty" json:"title,omitempty"`
-	Search                  *string `url:"search,omitempty" json:"search,omitempty"`
-	IncludeParentMilestones *bool   `url:"include_parent_milestones,omitempty" json:"include_parent_milestones,omitempty"`
+	IIDs                    *[]int     `url:"iids[],omitempty" json:"iids,omitempty"`
+	State                   *string    `url:"state,omitempty" json:"state,omitempty"`
+	Title                   *string    `url:"title,omitempty" json:"title,omitempty"`
+	Search                  *string    `url:"search,omitempty" json:"search,omitempty"`
+	SearchTitle             *string    `url:"search_title,omitempty" json:"search_title,omitempty"`
+	IncludeParentMilestones *bool      `url:"include_parent_milestones,omitempty" json:"include_parent_milestones,omitempty"`
+	IncludeAncestors        *bool      `url:"include_ancestors,omitempty" json:"include_ancestors,omitempty"`
+	IncludeDescendents      *bool      `url:"include_descendents,omitempty" json:"include_descendents,omitempty"`
+	UpdatedBefore           *time.Time `url:"updated_before,omitempty" json:"updated_before,omitempty"`
+	UpdatedAfter            *time.Time `url:"updated_after,omitempty" json:"updated_after,omitempty"`
+	ContainingDate          *time.Time `url:"containing_date,omitempty" json:"containing_date,omitempty"`
+	StartDate               *time.Time `url:"start_date,omitempty" json:"start_date,omitempty"`
+	EndDate                 *time.Time `url:"end_date,omitempty" json:"end_date,omitempty"`
 }
 
 // ListGroupMilestones returns a list of group milestones.


### PR DESCRIPTION
This MR adds the following filters to the [List group milestones](https://docs.gitlab.com/ee/api/group_milestones.html#list-group-milestones) endpoint:

- `SearchTitle`
- `IncludeAncestors`
- `IncludeDescendents`
- `UpdatedBefore`
- `UpdatedAfter`
- `ContainingDate`
- `StartDate`
- `EndDate`

See [Document fields for List Group milestones API](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/163712) for more details.