### PR TITLE
feat: add deployment approval config attribute

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -83,6 +83,7 @@ type Project struct {
 	StarCount                                 int                        `json:"star_count"`
 	RunnersToken                              string                     `json:"runners_token"`
 	AllowMergeOnSkippedPipeline               bool                       `json:"allow_merge_on_skipped_pipeline"`
+	AllowPipelineTriggerApproveDeployment     bool                       `json:"allow_pipeline_trigger_approve_deployment"`
 	OnlyAllowMergeIfPipelineSucceeds          bool                       `json:"only_allow_merge_if_pipeline_succeeds"`
 	OnlyAllowMergeIfAllDiscussionsAreResolved bool                       `json:"only_allow_merge_if_all_discussions_are_resolved"`
 	RemoveSourceBranchAfterMerge              bool                       `json:"remove_source_branch_after_merge"`


### PR DESCRIPTION
The `allow_pipeline_trigger_approve_deployment` attribute exists on the Project entity and is returned in the Get Project API[1] even though it is not documented.

[1]: https://docs.gitlab.com/ee/api/projects.html#get-a-single-project

Related: #1693