### PR TITLE
Fix an issue with omitempty on default_branch_protection_defaults

### DIFF
--- a/groups.go
+++ b/groups.go
@@ -393,7 +393,7 @@ type CreateGroupOptions struct {
 type DefaultBranchProtectionDefaultsOptions struct {
 	AllowedToPush           *[]*GroupAccessLevel `url:"allowed_to_push,omitempty" json:"allowed_to_push,omitempty"`
 	AllowForcePush          *bool                `url:"allow_force_push,omitempty" json:"allow_force_push,omitempty"`
-	AllowedToMerge          *[]*GroupAccessLevel `url:"allowed_to_merge.omitempty" json:"allowed_to_merge.omitempty"`
+	AllowedToMerge          *[]*GroupAccessLevel `url:"allowed_to_merge,omitempty" json:"allowed_to_merge,omitempty"`
 	DeveloperCanInitialPush *bool                `url:"developer_can_initial_push,omitempty" json:"developer_can_initial_push,omitempty"`
 }
 


### PR DESCRIPTION
This PR fixes an issue where the `omitempty` tag on the new DefaultBranchProtectionDefaults uses a period instead of a comma for `allowed_to_merge`, resulting in the create and update requests not properly updating the merge options.