### PR TITLE
Extend project lint result struct with includes

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -44,10 +44,26 @@ type LintResult struct {
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/lint.html#validate-a-projects-ci-configuration
 type ProjectLintResult struct {
-	Valid      bool     `json:"valid"`
-	Errors     []string `json:"errors"`
-	Warnings   []string `json:"warnings"`
-	MergedYaml string   `json:"merged_yaml"`
+	Valid      bool      `json:"valid"`
+	Errors     []string  `json:"errors"`
+	Warnings   []string  `json:"warnings"`
+	MergedYaml string    `json:"merged_yaml"`
+	Includes   []Include `json:"includes"`
+}
+
+// Include contains the details about an include block in the .gitlab-ci.yml file.
+// It is used in ProjectLintResult.
+//
+// Reference can be found at the lint API endpoint in the openapi yaml:
+// https://gitlab.com/gitlab-org/gitlab/-/blob/master/doc/api/openapi/openapi_v2.yaml
+type Include struct {
+	Type           string                 `json:"type"`
+	Location       string                 `json:"location"`
+	Blob           string                 `json:"blob"`
+	Raw            string                 `json:"raw"`
+	Extra          map[string]interface{} `json:"extra"`
+	ContextProject string                 `json:"context_project"`
+	ContextSHA     string                 `json:"context_sha"`
 }
 
 // LintOptions represents the available Lint() options.

--- a/validate_test.go
+++ b/validate_test.go
@@ -172,13 +172,41 @@ func TestValidateProjectNamespace(t *testing.T) {
 				"valid": true,
 				"errors": [],
 				"warnings": [],
-				"merged_yaml": 	"---\n:build:\n  :script:\n  - echo build"
+				"merged_yaml": 	"---\n:build:\n  :script:\n  - echo build",
+				"includes": [
+					{
+						"type": "file",
+      					"location": "template/pipeline.yml",
+      					"blob": "https://gitlab.com/namespace/project/-/blob/abcd1234/template/pipeline.yml",
+      					"raw": "https://gitlab.com/namespace/project/-/raw/abcd1234/template/pipeline.yml",
+      					"extra": {
+        					"project": "namespace/project",
+        					"ref": "1.2.3"
+      					},
+      					"context_project": "namespace/current-project",
+      					"context_sha": "abcd1234"
+    				}
+				]
 			}`,
 			want: &ProjectLintResult{
 				Valid:      true,
 				Warnings:   []string{},
 				Errors:     []string{},
 				MergedYaml: "---\n:build:\n  :script:\n  - echo build",
+				Includes: []Include{
+					{
+						Type:     "file",
+						Location: "template/pipeline.yml",
+						Blob:     "https://gitlab.com/namespace/project/-/blob/abcd1234/template/pipeline.yml",
+						Raw:      "https://gitlab.com/namespace/project/-/raw/abcd1234/template/pipeline.yml",
+						Extra: map[string]interface{}{
+							"project": "namespace/project",
+							"ref":     "1.2.3",
+						},
+						ContextProject: "namespace/current-project",
+						ContextSHA:     "abcd1234",
+					},
+				},
 			},
 		},
 		{
@@ -242,13 +270,41 @@ func TestValidateProjectLint(t *testing.T) {
 				"valid": true,
 				"errors": [],
 				"warnings": [],
-				"merged_yaml": 	"---\n:build:\n  :script:\n  - echo build"
+				"merged_yaml": 	"---\n:build:\n  :script:\n  - echo build",
+				"includes": [
+					{
+						"type": "file",
+      					"location": "template/pipeline.yml",
+      					"blob": "https://gitlab.com/namespace/project/-/blob/abcd1234/template/pipeline.yml",
+      					"raw": "https://gitlab.com/namespace/project/-/raw/abcd1234/template/pipeline.yml",
+      					"extra": {
+        					"project": "namespace/project",
+        					"ref": "1.2.3"
+      					},
+      					"context_project": "namespace/current-project",
+      					"context_sha": "abcd1234"
+    				}
+				]
 			}`,
 			want: &ProjectLintResult{
 				Valid:      true,
 				Warnings:   []string{},
 				Errors:     []string{},
 				MergedYaml: "---\n:build:\n  :script:\n  - echo build",
+				Includes: []Include{
+					{
+						Type:     "file",
+						Location: "template/pipeline.yml",
+						Blob:     "https://gitlab.com/namespace/project/-/blob/abcd1234/template/pipeline.yml",
+						Raw:      "https://gitlab.com/namespace/project/-/raw/abcd1234/template/pipeline.yml",
+						Extra: map[string]interface{}{
+							"project": "namespace/project",
+							"ref":     "1.2.3",
+						},
+						ContextProject: "namespace/current-project",
+						ContextSHA:     "abcd1234",
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
The Gitlab API exposes a list of (recursive) includes when linting a projects ci configuration. The ProjectLintResult struct representing the API response does not reflect this list, so a user of the SDK cannot use this information from the API. It is also not possible to grab this information via response body parsing outside of the go-gitlab client, as the body is already closed when the client code can access it.

So, in short, this change allows the client code to access the list of includes returned by the Gitlab API.

My only concern is the documentation of the includes type. It is not documented in the api docs of the lint API (see https://docs.gitlab.com/ee/api/lint.html#validate-a-projects-cicd-configuration). Instead, one can find the specification in the openapi spec, see https://gitlab.com/gitlab-org/gitlab/-/blob/master/doc/api/openapi/openapi_v2.yaml?plain=1#L52442. But relying on this spec is inconsistent with the rest of the go-gitlab library...

Please let me know if this still is an acceptable change - and of course whether there is anything else missing (e.g. if further tests are required).

Thank you! 