### PR TITLE
Add username to AddGroupMemberOptions

### DIFF
--- a/group_members.go
+++ b/group_members.go
@@ -161,6 +161,7 @@ func (s *GroupsService) ListAllGroupMembers(gid interface{}, opt *ListGroupMembe
 // https://docs.gitlab.com/ee/api/members.html#add-a-member-to-a-group-or-project
 type AddGroupMemberOptions struct {
 	UserID       *int              `url:"user_id,omitempty" json:"user_id,omitempty"`
+	Username     *string           `url:"username,omitempty" json:"username,omitempty"`
 	AccessLevel  *AccessLevelValue `url:"access_level,omitempty" json:"access_level,omitempty"`
 	ExpiresAt    *string           `url:"expires_at,omitempty" json:"expires_at"`
 	MemberRoleID *int              `url:"member_role_id,omitempty" json:"member_role_id,omitempty"`


### PR DESCRIPTION
This change adds support for providing a `username` instead of a `user_id` to the `AddGroupMemberOptions`. See https://docs.gitlab.com/ee/api/members.html#add-a-member-to-a-group-or-project