### PR TITLE
add 'name' and 'description' to project hooks structs

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -1270,6 +1270,8 @@ type HookCustomHeader struct {
 type ProjectHook struct {
 	ID                        int                 `json:"id"`
 	URL                       string              `json:"url"`
+	Name                      string              `json:"name,omitempty"`
+	Description               string              `json:"description,omitempty"`
 	ConfidentialNoteEvents    bool                `json:"confidential_note_events"`
 	ProjectID                 int                 `json:"project_id"`
 	PushEvents                bool                `json:"push_events"`
@@ -1352,6 +1354,8 @@ func (s *ProjectsService) GetProjectHook(pid interface{}, hook int, options ...R
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/projects.html#add-project-hook
 type AddProjectHookOptions struct {
+	Name                      *string              `url:"name,omitempty" json:"name,omitempty"`
+	Description               *string              `url:"description,omitempty" json:"description,omitempty"`
 	ConfidentialIssuesEvents  *bool                `url:"confidential_issues_events,omitempty" json:"confidential_issues_events,omitempty"`
 	ConfidentialNoteEvents    *bool                `url:"confidential_note_events,omitempty" json:"confidential_note_events,omitempty"`
 	DeploymentEvents          *bool                `url:"deployment_events,omitempty" json:"deployment_events,omitempty"`
@@ -1403,6 +1407,8 @@ func (s *ProjectsService) AddProjectHook(pid interface{}, opt *AddProjectHookOpt
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/projects.html#edit-project-hook
 type EditProjectHookOptions struct {
+	Name                      *string              `url:"name,omitempty" json:"name,omitempty"`
+	Description               *string              `url:"description,omitempty" json:"description,omitempty"`
 	ConfidentialIssuesEvents  *bool                `url:"confidential_issues_events,omitempty" json:"confidential_issues_events,omitempty"`
 	ConfidentialNoteEvents    *bool                `url:"confidential_note_events,omitempty" json:"confidential_note_events,omitempty"`
 	DeploymentEvents          *bool                `url:"deployment_events,omitempty" json:"deployment_events,omitempty"`

--- a/projects.go
+++ b/projects.go
@@ -1270,8 +1270,8 @@ type HookCustomHeader struct {
 type ProjectHook struct {
 	ID                        int                 `json:"id"`
 	URL                       string              `json:"url"`
-	Name                      string              `json:"name,omitempty"`
-	Description               string              `json:"description,omitempty"`
+	Name                      string              `json:"name"`
+	Description               string              `json:"description"`
 	ConfidentialNoteEvents    bool                `json:"confidential_note_events"`
 	ProjectID                 int                 `json:"project_id"`
 	PushEvents                bool                `json:"push_events"`

--- a/projects_test.go
+++ b/projects_test.go
@@ -1505,6 +1505,8 @@ func TestListProjectHooks(t *testing.T) {
 	{
 		"id": 1,
 		"url": "http://example.com/hook",
+		"name": "This is the name of an example hook",
+		"description": "This is the description of an example hook",
 		"confidential_note_events": true,
 		"project_id": 1,
 		"push_events": true,
@@ -1541,6 +1543,8 @@ func TestListProjectHooks(t *testing.T) {
 	want := []*ProjectHook{{
 		ID:                        1,
 		URL:                       "http://example.com/hook",
+		Name:                      "This is the name of an example hook",
+		Description:               "This is the description of an example hook",
 		ConfidentialNoteEvents:    true,
 		ProjectID:                 1,
 		PushEvents:                true,


### PR DESCRIPTION
Adds the `name` and `description` fields to the `ProjectHook`, `AddProjectHookOptions`, and `EditProjectHookOptions` structs.  These fields are supported by the GitLab 17.x API.  Also added them to the existing test.

I have been using this code in my fork to automatically generate hooks without any issues.  Thanks for all your work on this project!