### PR TITLE
Add options to CreateServiceAccountUser

### DIFF
--- a/testdata/create_service_account_user.json
+++ b/testdata/create_service_account_user.json
@@ -1,9 +1,9 @@
 {
   "id": 999,
-  "username": "service_account_94e556c44d40d5a710ca59e3a0f40a3d",
-  "name": "Service account user",
+  "username": "serviceaccount",
+  "name": "Test Service Account",
   "state": "active",
   "locked": false,
   "avatar_url": "http://localhost:3000/uploads/user/avatar/999/cd8.jpeg",
-  "web_url": "http://localhost:3000/service_account_94e556c44d40d5a710ca59e3a0f40a3d"
+  "web_url": "http://localhost:3000/serviceaccount"
 }

--- a/users.go
+++ b/users.go
@@ -1553,12 +1553,17 @@ func (s *UsersService) CreateUserRunner(opts *CreateUserRunnerOptions, options .
 	return r, resp, nil
 }
 
+type CreateServiceAccountUserOptions struct {
+	Name     *string `url:"name,omitempty" json:"name,omitempty"`
+	Username *string `url:"username,omitempty" json:"username,omitempty"`
+}
+
 // CreateServiceAccountUser creates a new service account user.
 //
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/users.html#create-service-account-user
-func (s *UsersService) CreateServiceAccountUser(options ...RequestOptionFunc) (*User, *Response, error) {
-	req, err := s.client.NewRequest(http.MethodPost, "service_accounts", nil, options)
+func (s *UsersService) CreateServiceAccountUser(opts *CreateServiceAccountUserOptions, options ...RequestOptionFunc) (*User, *Response, error) {
+	req, err := s.client.NewRequest(http.MethodPost, "service_accounts", opts, options)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/users.go
+++ b/users.go
@@ -1553,6 +1553,10 @@ func (s *UsersService) CreateUserRunner(opts *CreateUserRunnerOptions, options .
 	return r, resp, nil
 }
 
+
+// CreateServiceAccountUserOptions represents the available CreateServiceAccountUser() options.
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/user_service_accounts.html#create-a-service-account-user
 type CreateServiceAccountUserOptions struct {
 	Name     *string `url:"name,omitempty" json:"name,omitempty"`
 	Username *string `url:"username,omitempty" json:"username,omitempty"`

--- a/users_test.go
+++ b/users_test.go
@@ -727,20 +727,29 @@ func TestCreateServiceAccountUser(t *testing.T) {
 
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
+		if !strings.Contains(r.Header.Get("Content-Type"), "application/json") {
+			t.Fatalf("Users.CreateServiceAccountUser request content-type %+v want application/json;", r.Header.Get("Content-Type"))
+		}
+		if r.ContentLength == -1 {
+			t.Fatalf("Users.CreateServiceAccountUser request content-length is -1")
+		}
 		mustWriteHTTPResponse(t, w, "testdata/create_service_account_user.json")
 	})
 
-	user, _, err := client.Users.CreateServiceAccountUser()
+	user, _, err := client.Users.CreateServiceAccountUser(&CreateServiceAccountUserOptions{
+		Name:     Ptr("Test Service Account"),
+		Username: Ptr("serviceaccount"),
+	})
 	require.NoError(t, err)
 
 	want := &User{
 		ID:        999,
-		Username:  "service_account_94e556c44d40d5a710ca59e3a0f40a3d",
-		Name:      "Service account user",
+		Username:  "serviceaccount",
+		Name:      "Test Service Account",
 		State:     "active",
 		Locked:    false,
 		AvatarURL: "http://localhost:3000/uploads/user/avatar/999/cd8.jpeg",
-		WebURL:    "http://localhost:3000/service_account_94e556c44d40d5a710ca59e3a0f40a3d",
+		WebURL:    "http://localhost:3000/serviceaccount",
 	}
 	require.Equal(t, want, user)
 }


### PR DESCRIPTION
This PR addresses lack of options in the `CreateServiceAccountUser`

https://docs.gitlab.com/ee/api/user_service_accounts.html#create-a-service-account-user