### PR TITLE
Enhancement - make `projects` endpoints configurable

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -26,6 +26,11 @@ import (
 	"github.com/hashicorp/go-retryablehttp"
 )
 
+var (
+	UserContributedProjectsEndpoint = "users/%s/contributed_projects"
+	UserStarredProjectsEndpoint     = "users/%s/starred_projects"
+)
+
 // ProjectsService handles communication with the repositories related methods
 // of the GitLab API.
 //
@@ -410,7 +415,7 @@ func (s *ProjectsService) ListUserContributedProjects(uid interface{}, opt *List
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("users/%s/contributed_projects", user)
+	u := fmt.Sprintf(UserContributedProjectsEndpoint, user)
 
 	req, err := s.client.NewRequest(http.MethodGet, u, opt, options)
 	if err != nil {
@@ -435,7 +440,7 @@ func (s *ProjectsService) ListUserStarredProjects(uid interface{}, opt *ListProj
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("users/%s/starred_projects", user)
+	u := fmt.Sprintf(UserStarredProjectsEndpoint, user)
 
 	req, err := s.client.NewRequest(http.MethodGet, u, opt, options)
 	if err != nil {


### PR DESCRIPTION
We have GitLab deployed on prem and the URLs are slightly different from what is mentioned in the API specification. For instance, to get a list of projects the user contributed to, instead of invoking `https://gitlab.example.com/api/v4/users/5/contributed_projects` we have to invoke `https://gitlab.example.com/api/v4/users/5/contributed`.

This change accommodates these discrepancies by exporting the endpoints so that users can configure then if they so need it.