### PR TITLE
chore: fix golangci-lint warnings

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Lint package
-        uses: golangci/golangci-lint-action@v5
+        uses: golangci/golangci-lint-action@v6
         with:
           version: latest
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,7 +30,6 @@ linters:
     - gosimple
     - govet
     - ineffassign
-    - megacheck
     - misspell
     - nakedret
     - nolintlint


### PR DESCRIPTION
The PR removes `megacheck` linter and updates `golangci-lint-action` to fix the following golangci-lint [warnings](https://github.com/xanzy/go-gitlab/pull/2066/checks):
```
  level=warning msg="[config_reader] The output format `github-actions` is deprecated, please use `colored-line-number`"
  level=warning msg="[lintersdb] The linter named \"megacheck\" is deprecated. It has been split into: gosimple, staticcheck, unused."

```