### PR TITLE
Deprecate this project in favor of https://gitlab.com/gitlab-org/api/client-go

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,25 @@
-# go-gitlab
+# (deprecated) go-gitlab (migrated to https://gitlab.com/gitlab-org/api/client-go)
+
+🚧 **Project moved to https://gitlab.com/gitlab-org/api/client-go** 🚧
+
+This package, `github.com/xanzy/go-gitlab`, has been moved to
+[`gitlab.com/gitlab-org/api/client-go`](https://gitlab.com/gitlab-org/api/client-go).
+
+The project will continue to be a primarily community-maintained project,
+more about it [here](https://gitlab.com/gitlab-org/client.go/-/blob/main/README.md#maintenance).
+
+**References**:
+
+- [GitLab Project](https://gitlab.com/gitlab-org/api/client-go)
+- [Issue Tracker](https://gitlab.com/gitlab-org/api/client-go/-/issues)
+
+## Migration Steps
+
+- Replace `github.com/xanzy/go-gitlab` with `gitlab.com/gitlab-org/api/client-go` in your code base.
+- Profit 🎉
+- *(the code is fully backwards-compatible, no breaking changes are expected)*
+
+<details><summary>Former README contents</summary>
 
 A GitLab API client enabling Go programs to interact with GitLab in a simple and uniform way
 
@@ -206,3 +227,5 @@ Contributions are always welcome. For more information, check out the [contribut
 ## License
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at <http://www.apache.org/licenses/LICENSE-2.0>
+
+</details>

--- a/gitlab.go
+++ b/gitlab.go
@@ -70,6 +70,11 @@ const (
 var ErrNotFound = errors.New("404 Not Found")
 
 // A Client manages communication with the GitLab API.
+//
+// Deprecated: use gitlab.com/gitlab-org/api/client-go instead.
+// See https://gitlab.com/gitlab-org/api/client-go
+//
+// This package is completely frozen, nothing will be added, removed or changed.
 type Client struct {
 	// HTTP client used to communicate with the API.
 	client *retryablehttp.Client
@@ -258,6 +263,11 @@ type RateLimiter interface {
 
 // NewClient returns a new GitLab API client. To use API methods which require
 // authentication, provide a valid private or personal token.
+//
+// Deprecated: This module has been migrated to gitlab.com/gitlab-org/api/client-go.
+// See https://gitlab.com/gitlab-org/api/client-go
+//
+// This package is completely frozen, nothing will be added, removed or changed.
 func NewClient(token string, options ...ClientOptionFunc) (*Client, error) {
 	client, err := newClient(options...)
 	if err != nil {
@@ -270,6 +280,11 @@ func NewClient(token string, options ...ClientOptionFunc) (*Client, error) {
 
 // NewBasicAuthClient returns a new GitLab API client. To use API methods which
 // require authentication, provide a valid username and password.
+//
+// Deprecated: This module has been migrated to gitlab.com/gitlab-org/api/client-go.
+// See https://gitlab.com/gitlab-org/api/client-go
+//
+// This package is completely frozen, nothing will be added, removed or changed.
 func NewBasicAuthClient(username, password string, options ...ClientOptionFunc) (*Client, error) {
 	client, err := newClient(options...)
 	if err != nil {
@@ -285,6 +300,11 @@ func NewBasicAuthClient(username, password string, options ...ClientOptionFunc) 
 
 // NewJobClient returns a new GitLab API client. To use API methods which require
 // authentication, provide a valid job token.
+//
+// Deprecated: This module has been migrated to gitlab.com/gitlab-org/api/client-go.
+// See https://gitlab.com/gitlab-org/api/client-go
+//
+// This package is completely frozen, nothing will be added, removed or changed.
 func NewJobClient(token string, options ...ClientOptionFunc) (*Client, error) {
 	client, err := newClient(options...)
 	if err != nil {
@@ -297,6 +317,11 @@ func NewJobClient(token string, options ...ClientOptionFunc) (*Client, error) {
 
 // NewOAuthClient returns a new GitLab API client. To use API methods which
 // require authentication, provide a valid oauth token.
+//
+// Deprecated: This module has been migrated to gitlab.com/gitlab-org/api/client-go.
+// See https://gitlab.com/gitlab-org/api/client-go
+//
+// This package is completely frozen, nothing will be added, removed or changed.
 func NewOAuthClient(token string, options ...ClientOptionFunc) (*Client, error) {
 	client, err := newClient(options...)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: This module has been migrated to gitlab.com/gitlab-org/api/client-go. See https://gitlab.com/gitlab-org/api/client-go
 module github.com/xanzy/go-gitlab
 
 go 1.19


### PR DESCRIPTION
See #2060 