### PR TITLE
Breaking change: New options when calling DeleteProject

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -1159,18 +1159,28 @@ func (s *ProjectsService) UnarchiveProject(pid interface{}, options ...RequestOp
 	return p, resp, nil
 }
 
+// DeleteProjectOptions represents options to delete a project.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/projects.html#delete-project
+type DeleteProjectOptions struct {
+	FullPath          *string `url:"full_path" json:"full_path"`
+	PermanentlyRemove *bool   `url:"permanently_remove" json:"permanently_remove"`
+}
+
 // DeleteProject removes a project including all associated resources
 // (issues, merge requests etc.)
 //
-// GitLab API docs: https://docs.gitlab.com/ee/api/projects.html#delete-project
-func (s *ProjectsService) DeleteProject(pid interface{}, options ...RequestOptionFunc) (*Response, error) {
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/projects.html#delete-project
+func (s *ProjectsService) DeleteProject(pid interface{}, opt *DeleteProjectOptions, options ...RequestOptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, err
 	}
 	u := fmt.Sprintf("projects/%s", PathEscape(project))
 
-	req, err := s.client.NewRequest(http.MethodDelete, u, nil, options)
+	req, err := s.client.NewRequest(http.MethodDelete, u, opt, options)
 	if err != nil {
 		return nil, err
 	}

--- a/projects_test.go
+++ b/projects_test.go
@@ -647,6 +647,24 @@ func TestListProjectForks(t *testing.T) {
 	}
 }
 
+func TestDeleteProject(t *testing.T) {
+	mux, client := setup(t)
+
+	mux.HandleFunc("/api/v4/projects/1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodDelete)
+	})
+
+	opt := &DeleteProjectOptions{
+		FullPath:          Ptr("group/project"),
+		PermanentlyRemove: Ptr(true),
+	}
+
+	_, err := client.Projects.DeleteProject(1, opt)
+	if err != nil {
+		t.Errorf("Projects.DeleteProject returned error: %v", err)
+	}
+}
+
 func TestShareProjectWithGroup(t *testing.T) {
 	mux, client := setup(t)
 


### PR DESCRIPTION
Allow passing options to the DeleteProject function for immediately deleting a project. Used in Premium/Ultimate tiers where delayed deletion is enabled by default. See API docs: https://docs.gitlab.com/ee/api/projects.html#delete-project

This is a breaking change. Closes https://github.com/xanzy/go-gitlab/issues/2008