### PR TITLE
Add alert status to project hooks

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -1283,6 +1283,7 @@ type ProjectHook struct {
 	ReleasesEvents            bool                `json:"releases_events"`
 	EnableSSLVerification     bool                `json:"enable_ssl_verification"`
 	CreatedAt                 *time.Time          `json:"created_at"`
+	AlertStatus               string              `json:"alert_status"`
 	ResourceAccessTokenEvents bool                `json:"resource_access_token_events"`
 	CustomWebhookTemplate     string              `json:"custom_webhook_template"`
 	CustomHeaders             []*HookCustomHeader `json:"custom_headers"`


### PR DESCRIPTION
This commit adds the alert_status field to project hooks, similar to how we return it in group hooks.