### PR TITLE
chore: add ReportType to ProjectApprovalRule

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -309,6 +309,7 @@ type ProjectApprovalRule struct {
 	ID                            int                `json:"id"`
 	Name                          string             `json:"name"`
 	RuleType                      string             `json:"rule_type"`
+	ReportType                    string             `json:"report_type"`
 	EligibleApprovers             []*BasicUser       `json:"eligible_approvers"`
 	ApprovalsRequired             int                `json:"approvals_required"`
 	Users                         []*BasicUser       `json:"users"`


### PR DESCRIPTION
This PR adds ReportType to the ProjectApprovalRule.
Was added to gitlab in https://gitlab.com/gitlab-org/gitlab/-/merge_requests/155772

It is only accessible under the EE version of gitlab 🫤 