### PR TITLE
Make `cluster_agent_id` in Environment API nullable

### DIFF
--- a/environments.go
+++ b/environments.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/oapi-codegen/nullable"
 )
 
 // EnvironmentsService handles communication with the environment related methods
@@ -163,13 +165,13 @@ func (s *EnvironmentsService) CreateEnvironment(pid interface{}, opt *CreateEnvi
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/environments.html#update-an-existing-environment
 type EditEnvironmentOptions struct {
-	Name                *string `url:"name,omitempty" json:"name,omitempty"`
-	Description         *string `url:"description,omitempty" json:"description,omitempty"`
-	ExternalURL         *string `url:"external_url,omitempty" json:"external_url,omitempty"`
-	Tier                *string `url:"tier,omitempty" json:"tier,omitempty"`
-	ClusterAgentID      *int    `url:"cluster_agent_id,omitempty" json:"cluster_agent_id,omitempty"`
-	KubernetesNamespace *string `url:"kubernetes_namespace,omitempty" json:"kubernetes_namespace,omitempty"`
-	FluxResourcePath    *string `url:"flux_resource_path,omitempty" json:"flux_resource_path,omitempty"`
+	Name                *string                `url:"name,omitempty" json:"name,omitempty"`
+	Description         *string                `url:"description,omitempty" json:"description,omitempty"`
+	ExternalURL         *string                `url:"external_url,omitempty" json:"external_url,omitempty"`
+	Tier                *string                `url:"tier,omitempty" json:"tier,omitempty"`
+	ClusterAgentID      nullable.Nullable[int] `url:"cluster_agent_id,omitempty" json:"cluster_agent_id,omitempty"`
+	KubernetesNamespace *string                `url:"kubernetes_namespace,omitempty" json:"kubernetes_namespace,omitempty"`
+	FluxResourcePath    *string                `url:"flux_resource_path,omitempty" json:"flux_resource_path,omitempty"`
 }
 
 // EditEnvironment updates a project team environment to a specified access level..

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/google/go-querystring v1.1.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-retryablehttp v0.7.7
+	github.com/oapi-codegen/nullable v1.1.0
 	github.com/stretchr/testify v1.8.1
 	golang.org/x/oauth2 v0.6.0
 	golang.org/x/time v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/hashicorp/go-retryablehttp v0.7.7 h1:C8hUCYzor8PIfXHa4UrZkU4VvK8o9ISH
 github.com/hashicorp/go-retryablehttp v0.7.7/go.mod h1:pkQpWZeYWskR+D1tR2O5OcBFOxfA7DoAO6xtkuQnHTk=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
+github.com/oapi-codegen/nullable v1.1.0 h1:eAh8JVc5430VtYVnq00Hrbpag9PFRGWLjxR1/3KntMs=
+github.com/oapi-codegen/nullable v1.1.0/go.mod h1:KUZ3vUzkmEKY90ksAmit2+5juDIhIZhfDl+0PwOQlFY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
This change set adds support to distinguish `null` and omitted values in the `cluster_agent_id` field of the edit environments API.

The added unit tests show how `null` and omitted `ClusterAgentID` values are differently marshaled.

The pulled in dependency is an Apache v2 license:
http://www.apache.org/licenses/LICENSE-2.0