### PR TITLE
Add support for updating a project's GitLab Pages settings

### DIFF
--- a/pages.go
+++ b/pages.go
@@ -90,3 +90,38 @@ func (s *PagesService) GetPages(gid interface{}, options ...RequestOptionFunc) (
 
 	return p, resp, nil
 }
+
+// UpdatePages represents the available UpdatePages() options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/pages.html#update-pages-settings-for-a-project
+type UpdatePagesOptions struct {
+	PagesUniqueDomainEnabled *bool `url:"pages_unique_domain_enabled,omitempty" json:"pages_unique_domain_enabled,omitempty"`
+	PagesHttpsOnly           *bool `url:"pages_https_only,omitempty" json:"pages_https_only,omitempty"`
+}
+
+// UpdatePages updates Pages settings for a project. The user must have
+// administrator privileges.
+//
+// GitLab API Docs:
+// https://docs.gitlab.com/ee/api/pages.html#update-pages-settings-for-a-project
+func (s *PagesService) UpdatePages(pid interface{}, opt UpdatePagesOptions, options ...RequestOptionFunc) (*Pages, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/pages", PathEscape(project))
+
+	req, err := s.client.NewRequest(http.MethodPatch, u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	p := new(Pages)
+	resp, err := s.client.Do(req, p)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return p, resp, nil
+}

--- a/pages.go
+++ b/pages.go
@@ -97,7 +97,7 @@ func (s *PagesService) GetPages(gid interface{}, options ...RequestOptionFunc) (
 // https://docs.gitlab.com/ee/api/pages.html#update-pages-settings-for-a-project
 type UpdatePagesOptions struct {
 	PagesUniqueDomainEnabled *bool `url:"pages_unique_domain_enabled,omitempty" json:"pages_unique_domain_enabled,omitempty"`
-	PagesHttpsOnly           *bool `url:"pages_https_only,omitempty" json:"pages_https_only,omitempty"`
+	PagesHTTPSOnly           *bool `url:"pages_https_only,omitempty" json:"pages_https_only,omitempty"`
 }
 
 // UpdatePages updates Pages settings for a project. The user must have

--- a/pages_test.go
+++ b/pages_test.go
@@ -78,3 +78,47 @@ func TestGetPages(t *testing.T) {
 	require.NotNil(t, resp)
 	require.Equal(t, want, p)
 }
+
+func TestUpdatePages(t *testing.T) {
+	mux, client := setup(t)
+	mux.HandleFunc("/api/v4/projects/2/pages", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPatch)
+		fmt.Fprint(w, `
+		  {
+			"url": "https://ssl.domain.example",
+			"deployments": [
+			  {
+				"created_at": "2021-04-27T21:27:38.584Z",
+				"url": "https://ssl.domain.example/",
+				"path_prefix": "",
+				"root_directory": null
+			  }
+			],
+			"is_unique_domain_enabled": true,
+			"force_https": false
+		  }
+		`)
+	})
+
+	want := &Pages{
+		URL:                   "https://ssl.domain.example",
+		IsUniqueDomainEnabled: true,
+		ForceHTTPS:            false,
+		Deployments: []*PagesDeployment{
+			{
+				CreatedAt:     time.Date(2021, time.April, 27, 21, 27, 38, 584000000, time.UTC),
+				URL:           "https://ssl.domain.example/",
+				PathPrefix:    "",
+				RootDirectory: "",
+			},
+		},
+	}
+
+	p, resp, err := client.Pages.UpdatePages(2, UpdatePagesOptions{
+		PagesUniqueDomainEnabled: Ptr(true),
+		PagesHttpsOnly:           Ptr(false),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, want, p)
+}

--- a/pages_test.go
+++ b/pages_test.go
@@ -116,7 +116,7 @@ func TestUpdatePages(t *testing.T) {
 
 	p, resp, err := client.Pages.UpdatePages(2, UpdatePagesOptions{
 		PagesUniqueDomainEnabled: Ptr(true),
-		PagesHttpsOnly:           Ptr(false),
+		PagesHTTPSOnly:           Ptr(false),
 	})
 	require.NoError(t, err)
 	require.NotNil(t, resp)


### PR DESCRIPTION
Adds support for the Update Pages settings for a project endpoint: https://docs.gitlab.com/ee/api/pages.html#update-pages-settings-for-a-project