### PR TITLE
feat: added 'NewPutQueryRequest' to support the 'integrations' endpoint

### DIFF
--- a/gitlab_test.go
+++ b/gitlab_test.go
@@ -122,6 +122,32 @@ func TestNewClient(t *testing.T) {
 	}
 }
 
+func TestNewPutQueryRequest(t *testing.T) {
+	c, err := NewClient("")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	type Query struct {
+		A string `url:"a"`
+		B string `url:"b"`
+	}
+
+	resp, err := c.NewPutQueryRequest("test", Query{"1", "2"}, nil)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+
+	if resp.Method != "PUT" {
+		t.Errorf("Expected: 'PUT' method, got %s", resp.Method)
+	}
+
+	want := "https://gitlab.com/api/v4/test?a=1&b=2"
+	if resp.URL.String() != want {
+		t.Errorf("Expected: %s, got %s", want, resp.URL.String())
+	}
+}
+
 func TestCheckResponse(t *testing.T) {
 	c, err := NewClient("")
 	if err != nil {


### PR DESCRIPTION
Resolves #2040

I refactored the code ever so slightly to not duplicate building the url or setting the headers on the request. I also didn't want to modify the existing `NewRequest` method signature and cause a cascade of changes elsewhere, so i just added a new method. 

Includes a test.