### PR TITLE
feat(runners): add maintenance_note on put/get runner details

### DIFF
--- a/runners.go
+++ b/runners.go
@@ -84,6 +84,7 @@ type RunnerDetails struct {
 		Name   string `json:"name"`
 		WebURL string `json:"web_url"`
 	} `json:"groups"`
+	MaintenanceNote string `json:"maintenance_note"`
 
 	// Deprecated: Use Paused instead. (Deprecated in GitLab 14.8)
 	Active bool `json:"active"`
@@ -180,6 +181,7 @@ type UpdateRunnerDetailsOptions struct {
 	Locked         *bool     `url:"locked,omitempty" json:"locked,omitempty"`
 	AccessLevel    *string   `url:"access_level,omitempty" json:"access_level,omitempty"`
 	MaximumTimeout *int      `url:"maximum_timeout,omitempty" json:"maximum_timeout,omitempty"`
+	MaintenanceNote *string  `url:"maintenance_note,omitempty" json:"maintenance_note,omitempty"`
 
 	// Deprecated: Use Paused instead. (Deprecated in GitLab 14.8)
 	Active *bool `url:"active,omitempty" json:"active,omitempty"`

--- a/runners.go
+++ b/runners.go
@@ -60,6 +60,7 @@ type RunnerDetails struct {
 	IsShared     bool       `json:"is_shared"`
 	RunnerType   string     `json:"runner_type"`
 	ContactedAt  *time.Time `json:"contacted_at"`
+	MaintenanceNote string `json:"maintenance_note"`
 	Name         string     `json:"name"`
 	Online       bool       `json:"online"`
 	Status       string     `json:"status"`
@@ -84,7 +85,6 @@ type RunnerDetails struct {
 		Name   string `json:"name"`
 		WebURL string `json:"web_url"`
 	} `json:"groups"`
-	MaintenanceNote string `json:"maintenance_note"`
 
 	// Deprecated: Use Paused instead. (Deprecated in GitLab 14.8)
 	Active bool `json:"active"`


### PR DESCRIPTION
Adds support for the `maintenance_note` field.

Resolves #2014