### PR TITLE
add MergeStatus filed to struct MergeEvent

### DIFF
--- a/event_webhook_types.go
+++ b/event_webhook_types.go
@@ -721,6 +721,10 @@ type MergeEvent struct {
 			Previous int `json:"previous"`
 			Current  int `json:"current"`
 		} `json:"last_edited_by_id"`
+		MergeStatus struct {
+			Previous string `json:"previous"`
+			Current  string `json:"current"`
+		}`json:"merge_status"`
 		MilestoneID struct {
 			Previous int `json:"previous"`
 			Current  int `json:"current"`


### PR DESCRIPTION
when a merge request was created at the first begin, the changes will only contains filed: MergeStatus, which was missing in current version.
Already put it in the alphabetically ordered location, please review.
Thanks! @svanharmelen 

